### PR TITLE
fix: freeze bun-ffi-z

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -268,3 +268,5 @@ jobs:
         if: ${{ steps.release.outputs.release_created }}
         run: bun run publish
         working-directory: ./bun
+        env:
+          NPM_CONFIG_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/bun/package.json
+++ b/bun/package.json
@@ -4,7 +4,7 @@
 	"module": "src/index.ts",
 	"type": "module",
 	"dependencies": {
-		"@chainsafe/bun-ffi-z": "https://github.com/ChainSafe/bun-ffi-z.git"
+		"@chainsafe/bun-ffi-z": "^1.0.0"
 	},
 	"devDependencies": {
 		"@types/bun": "latest",


### PR DESCRIPTION
**Motivation**
- the last step to release v1.0.0 of this repo

**Description**
- `bun-ffi-z` v1.0.0
- use `secrets.NPM_TOKEN`