### PR TITLE
fix: add Block functions

### DIFF
--- a/src/state_transition/block/process_block_header.zig
+++ b/src/state_transition/block/process_block_header.zig
@@ -8,8 +8,9 @@ const BeaconBlockHeader = ssz.phase0.BeaconBlockHeader.Type;
 const Root = ssz.primitive.Root;
 const SignedBlock = @import("../types/signed_block.zig").SignedBlock;
 const ZERO_HASH = @import("constants").ZERO_HASH;
+const Block = @import("../types/signed_block.zig").Block;
 
-pub fn processBlockHeader(allocator: Allocator, cached_state: *const CachedBeaconStateAllForks, block: *const SignedBlock) !void {
+pub fn processBlockHeader(allocator: Allocator, cached_state: *const CachedBeaconStateAllForks, block: Block) !void {
     const state = cached_state.state;
     const epoch_cache = cached_state.getEpochCache();
     const slot = state.slot();
@@ -55,7 +56,8 @@ pub fn processBlockHeader(allocator: Allocator, cached_state: *const CachedBeaco
     }
 }
 
-pub fn blockToHeader(allocator: Allocator, block: *const SignedBlock, out: *BeaconBlockHeader) !void {
+pub fn blockToHeader(allocator: Allocator, signed_block: SignedBlock, out: *BeaconBlockHeader) !void {
+    const block = signed_block.message();
     out.slot = block.slot();
     out.proposer_index = block.proposerIndex();
     out.parent_root = block.parentRoot();

--- a/src/state_transition/block/process_execution_payload.zig
+++ b/src/state_transition/block/process_execution_payload.zig
@@ -5,6 +5,7 @@ const ssz = @import("consensus_types");
 const preset = @import("preset").preset;
 const ForkSeq = @import("config").ForkSeq;
 const SignedBlock = @import("../types/signed_block.zig").SignedBlock;
+const Body = @import("../types/signed_block.zig").Body;
 const ExecutionPayloadStatus = @import("../state_transition.zig").ExecutionPayloadStatus;
 const SignedBlindedBeaconBlock = @import("../types/beacon_block.zig").SignedBlindedBeaconBlock;
 const BlockExternalData = @import("../state_transition.zig").BlockExternalData;
@@ -23,7 +24,7 @@ const PartialPayload = struct {
 pub fn processExecutionPayload(
     allocator: Allocator,
     cached_state: *const CachedBeaconStateAllForks,
-    body: SignedBlock.Body,
+    body: Body,
     external_data: BlockExternalData,
 ) !void {
     const state = cached_state.state;

--- a/src/state_transition/block/process_operations.zig
+++ b/src/state_transition/block/process_operations.zig
@@ -2,7 +2,7 @@ const std = @import("std");
 const CachedBeaconStateAllForks = @import("../cache/state_cache.zig").CachedBeaconStateAllForks;
 const ssz = @import("consensus_types");
 const preset = @import("preset").preset;
-const Body = @import("../types/signed_block.zig").SignedBlock.Body;
+const Body = @import("../types/signed_block.zig").Body;
 
 const getEth1DepositCount = @import("../utils/deposit.zig").getEth1DepositCount;
 const processAttestations = @import("./process_attestations.zig").processAttestations;
@@ -19,7 +19,7 @@ const ProcessBlockOpts = @import("./process_block.zig").ProcessBlockOpts;
 pub fn processOperations(
     allocator: std.mem.Allocator,
     cached_state: *CachedBeaconStateAllForks,
-    body: *const Body,
+    body: Body,
     opts: ProcessBlockOpts,
 ) !void {
     const state = cached_state.state;

--- a/src/state_transition/block/process_randao.zig
+++ b/src/state_transition/block/process_randao.zig
@@ -5,7 +5,7 @@ const ssz = @import("consensus_types");
 const preset = @import("preset").preset;
 const ForkSeq = @import("config").ForkSeq;
 const BeaconBlock = @import("../types/beacon_block.zig").BeaconBlock;
-const Body = @import("../types/signed_block.zig").SignedBlock.Body;
+const Body = @import("../types/signed_block.zig").Body;
 const Bytes32 = ssz.primitive.Bytes32.Type;
 const getRandaoMix = @import("../utils/seed.zig").getRandaoMix;
 const verifyRandaoSignature = @import("../signature_sets/randao.zig").verifyRandaoSignature;
@@ -13,7 +13,7 @@ const digest = @import("../utils/sha256.zig").digest;
 
 pub fn processRandao(
     cached_state: *const CachedBeaconStateAllForks,
-    body: *const Body,
+    body: Body,
     proposer_idx: u64,
     verify_signature: bool,
 ) !void {

--- a/src/state_transition/root.zig
+++ b/src/state_transition/root.zig
@@ -65,6 +65,7 @@ pub const bls = @import("utils/bls.zig");
 const seed = @import("./utils/seed.zig");
 pub const state_transition = @import("./state_transition.zig");
 const EpochShuffling = @import("./utils/epoch_shuffling.zig");
+pub const Block = @import("./types/signed_block.zig").Block;
 pub const SignedBlock = @import("./types/signed_block.zig").SignedBlock;
 pub const SignedBeaconBlock = @import("./types/beacon_block.zig").SignedBeaconBlock;
 pub const Attestations = @import("./types/attestation.zig").Attestations;

--- a/src/state_transition/signature_sets/proposer.zig
+++ b/src/state_transition/signature_sets/proposer.zig
@@ -21,14 +21,15 @@ pub fn getBlockProposerSignatureSet(allocator: Allocator, cached_state: *CachedB
     const config = cached_state.config;
     const state = cached_state.state;
     const epoch_cache = cached_state.getEpochCache();
-    const domain = try config.getDomain(state.slot(), c.DOMAIN_BEACON_PROPOSER, signed_block.slot());
+    const block = signed_block.message();
+    const domain = try config.getDomain(state.slot(), c.DOMAIN_BEACON_PROPOSER, block.slot());
     // var signing_root: Root = undefined;
     var signing_root_buf: [32]u8 = undefined;
     try computeBlockSigningRoot(allocator, signed_block, domain, &signing_root_buf);
 
     // Root.uncompressFromBytes(&signing_root_buf, &signing_root);
     return .{
-        .pubkey = epoch_cache.index_to_pubkey.items[signed_block.proposerIndex()],
+        .pubkey = epoch_cache.index_to_pubkey.items[block.proposerIndex()],
         .signing_root = signing_root_buf,
         .signature = signed_block.signature(),
     };

--- a/src/state_transition/signature_sets/proposer.zig
+++ b/src/state_transition/signature_sets/proposer.zig
@@ -25,7 +25,7 @@ pub fn getBlockProposerSignatureSet(allocator: Allocator, cached_state: *CachedB
     const domain = try config.getDomain(state.slot(), c.DOMAIN_BEACON_PROPOSER, block.slot());
     // var signing_root: Root = undefined;
     var signing_root_buf: [32]u8 = undefined;
-    try computeBlockSigningRoot(allocator, signed_block, domain, &signing_root_buf);
+    try computeBlockSigningRoot(allocator, block, domain, &signing_root_buf);
 
     // Root.uncompressFromBytes(&signing_root_buf, &signing_root);
     return .{

--- a/src/state_transition/signature_sets/proposer.zig
+++ b/src/state_transition/signature_sets/proposer.zig
@@ -11,13 +11,13 @@ const computeSigningRoot = @import("../utils/signing_root.zig").computeSigningRo
 const verifySignatureSet = @import("../utils/signature_sets.zig").verifySingleSignatureSet;
 const SignedBlock = @import("../types/signed_block.zig").SignedBlock;
 
-pub fn verifyProposerSignature(cached_state: *CachedBeaconStateAllForks, signed_block: *const SignedBlock) !bool {
+pub fn verifyProposerSignature(cached_state: *CachedBeaconStateAllForks, signed_block: SignedBlock) !bool {
     const signature_set = try getBlockProposerSignatureSet(cached_state.allocator, cached_state, signed_block);
     return try verifySignatureSet(&signature_set);
 }
 
 // TODO: support SignedBlindedBeaconBlock
-pub fn getBlockProposerSignatureSet(allocator: Allocator, cached_state: *CachedBeaconStateAllForks, signed_block: *const SignedBlock) !SingleSignatureSet {
+pub fn getBlockProposerSignatureSet(allocator: Allocator, cached_state: *CachedBeaconStateAllForks, signed_block: SignedBlock) !SingleSignatureSet {
     const config = cached_state.config;
     const state = cached_state.state;
     const epoch_cache = cached_state.getEpochCache();

--- a/src/state_transition/signature_sets/proposer_slashings.zig
+++ b/src/state_transition/signature_sets/proposer_slashings.zig
@@ -6,7 +6,6 @@ const SingleSignatureSet = @import("../utils/signature_sets.zig").SingleSignatur
 const c = @import("constants");
 const ssz = @import("consensus_types");
 const Root = ssz.primitive.Root;
-const computeBlockSigningRoot = @import("../utils/signing_root.zig").computeBlockSigningRoot;
 const computeSigningRoot = @import("../utils/signing_root.zig").computeSigningRoot;
 const verifySignatureSet = @import("../utils/signature_sets.zig").verifySingleSignatureSet;
 

--- a/src/state_transition/signature_sets/randao.zig
+++ b/src/state_transition/signature_sets/randao.zig
@@ -3,7 +3,7 @@ const Slot = ssz.primitive.Slot.Type;
 const CachedBeaconStateAllForks = @import("../cache/state_cache.zig").CachedBeaconStateAllForks;
 const Root = ssz.primitive.Root.Type;
 const Epoch = ssz.primitive.Epoch.Type;
-const Body = @import("../types/signed_block.zig").SignedBlock.Body;
+const Body = @import("../types/signed_block.zig").Body;
 const SingleSignatureSet = @import("../utils/signature_sets.zig").SingleSignatureSet;
 const computeEpochAtSlot = @import("../utils/epoch.zig").computeEpochAtSlot;
 const c = @import("constants");
@@ -12,7 +12,7 @@ const verifySingleSignatureSet = @import("../utils/signature_sets.zig").verifySi
 
 pub fn verifyRandaoSignature(
     state: *const CachedBeaconStateAllForks,
-    body: *const Body,
+    body: Body,
     slot: Slot,
     proposer_idx: u64,
 ) !bool {
@@ -22,7 +22,7 @@ pub fn verifyRandaoSignature(
 
 pub fn randaoRevealSignatureSet(
     cached_state: *const CachedBeaconStateAllForks,
-    body: *const Body,
+    body: Body,
     slot: Slot,
     proposer_idx: u64,
 ) !SingleSignatureSet {

--- a/src/state_transition/state_transition.zig
+++ b/src/state_transition/state_transition.zig
@@ -124,7 +124,7 @@ pub fn stateTransition(
     try processSlotsWithTransientCache(allocator, post_state, block_slot, .{});
 
     // Verify proposer signature only
-    if (opts.verify_proposer and !try verifyProposerSignature(post_state, &signed_block)) {
+    if (opts.verify_proposer and !try verifyProposerSignature(post_state, signed_block)) {
         return error.InvalidBlockSignature;
     }
 

--- a/src/state_transition/state_transition.zig
+++ b/src/state_transition/state_transition.zig
@@ -134,7 +134,7 @@ pub fn stateTransition(
     try processBlock(
         allocator,
         post_state,
-        &signed_block,
+        block,
         BlockExternalData{
             .execution_payload_status = .valid,
             .data_availability_status = .available,

--- a/src/state_transition/types/signed_block.zig
+++ b/src/state_transition/types/signed_block.zig
@@ -1,91 +1,6 @@
-pub const Block = union(enum) {
-    regular: BeaconBlock,
-    blinded: BlindedBeaconBlock,
-};
-
 pub const SignedBlock = union(enum) {
-    regular: *const SignedBeaconBlock,
-    blinded: *const SignedBlindedBeaconBlock,
-
-    pub const Body = union(enum) {
-        regular: BeaconBlockBody,
-        blinded: BlindedBeaconBlockBody,
-
-        pub fn blobKzgCommitmentsLen(self: *const Body) usize {
-            return switch (self.*) {
-                inline .regular, .blinded => |b| b.blobKzgCommitments().items.len,
-            };
-        }
-
-        pub fn eth1Data(self: *const Body) *const ssz.phase0.Eth1Data.Type {
-            return switch (self.*) {
-                inline .regular, .blinded => |b| b.eth1Data(),
-            };
-        }
-
-        pub fn randaoReveal(self: *const Body) ssz.primitive.BLSSignature.Type {
-            return switch (self.*) {
-                inline .regular, .blinded => |b| b.randaoReveal(),
-            };
-        }
-
-        pub fn deposits(self: *const Body) []Deposit {
-            return switch (self.*) {
-                inline .regular, .blinded => |b| b.deposits(),
-            };
-        }
-        pub fn depositRequests(self: *const Body) []DepositRequest {
-            return switch (self.*) {
-                inline .regular, .blinded => |b| b.depositRequests(),
-            };
-        }
-        pub fn withdrawalRequests(self: *const Body) []WithdrawalRequest {
-            return switch (self.*) {
-                inline .regular, .blinded => |b| b.withdrawalRequests(),
-            };
-        }
-        pub fn consolidationRequests(self: *const Body) []ConsolidationRequest {
-            return switch (self.*) {
-                inline .regular, .blinded => |b| b.consolidationRequests(),
-            };
-        }
-
-        pub fn syncAggregate(self: *const Body) *const ssz.altair.SyncAggregate.Type {
-            return switch (self.*) {
-                inline .regular, .blinded => |b| b.syncAggregate(),
-            };
-        }
-
-        pub fn attesterSlashings(self: *const Body) AttesterSlashings {
-            return switch (self.*) {
-                inline .regular, .blinded => |b| b.attesterSlashings(),
-            };
-        }
-
-        pub fn attestations(self: *const Body) Attestations {
-            return switch (self.*) {
-                inline .regular, .blinded => |b| b.attestations(),
-            };
-        }
-
-        pub fn voluntaryExits(self: *const Body) []SignedVoluntaryExit {
-            return switch (self.*) {
-                inline .regular, .blinded => |b| b.voluntaryExits(),
-            };
-        }
-
-        pub fn proposerSlashings(self: *const Body) []ProposerSlashing {
-            return switch (self.*) {
-                inline .regular, .blinded => |b| b.proposerSlashings(),
-            };
-        }
-
-        pub fn blsToExecutionChanges(self: *const Body) []SignedBLSToExecutionChange {
-            return switch (self.*) {
-                inline .regular, .blinded => |b| b.blsToExecutionChanges(),
-            };
-        }
-    };
+    regular: SignedBeaconBlock,
+    blinded: SignedBlindedBeaconBlock,
 
     pub fn message(self: *const SignedBlock) Block {
         return switch (self.*) {
@@ -93,44 +8,130 @@ pub const SignedBlock = union(enum) {
             .blinded => |b| .{ .blinded = b.beaconBlock() },
         };
     }
-    pub fn beaconBlockBody(self: *const SignedBlock) Body {
-        return switch (self.*) {
-            .regular => |b| .{ .regular = b.beaconBlock().beaconBlockBody() },
-            .blinded => |b| .{ .blinded = b.beaconBlock().beaconBlockBody() },
-        };
-    }
-
-    pub fn parentRoot(self: *const SignedBlock) [32]u8 {
-        return switch (self.*) {
-            .regular => |b| b.beaconBlock().parentRoot(),
-            .blinded => |b| b.beaconBlock().parentRoot(),
-        };
-    }
-
-    pub fn slot(self: *const SignedBlock) Slot {
-        return switch (self.*) {
-            .regular => |b| b.beaconBlock().slot(),
-            .blinded => |b| b.beaconBlock().slot(),
-        };
-    }
-
-    pub fn hashTreeRoot(self: *const SignedBlock, allocator: std.mem.Allocator, out: *[32]u8) !void {
-        return switch (self.*) {
-            .regular => |b| b.beaconBlock().hashTreeRoot(allocator, out),
-            .blinded => |b| b.beaconBlock().hashTreeRoot(allocator, out),
-        };
-    }
-
-    pub fn proposerIndex(self: *const SignedBlock) u64 {
-        return switch (self.*) {
-            .regular => |b| b.beaconBlock().proposerIndex(),
-            .blinded => |b| b.beaconBlock().proposerIndex(),
-        };
-    }
 
     pub fn signature(self: *const SignedBlock) ssz.primitive.BLSSignature.Type {
         return switch (self.*) {
             inline .regular, .blinded => |b| b.signature(),
+        };
+    }
+};
+
+pub const Block = union(enum) {
+    regular: BeaconBlock,
+    blinded: BlindedBeaconBlock,
+
+    pub fn beaconBlockBody(self: *const Block) Body {
+        return switch (self.*) {
+            .regular => |b| .{ .regular = b.beaconBlockBody() },
+            .blinded => |b| .{ .blinded = b.beaconBlockBody() },
+        };
+    }
+
+    pub fn parentRoot(self: *const Block) [32]u8 {
+        return switch (self.*) {
+            .regular => |b| b.parentRoot(),
+            .blinded => |b| b.parentRoot(),
+        };
+    }
+
+    pub fn slot(self: *const Block) Slot {
+        return switch (self.*) {
+            .regular => |b| b.slot(),
+            .blinded => |b| b.slot(),
+        };
+    }
+
+    pub fn hashTreeRoot(self: *const Block, allocator: std.mem.Allocator, out: *[32]u8) !void {
+        return switch (self.*) {
+            .regular => |b| b.hashTreeRoot(allocator, out),
+            .blinded => |b| b.hashTreeRoot(allocator, out),
+        };
+    }
+
+    pub fn proposerIndex(self: *const Block) u64 {
+        return switch (self.*) {
+            .regular => |b| b.proposerIndex(),
+            .blinded => |b| b.proposerIndex(),
+        };
+    }
+};
+
+pub const Body = union(enum) {
+    regular: BeaconBlockBody,
+    blinded: BlindedBeaconBlockBody,
+
+    pub fn blobKzgCommitmentsLen(self: *const Body) usize {
+        return switch (self.*) {
+            inline .regular, .blinded => |b| b.blobKzgCommitments().items.len,
+        };
+    }
+
+    pub fn eth1Data(self: *const Body) *const ssz.phase0.Eth1Data.Type {
+        return switch (self.*) {
+            inline .regular, .blinded => |b| b.eth1Data(),
+        };
+    }
+
+    pub fn randaoReveal(self: *const Body) ssz.primitive.BLSSignature.Type {
+        return switch (self.*) {
+            inline .regular, .blinded => |b| b.randaoReveal(),
+        };
+    }
+
+    pub fn deposits(self: *const Body) []Deposit {
+        return switch (self.*) {
+            inline .regular, .blinded => |b| b.deposits(),
+        };
+    }
+    pub fn depositRequests(self: *const Body) []DepositRequest {
+        return switch (self.*) {
+            inline .regular, .blinded => |b| b.depositRequests(),
+        };
+    }
+    pub fn withdrawalRequests(self: *const Body) []WithdrawalRequest {
+        return switch (self.*) {
+            inline .regular, .blinded => |b| b.withdrawalRequests(),
+        };
+    }
+    pub fn consolidationRequests(self: *const Body) []ConsolidationRequest {
+        return switch (self.*) {
+            inline .regular, .blinded => |b| b.consolidationRequests(),
+        };
+    }
+
+    pub fn syncAggregate(self: *const Body) *const ssz.altair.SyncAggregate.Type {
+        return switch (self.*) {
+            inline .regular, .blinded => |b| b.syncAggregate(),
+        };
+    }
+
+    pub fn attesterSlashings(self: *const Body) AttesterSlashings {
+        return switch (self.*) {
+            inline .regular, .blinded => |b| b.attesterSlashings(),
+        };
+    }
+
+    pub fn attestations(self: *const Body) Attestations {
+        return switch (self.*) {
+            inline .regular, .blinded => |b| b.attestations(),
+        };
+    }
+
+    pub fn voluntaryExits(self: *const Body) []SignedVoluntaryExit {
+        return switch (self.*) {
+            inline .regular, .blinded => |b| b.voluntaryExits(),
+        };
+    }
+
+    pub fn proposerSlashings(self: *const Body) []ProposerSlashing {
+        return switch (self.*) {
+            inline .regular, .blinded => |b| b.proposerSlashings(),
+        };
+    }
+
+    pub fn blsToExecutionChanges(self: *const Body) []SignedBLSToExecutionChange {
+        return switch (self.*) {
+            inline .regular, .blinded => |b| b.blsToExecutionChanges(),
         };
     }
 };

--- a/src/state_transition/utils/signing_root.zig
+++ b/src/state_transition/utils/signing_root.zig
@@ -5,8 +5,7 @@ const Root = ssz.primitive.Root.Type;
 const ssz = @import("consensus_types");
 const BeaconBlock = @import("../types/beacon_block.zig").BeaconBlock;
 const SignedBeaconBlock = @import("../state_transition.zig").SignedBeaconBlock;
-const Block = @import("../state_transition.zig").Block;
-const SignedBlock = @import("../types/signed_block.zig").SignedBlock;
+const Block = @import("../types/signed_block.zig").Block;
 
 const SigningData = ssz.phase0.SigningData.Type;
 
@@ -22,9 +21,8 @@ pub fn computeSigningRoot(comptime T: type, ssz_object: *const T.Type, domain: D
     try ssz.phase0.SigningData.hashTreeRoot(&domain_wrapped_object, out);
 }
 
-pub fn computeBlockSigningRoot(allocator: Allocator, signed_block: *const SignedBlock, domain: Domain, out: *[32]u8) !void {
+pub fn computeBlockSigningRoot(allocator: Allocator, block: Block, domain: Domain, out: *[32]u8) !void {
     var object_root: Root = undefined;
-    const block = signed_block.message();
     try block.hashTreeRoot(allocator, &object_root);
     const domain_wrapped_object: SigningData = .{
         .object_root = object_root,
@@ -49,12 +47,10 @@ test "computeBlockSigningRoot - sanity" {
     const allocator = std.testing.allocator;
     var electra_block = ssz.electra.BeaconBlock.default_value;
     electra_block.slot = 2025;
-    var signed_electra_block = ssz.electra.SignedBeaconBlock.default_value;
-    signed_electra_block.message = electra_block;
     const domain = [_]u8{0x01} ** 32;
     var out: [32]u8 = undefined;
 
-    const signed_beacon_block = SignedBeaconBlock{ .electra = &signed_electra_block };
-    const signed_block = SignedBlock{ .regular = signed_beacon_block };
-    try computeBlockSigningRoot(allocator, &signed_block, domain, &out);
+    const beacon_block = BeaconBlock{ .electra = &electra_block };
+    const block = Block{ .regular = beacon_block };
+    try computeBlockSigningRoot(allocator, block, domain, &out);
 }

--- a/src/state_transition/utils/signing_root.zig
+++ b/src/state_transition/utils/signing_root.zig
@@ -22,8 +22,9 @@ pub fn computeSigningRoot(comptime T: type, ssz_object: *const T.Type, domain: D
     try ssz.phase0.SigningData.hashTreeRoot(&domain_wrapped_object, out);
 }
 
-pub fn computeBlockSigningRoot(allocator: Allocator, block: *const SignedBlock, domain: Domain, out: *[32]u8) !void {
+pub fn computeBlockSigningRoot(allocator: Allocator, signed_block: *const SignedBlock, domain: Domain, out: *[32]u8) !void {
     var object_root: Root = undefined;
+    const block = signed_block.message();
     try block.hashTreeRoot(allocator, &object_root);
     const domain_wrapped_object: SigningData = .{
         .object_root = object_root,
@@ -54,6 +55,6 @@ test "computeBlockSigningRoot - sanity" {
     var out: [32]u8 = undefined;
 
     const signed_beacon_block = SignedBeaconBlock{ .electra = &signed_electra_block };
-    const signed_block = SignedBlock{ .regular = &signed_beacon_block };
+    const signed_block = SignedBlock{ .regular = signed_beacon_block };
     try computeBlockSigningRoot(allocator, &signed_block, domain, &out);
 }

--- a/test/int/process_block_header.zig
+++ b/test/int/process_block_header.zig
@@ -17,22 +17,18 @@ test "process block header - sanity" {
     message.proposer_index = proposer_index;
     message.parent_root = header_parent_root;
 
-    var beacon_block: ssz.electra.SignedBeaconBlock.Type = ssz.electra.SignedBeaconBlock.default_value;
-    beacon_block.message = message;
-    const signed_beacon_block = SignedBeaconBlock{ .electra = &beacon_block };
-    const block = SignedBlock{ .regular = &signed_beacon_block };
-    try processBlockHeader(allocator, test_state.cached_state, &block);
+    const beacon_block = BeaconBlock{ .electra = &message };
+
+    const block = Block{ .regular = beacon_block };
+    try processBlockHeader(allocator, test_state.cached_state, block);
 }
 
 const std = @import("std");
 const ssz = @import("consensus_types");
 const config = @import("config");
-
 const state_transition = @import("state_transition");
 const TestCachedBeaconStateAllForks = state_transition.test_utils.TestCachedBeaconStateAllForks;
-
 const preset = @import("preset").preset;
-
 const processBlockHeader = state_transition.processBlockHeader;
-const SignedBlock = state_transition.SignedBlock;
-const SignedBeaconBlock = state_transition.SignedBeaconBlock;
+const Block = state_transition.Block;
+const BeaconBlock = state_transition.BeaconBlock;

--- a/test/int/process_eth1_data.zig
+++ b/test/int/process_eth1_data.zig
@@ -4,9 +4,6 @@ test "process eth1 data - sanity" {
     var test_state = try TestCachedBeaconStateAllForks.init(allocator, 256);
     defer test_state.deinit();
 
-    // const beacon_block: ssz.electra.SignedBeaconBlock.Type = ssz.electra.SignedBeaconBlock.default_value;
-    // const signed_beacon_block = SignedBeaconBlock{ .electra = &beacon_block };
-    // const block = SignedBlock{ .regular = &signed_beacon_block };
     const block = ssz.electra.BeaconBlock.default_value;
     try processEth1Data(allocator, test_state.cached_state, &block.body.eth1_data);
 }

--- a/test/int/process_eth1_data.zig
+++ b/test/int/process_eth1_data.zig
@@ -4,10 +4,11 @@ test "process eth1 data - sanity" {
     var test_state = try TestCachedBeaconStateAllForks.init(allocator, 256);
     defer test_state.deinit();
 
-    const beacon_block: ssz.electra.SignedBeaconBlock.Type = ssz.electra.SignedBeaconBlock.default_value;
-    const signed_beacon_block = SignedBeaconBlock{ .electra = &beacon_block };
-    const block = SignedBlock{ .regular = &signed_beacon_block };
-    try processEth1Data(allocator, test_state.cached_state, block.beaconBlockBody().eth1Data());
+    // const beacon_block: ssz.electra.SignedBeaconBlock.Type = ssz.electra.SignedBeaconBlock.default_value;
+    // const signed_beacon_block = SignedBeaconBlock{ .electra = &beacon_block };
+    // const block = SignedBlock{ .regular = &signed_beacon_block };
+    const block = ssz.electra.BeaconBlock.default_value;
+    try processEth1Data(allocator, test_state.cached_state, &block.body.eth1_data);
 }
 
 const std = @import("std");

--- a/test/int/process_execution_payload.zig
+++ b/test/int/process_execution_payload.zig
@@ -12,11 +12,8 @@ test "process execution payload - sanity" {
     var message: ssz.electra.BeaconBlock.Type = ssz.electra.BeaconBlock.default_value;
     message.body = body;
 
-    var beacon_block: ssz.electra.SignedBeaconBlock.Type = ssz.electra.SignedBeaconBlock.default_value;
-    beacon_block.message = message;
-
-    const signed_beacon_block = SignedBeaconBlock{ .electra = &beacon_block };
-    const block = SignedBlock{ .regular = &signed_beacon_block };
+    const beacon_block = BeaconBlock{ .electra = &message };
+    const block = Block{ .regular = beacon_block };
 
     try processExecutionPayload(
         allocator,
@@ -34,4 +31,6 @@ const state_transition = @import("state_transition");
 const TestCachedBeaconStateAllForks = state_transition.test_utils.TestCachedBeaconStateAllForks;
 const processExecutionPayload = state_transition.processExecutionPayload;
 const SignedBlock = state_transition.SignedBlock;
+const Block = state_transition.Block;
 const SignedBeaconBlock = state_transition.SignedBeaconBlock;
+const BeaconBlock = state_transition.BeaconBlock;

--- a/test/int/process_operations.zig
+++ b/test/int/process_operations.zig
@@ -4,10 +4,11 @@ test "process operations" {
     var test_state = try TestCachedBeaconStateAllForks.init(allocator, 256);
     defer test_state.deinit();
 
-    const beacon_block: ssz.electra.SignedBeaconBlock.Type = ssz.electra.SignedBeaconBlock.default_value;
-    const signed_beacon_block = SignedBeaconBlock{ .electra = &beacon_block };
-    const block = SignedBlock{ .regular = &signed_beacon_block };
-    try processOperations(allocator, test_state.cached_state, &block.beaconBlockBody(), .{});
+    const electra_block = ssz.electra.BeaconBlock.default_value;
+    const beacon_block = BeaconBlock{ .electra = &electra_block };
+
+    const block = Block{ .regular = beacon_block };
+    try processOperations(allocator, test_state.cached_state, block.beaconBlockBody(), .{});
 }
 
 const std = @import("std");
@@ -16,5 +17,5 @@ const ssz = @import("consensus_types");
 const state_transition = @import("state_transition");
 const TestCachedBeaconStateAllForks = state_transition.test_utils.TestCachedBeaconStateAllForks;
 const processOperations = state_transition.processOperations;
-const SignedBlock = state_transition.SignedBlock;
-const SignedBeaconBlock = state_transition.SignedBeaconBlock;
+const Block = state_transition.Block;
+const BeaconBlock = state_transition.BeaconBlock;

--- a/test/int/process_randao.zig
+++ b/test/int/process_randao.zig
@@ -17,11 +17,9 @@ test "process randao - sanity" {
     message.proposer_index = proposer_index;
     message.parent_root = header_parent_root;
 
-    var beacon_block: ssz.electra.SignedBeaconBlock.Type = ssz.electra.SignedBeaconBlock.default_value;
-    beacon_block.message = message;
-    const signed_beacon_block = SignedBeaconBlock{ .electra = &beacon_block };
-    const block = SignedBlock{ .regular = &signed_beacon_block };
-    try processRandao(test_state.cached_state, &block.beaconBlockBody(), block.proposerIndex(), false);
+    const beacon_block = BeaconBlock{ .electra = &message };
+    const block = Block{ .regular = beacon_block };
+    try processRandao(test_state.cached_state, block.beaconBlockBody(), block.proposerIndex(), false);
 }
 
 const std = @import("std");
@@ -35,5 +33,5 @@ const TestCachedBeaconStateAllForks = state_transition.test_utils.TestCachedBeac
 const preset = @import("preset").preset;
 
 const processRandao = state_transition.processRandao;
-const SignedBlock = state_transition.SignedBlock;
-const SignedBeaconBlock = state_transition.SignedBeaconBlock;
+const Block = state_transition.Block;
+const BeaconBlock = state_transition.BeaconBlock;

--- a/test/int/process_sync_aggregate.zig
+++ b/test/int/process_sync_aggregate.zig
@@ -12,12 +12,9 @@ test "process sync aggregate - sanity" {
     var message: ssz.electra.BeaconBlock.Type = ssz.electra.BeaconBlock.default_value;
     message.body = body;
 
-    var beacon_block: ssz.electra.SignedBeaconBlock.Type = ssz.electra.SignedBeaconBlock.default_value;
-    beacon_block.message = message;
-    const signed_beacon_block = SignedBeaconBlock{ .electra = &beacon_block };
-    const block = SignedBlock{ .regular = &signed_beacon_block };
-
-    try processSyncAggregate(allocator, test_state.cached_state, &block, true);
+    const beacon_block = BeaconBlock{ .electra = &message };
+    const block = Block{ .regular = beacon_block };
+    try processSyncAggregate(allocator, test_state.cached_state, block, true);
 }
 
 const std = @import("std");
@@ -29,6 +26,8 @@ const TestCachedBeaconStateAllForks = @import("state_transition").test_utils.Tes
 
 const state_transition = @import("state_transition");
 const processSyncAggregate = state_transition.processSyncAggregate;
+const Block = state_transition.Block;
 const SignedBlock = state_transition.SignedBlock;
+const BeaconBlock = state_transition.BeaconBlock;
 const SignedBeaconBlock = state_transition.SignedBeaconBlock;
 const G2_POINT_AT_INFINITY = @import("constants").G2_POINT_AT_INFINITY;

--- a/test/int/state_transition.zig
+++ b/test/int/state_transition.zig
@@ -40,7 +40,7 @@ test "state transition - electra block" {
         }
 
         const signed_beacon_block = SignedBeaconBlock{ .electra = electra_block_ptr };
-        const signed_block = SignedBlock{ .regular = &signed_beacon_block };
+        const signed_block = SignedBlock{ .regular = signed_beacon_block };
 
         // this returns the error so no need to handle returned post_state
         // TODO: if blst can publish BlstError.BadEncoding, can just use testing.expectError

--- a/test/spec/runner/Sanity.zig
+++ b/test/spec/runner/Sanity.zig
@@ -199,7 +199,7 @@ pub fn BlocksTestCase(comptime fork: ForkSeq, comptime valid: bool) type {
                     self.pre.allocator,
                     state,
                     .{
-                        .regular = &signed_block,
+                        .regular = signed_block,
                     },
                     .{},
                 );


### PR DESCRIPTION
**Motivation**
- we miss `Block` functions, that causes us to use `SignedBlock` everywhere
- this is also not consistent to lodestar
- it'll likely a blocker for spec test

**Description**
- move functions from `SignedBlock` to `Block`, ensure the functions have the same signatures to the current lodestar
- no pointer on wrapped enums because we already have pointers in embedded enumbs
  - instead of
 ```zig
pub const SignedBlock = union(enum) {
    regular: *const SignedBeaconBlock,
    blinded: *const SignedBlindedBeaconBlock,
}
```
  - this PR changes to
```zig
pub const SignedBlock = union(enum) {
    regular: SignedBeaconBlock,
    blinded: SignedBlindedBeaconBlock,
}
```
because the last level already includes pointers
```zig
pub const SignedBeaconBlock = union(enum) {
    phase0: *const ssz.phase0.SignedBeaconBlock.Type,
    altair: *const ssz.altair.SignedBeaconBlock.Type,
    bellatrix: *const ssz.bellatrix.SignedBeaconBlock.Type,
    capella: *const ssz.capella.SignedBeaconBlock.Type,
    deneb: *const ssz.deneb.SignedBeaconBlock.Type,
    electra: *const ssz.electra.SignedBeaconBlock.Type,
```

- no need pointer in wrapped enum types, ie use `Block` instead of `*const Block` in function signatures because we already have pointers inside the last level
```zig
pub const BeaconBlock = union(enum) {
    phase0: *const ssz.phase0.BeaconBlock.Type,
    altair: *const ssz.altair.BeaconBlock.Type,
    bellatrix: *const ssz.bellatrix.BeaconBlock.Type,
    capella: *const ssz.capella.BeaconBlock.Type,
    deneb: *const ssz.deneb.BeaconBlock.Type,
    electra: *const ssz.electra.BeaconBlock.Type,
```

Closes #50