### PR TITLE
feat: impl the tree view clone API

### DIFF
--- a/src/ssz/tree_view/array_basic.zig
+++ b/src/ssz/tree_view/array_basic.zig
@@ -45,6 +45,10 @@ pub fn ArrayBasicTreeView(comptime ST: type) type {
             };
         }
 
+        pub fn clone(self: *Self, dont_transfer_cache: bool) !Self {
+            return Self{ .base_view = try self.base_view.clone(dont_transfer_cache) };
+        }
+
         pub fn deinit(self: *Self) void {
             self.base_view.deinit();
         }

--- a/src/ssz/tree_view/array_basic.zig
+++ b/src/ssz/tree_view/array_basic.zig
@@ -45,8 +45,8 @@ pub fn ArrayBasicTreeView(comptime ST: type) type {
             };
         }
 
-        pub fn clone(self: *Self, dont_transfer_cache: bool) !Self {
-            return Self{ .base_view = try self.base_view.clone(dont_transfer_cache) };
+        pub fn clone(self: *Self, opts: BaseTreeView.CloneOpts) !Self {
+            return Self{ .base_view = try self.base_view.clone(opts) };
         }
 
         pub fn deinit(self: *Self) void {

--- a/src/ssz/tree_view/array_composite.zig
+++ b/src/ssz/tree_view/array_composite.zig
@@ -45,6 +45,10 @@ pub fn ArrayCompositeTreeView(comptime ST: type) type {
             };
         }
 
+        pub fn clone(self: *Self, dont_transfer_cache: bool) !Self {
+            return Self{ .base_view = try self.base_view.clone(dont_transfer_cache) };
+        }
+
         pub fn deinit(self: *Self) void {
             self.base_view.deinit();
         }

--- a/src/ssz/tree_view/array_composite.zig
+++ b/src/ssz/tree_view/array_composite.zig
@@ -45,8 +45,8 @@ pub fn ArrayCompositeTreeView(comptime ST: type) type {
             };
         }
 
-        pub fn clone(self: *Self, dont_transfer_cache: bool) !Self {
-            return Self{ .base_view = try self.base_view.clone(dont_transfer_cache) };
+        pub fn clone(self: *Self, opts: BaseTreeView.CloneOpts) !Self {
+            return Self{ .base_view = try self.base_view.clone(opts) };
         }
 
         pub fn deinit(self: *Self) void {

--- a/src/ssz/tree_view/base.zig
+++ b/src/ssz/tree_view/base.zig
@@ -157,8 +157,8 @@ pub const BaseTreeView = struct {
             }
         }
 
-        try out.data.children_nodes.ensureUnusedCapacity(self.allocator, safe_node_keys.items.len);
-        try out.data.children_data.ensureUnusedCapacity(self.allocator, safe_data_keys.items.len);
+        try out.data.children_nodes.ensureUnusedCapacity(self.allocator, @intCast(safe_node_keys.items.len));
+        try out.data.children_data.ensureUnusedCapacity(self.allocator, @intCast(safe_data_keys.items.len));
 
         for (safe_node_keys.items) |gindex| {
             const removed = self.data.children_nodes.fetchRemove(gindex) orelse continue;

--- a/src/ssz/tree_view/bit_list.zig
+++ b/src/ssz/tree_view/bit_list.zig
@@ -38,6 +38,10 @@ pub fn BitListTreeView(comptime ST: type) type {
             return Self{ .base_view = try BaseTreeView.init(allocator, pool, root) };
         }
 
+        pub fn clone(self: *Self, dont_transfer_cache: bool) !Self {
+            return Self{ .base_view = try self.base_view.clone(dont_transfer_cache) };
+        }
+
         pub fn deinit(self: *Self) void {
             self.base_view.deinit();
         }

--- a/src/ssz/tree_view/bit_list.zig
+++ b/src/ssz/tree_view/bit_list.zig
@@ -38,8 +38,8 @@ pub fn BitListTreeView(comptime ST: type) type {
             return Self{ .base_view = try BaseTreeView.init(allocator, pool, root) };
         }
 
-        pub fn clone(self: *Self, dont_transfer_cache: bool) !Self {
-            return Self{ .base_view = try self.base_view.clone(dont_transfer_cache) };
+        pub fn clone(self: *Self, opts: BaseTreeView.CloneOpts) !Self {
+            return Self{ .base_view = try self.base_view.clone(opts) };
         }
 
         pub fn deinit(self: *Self) void {

--- a/src/ssz/tree_view/bit_vector.zig
+++ b/src/ssz/tree_view/bit_vector.zig
@@ -35,8 +35,8 @@ pub fn BitVectorTreeView(comptime ST: type) type {
             return Self{ .base_view = try BaseTreeView.init(allocator, pool, root) };
         }
 
-        pub fn clone(self: *Self, dont_transfer_cache: bool) !Self {
-            return Self{ .base_view = try self.base_view.clone(dont_transfer_cache) };
+        pub fn clone(self: *Self, opts: BaseTreeView.CloneOpts) !Self {
+            return Self{ .base_view = try self.base_view.clone(opts) };
         }
 
         pub fn deinit(self: *Self) void {

--- a/src/ssz/tree_view/bit_vector.zig
+++ b/src/ssz/tree_view/bit_vector.zig
@@ -35,6 +35,10 @@ pub fn BitVectorTreeView(comptime ST: type) type {
             return Self{ .base_view = try BaseTreeView.init(allocator, pool, root) };
         }
 
+        pub fn clone(self: *Self, dont_transfer_cache: bool) !Self {
+            return Self{ .base_view = try self.base_view.clone(dont_transfer_cache) };
+        }
+
         pub fn deinit(self: *Self) void {
             self.base_view.deinit();
         }

--- a/src/ssz/tree_view/container.zig
+++ b/src/ssz/tree_view/container.zig
@@ -27,8 +27,8 @@ pub fn ContainerTreeView(comptime ST: type) type {
             };
         }
 
-        pub fn clone(self: *Self, dont_transfer_cache: bool) !Self {
-            return Self{ .base_view = try self.base_view.clone(dont_transfer_cache) };
+        pub fn clone(self: *Self, opts: BaseTreeView.CloneOpts) !Self {
+            return Self{ .base_view = try self.base_view.clone(opts) };
         }
 
         pub fn deinit(self: *Self) void {

--- a/src/ssz/tree_view/container.zig
+++ b/src/ssz/tree_view/container.zig
@@ -27,6 +27,10 @@ pub fn ContainerTreeView(comptime ST: type) type {
             };
         }
 
+        pub fn clone(self: *Self, dont_transfer_cache: bool) !Self {
+            return Self{ .base_view = try self.base_view.clone(dont_transfer_cache) };
+        }
+
         pub fn deinit(self: *Self) void {
             self.base_view.deinit();
         }

--- a/src/ssz/tree_view/list_basic.zig
+++ b/src/ssz/tree_view/list_basic.zig
@@ -45,8 +45,8 @@ pub fn ListBasicTreeView(comptime ST: type) type {
             };
         }
 
-        pub fn clone(self: *Self, dont_transfer_cache: bool) !Self {
-            return Self{ .base_view = try self.base_view.clone(dont_transfer_cache) };
+        pub fn clone(self: *Self, opts: BaseTreeView.CloneOpts) !Self {
+            return Self{ .base_view = try self.base_view.clone(opts) };
         }
 
         pub fn deinit(self: *Self) void {

--- a/src/ssz/tree_view/list_basic.zig
+++ b/src/ssz/tree_view/list_basic.zig
@@ -45,6 +45,10 @@ pub fn ListBasicTreeView(comptime ST: type) type {
             };
         }
 
+        pub fn clone(self: *Self, dont_transfer_cache: bool) !Self {
+            return Self{ .base_view = try self.base_view.clone(dont_transfer_cache) };
+        }
+
         pub fn deinit(self: *Self) void {
             self.base_view.deinit();
         }

--- a/src/ssz/tree_view/list_composite.zig
+++ b/src/ssz/tree_view/list_composite.zig
@@ -44,8 +44,8 @@ pub fn ListCompositeTreeView(comptime ST: type) type {
             };
         }
 
-        pub fn clone(self: *Self, dont_transfer_cache: bool) !Self {
-            return Self{ .base_view = try self.base_view.clone(dont_transfer_cache) };
+        pub fn clone(self: *Self, opts: BaseTreeView.CloneOpts) !Self {
+            return Self{ .base_view = try self.base_view.clone(opts) };
         }
 
         pub fn deinit(self: *Self) void {

--- a/src/ssz/tree_view/list_composite.zig
+++ b/src/ssz/tree_view/list_composite.zig
@@ -44,6 +44,10 @@ pub fn ListCompositeTreeView(comptime ST: type) type {
             };
         }
 
+        pub fn clone(self: *Self, dont_transfer_cache: bool) !Self {
+            return Self{ .base_view = try self.base_view.clone(dont_transfer_cache) };
+        }
+
         pub fn deinit(self: *Self) void {
             self.base_view.deinit();
         }

--- a/test/int/ssz/tree_view/array_basic.zig
+++ b/test/int/ssz/tree_view/array_basic.zig
@@ -125,7 +125,7 @@ test "TreeView vector clone isolates subsequent updates" {
     var v1 = try Vec4.TreeView.init(allocator, &pool, root);
     defer v1.deinit();
 
-    var v2 = try v1.clone(false);
+    var v2 = try v1.clone(.{});
     defer v2.deinit();
 
     try v2.set(1, @as(u16, 9));
@@ -152,7 +152,7 @@ test "TreeView vector clone reads committed state" {
     try v1.set(2, @as(u16, 7));
     try v1.commit();
 
-    var v2 = try v1.clone(false);
+    var v2 = try v1.clone(.{});
     defer v2.deinit();
 
     try std.testing.expectEqual(@as(u16, 7), try v2.get(2));
@@ -175,7 +175,7 @@ test "TreeView vector clone drops uncommitted changes" {
     try v.set(0, @as(u16, 9));
     try std.testing.expectEqual(@as(u16, 9), try v.get(0));
 
-    var dropped = try v.clone(false);
+    var dropped = try v.clone(.{});
     defer dropped.deinit();
 
     try std.testing.expectEqual(@as(u16, 1), try v.get(0));
@@ -199,7 +199,7 @@ test "TreeView vector clone(true) does not transfer cache" {
     _ = try v.get(0);
     try std.testing.expect(v.base_view.data.children_nodes.count() > 0);
 
-    var cloned_no_cache = try v.clone(true);
+    var cloned_no_cache = try v.clone(.{ .transfer_cache = false });
     defer cloned_no_cache.deinit();
 
     try std.testing.expect(v.base_view.data.children_nodes.count() > 0);
@@ -223,7 +223,7 @@ test "TreeView vector clone(false) transfers cache and clears source" {
     _ = try v.get(0);
     try std.testing.expect(v.base_view.data.children_nodes.count() > 0);
 
-    var cloned = try v.clone(false);
+    var cloned = try v.clone(.{});
     defer cloned.deinit();
 
     try std.testing.expectEqual(@as(usize, 0), v.base_view.data.children_nodes.count());

--- a/test/int/ssz/tree_view/array_basic.zig
+++ b/test/int/ssz/tree_view/array_basic.zig
@@ -111,6 +111,125 @@ test "TreeView vector getAllAlloc repeat reflects updates" {
     try std.testing.expectEqualSlices(u32, values[0..], second);
 }
 
+test "TreeView vector clone isolates subsequent updates" {
+    const allocator = std.testing.allocator;
+    var pool = try Node.Pool.init(allocator, 1024);
+    defer pool.deinit();
+
+    const Uint16 = ssz.UintType(16);
+    const Vec4 = ssz.FixedVectorType(Uint16, 4);
+
+    const value: Vec4.Type = [_]u16{ 0, 0, 0, 0 };
+    const root = try Vec4.tree.fromValue(&pool, &value);
+
+    var v1 = try Vec4.TreeView.init(allocator, &pool, root);
+    defer v1.deinit();
+
+    var v2 = try v1.clone(false);
+    defer v2.deinit();
+
+    try v2.set(1, @as(u16, 9));
+    try v2.commit();
+
+    try std.testing.expectEqual(@as(u16, 0), try v1.get(1));
+    try std.testing.expectEqual(@as(u16, 9), try v2.get(1));
+}
+
+test "TreeView vector clone reads committed state" {
+    const allocator = std.testing.allocator;
+    var pool = try Node.Pool.init(allocator, 1024);
+    defer pool.deinit();
+
+    const Uint16 = ssz.UintType(16);
+    const Vec4 = ssz.FixedVectorType(Uint16, 4);
+
+    const value: Vec4.Type = [_]u16{ 0, 0, 0, 0 };
+    const root = try Vec4.tree.fromValue(&pool, &value);
+
+    var v1 = try Vec4.TreeView.init(allocator, &pool, root);
+    defer v1.deinit();
+
+    try v1.set(2, @as(u16, 7));
+    try v1.commit();
+
+    var v2 = try v1.clone(false);
+    defer v2.deinit();
+
+    try std.testing.expectEqual(@as(u16, 7), try v2.get(2));
+}
+
+test "TreeView vector clone drops uncommitted changes" {
+    const allocator = std.testing.allocator;
+    var pool = try Node.Pool.init(allocator, 1024);
+    defer pool.deinit();
+
+    const Uint16 = ssz.UintType(16);
+    const Vec4 = ssz.FixedVectorType(Uint16, 4);
+
+    const value: Vec4.Type = [_]u16{ 1, 2, 3, 4 };
+    const root = try Vec4.tree.fromValue(&pool, &value);
+
+    var v = try Vec4.TreeView.init(allocator, &pool, root);
+    defer v.deinit();
+
+    try v.set(0, @as(u16, 9));
+    try std.testing.expectEqual(@as(u16, 9), try v.get(0));
+
+    var dropped = try v.clone(false);
+    defer dropped.deinit();
+
+    try std.testing.expectEqual(@as(u16, 1), try v.get(0));
+    try std.testing.expectEqual(@as(u16, 1), try dropped.get(0));
+}
+
+test "TreeView vector clone(true) does not transfer cache" {
+    const allocator = std.testing.allocator;
+    var pool = try Node.Pool.init(allocator, 1024);
+    defer pool.deinit();
+
+    const Uint16 = ssz.UintType(16);
+    const Vec4 = ssz.FixedVectorType(Uint16, 4);
+
+    const value: Vec4.Type = [_]u16{ 1, 2, 3, 4 };
+    const root = try Vec4.tree.fromValue(&pool, &value);
+
+    var v = try Vec4.TreeView.init(allocator, &pool, root);
+    defer v.deinit();
+
+    _ = try v.get(0);
+    try std.testing.expect(v.base_view.data.children_nodes.count() > 0);
+
+    var cloned_no_cache = try v.clone(true);
+    defer cloned_no_cache.deinit();
+
+    try std.testing.expect(v.base_view.data.children_nodes.count() > 0);
+    try std.testing.expectEqual(@as(usize, 0), cloned_no_cache.base_view.data.children_nodes.count());
+}
+
+test "TreeView vector clone(false) transfers cache and clears source" {
+    const allocator = std.testing.allocator;
+    var pool = try Node.Pool.init(allocator, 1024);
+    defer pool.deinit();
+
+    const Uint16 = ssz.UintType(16);
+    const Vec4 = ssz.FixedVectorType(Uint16, 4);
+
+    const value: Vec4.Type = [_]u16{ 1, 2, 3, 4 };
+    const root = try Vec4.tree.fromValue(&pool, &value);
+
+    var v = try Vec4.TreeView.init(allocator, &pool, root);
+    defer v.deinit();
+
+    _ = try v.get(0);
+    try std.testing.expect(v.base_view.data.children_nodes.count() > 0);
+
+    var cloned = try v.clone(false);
+    defer cloned.deinit();
+
+    try std.testing.expectEqual(@as(usize, 0), v.base_view.data.children_nodes.count());
+    try std.testing.expect(cloned.base_view.data.children_nodes.count() > 0);
+}
+
 // Tests ported from TypeScript ssz packages/ssz/test/unit/byType/vector/tree.test.ts
 test "ArrayBasicTreeView - serialize (uint64 vector)" {
     const allocator = std.testing.allocator;

--- a/test/int/ssz/tree_view/array_composite.zig
+++ b/test/int/ssz/tree_view/array_composite.zig
@@ -128,7 +128,7 @@ test "TreeView vector composite clone isolates updates" {
     var v1 = try VectorType.TreeView.init(allocator, &pool, root);
     defer v1.deinit();
 
-    var v2 = try v1.clone(false);
+    var v2 = try v1.clone(.{});
     defer v2.deinit();
 
     const replacement: Inner.Type = .{ .a = 9 };
@@ -175,7 +175,7 @@ test "TreeView vector composite clone reads committed state" {
     replacement_view = null;
     try v1.commit();
 
-    var v2 = try v1.clone(false);
+    var v2 = try v1.clone(.{});
     defer v2.deinit();
 
     const v2_e1 = try v2.get(1);
@@ -212,7 +212,7 @@ test "TreeView vector composite clone drops uncommitted changes" {
     try Inner.tree.toValue(v_e1_before.base_view.data.root, &pool, &v_e1_before_value);
     try std.testing.expectEqual(@as(u32, 9), v_e1_before_value.a);
 
-    var dropped = try v.clone(false);
+    var dropped = try v.clone(.{});
     defer dropped.deinit();
 
     const v_e1_after = try v.get(1);
@@ -248,7 +248,7 @@ test "TreeView vector composite clone(true) does not transfer cache" {
 
     try std.testing.expect(view.base_view.data.children_data.count() > 0);
 
-    var cloned_no_cache = try view.clone(true);
+    var cloned_no_cache = try view.clone(.{ .transfer_cache = false });
     defer cloned_no_cache.deinit();
 
     try std.testing.expect(view.base_view.data.children_data.count() > 0);
@@ -276,7 +276,7 @@ test "TreeView vector composite clone(false) transfers cache and clears source" 
 
     try std.testing.expect(view.base_view.data.children_data.count() > 0);
 
-    var cloned = try view.clone(false);
+    var cloned = try view.clone(.{});
     defer cloned.deinit();
 
     try std.testing.expectEqual(@as(usize, 0), view.base_view.data.children_data.count());

--- a/test/int/ssz/tree_view/bit_list.zig
+++ b/test/int/ssz/tree_view/bit_list.zig
@@ -39,6 +39,129 @@ test "BitListTreeView get/set roundtrip" {
     try std.testing.expectEqualSlices(u8, &expected_root, &view_root);
 }
 
+test "BitListTreeView clone(true) does not transfer cache" {
+    const allocator = std.testing.allocator;
+    const Bits = ssz.BitListType(64);
+
+    var pool = try Node.Pool.init(allocator, 4096);
+    defer pool.deinit();
+
+    var value = try Bits.Type.fromBitLen(allocator, 12);
+    defer value.deinit(allocator);
+    try value.setAssumeCapacity(1, true);
+    try value.setAssumeCapacity(9, true);
+
+    const root = try Bits.tree.fromValue(allocator, &pool, &value);
+    var view = try Bits.TreeView.init(allocator, &pool, root);
+    defer view.deinit();
+
+    _ = try view.get(0);
+    try std.testing.expect(view.base_view.data.children_nodes.count() > 0);
+
+    var cloned_no_cache = try view.clone(true);
+    defer cloned_no_cache.deinit();
+
+    try std.testing.expect(view.base_view.data.children_nodes.count() > 0);
+    try std.testing.expectEqual(@as(usize, 0), cloned_no_cache.base_view.data.children_nodes.count());
+}
+
+test "BitListTreeView clone(false) transfers cache and clears source" {
+    const allocator = std.testing.allocator;
+    const Bits = ssz.BitListType(64);
+
+    var pool = try Node.Pool.init(allocator, 4096);
+    defer pool.deinit();
+
+    var value = try Bits.Type.fromBitLen(allocator, 12);
+    defer value.deinit(allocator);
+    try value.setAssumeCapacity(1, true);
+    try value.setAssumeCapacity(9, true);
+
+    const root = try Bits.tree.fromValue(allocator, &pool, &value);
+    var view = try Bits.TreeView.init(allocator, &pool, root);
+    defer view.deinit();
+
+    _ = try view.get(0);
+    try std.testing.expect(view.base_view.data.children_nodes.count() > 0);
+
+    var cloned = try view.clone(false);
+    defer cloned.deinit();
+
+    try std.testing.expectEqual(@as(usize, 0), view.base_view.data.children_nodes.count());
+    try std.testing.expect(cloned.base_view.data.children_nodes.count() > 0);
+}
+
+test "BitListTreeView clone isolates updates" {
+    const allocator = std.testing.allocator;
+    const Bits = ssz.BitListType(64);
+
+    var pool = try Node.Pool.init(allocator, 4096);
+    defer pool.deinit();
+
+    var value = try Bits.Type.fromBitLen(allocator, 12);
+    defer value.deinit(allocator);
+
+    const root = try Bits.tree.fromValue(allocator, &pool, &value);
+    var v1 = try Bits.TreeView.init(allocator, &pool, root);
+    defer v1.deinit();
+
+    var v2 = try v1.clone(false);
+    defer v2.deinit();
+
+    try v2.set(0, true);
+    try v2.commit();
+
+    try std.testing.expect(!try v1.get(0));
+    try std.testing.expect(try v2.get(0));
+}
+
+test "BitListTreeView clone reads committed state" {
+    const allocator = std.testing.allocator;
+    const Bits = ssz.BitListType(64);
+
+    var pool = try Node.Pool.init(allocator, 4096);
+    defer pool.deinit();
+
+    var value = try Bits.Type.fromBitLen(allocator, 12);
+    defer value.deinit(allocator);
+
+    const root = try Bits.tree.fromValue(allocator, &pool, &value);
+    var v1 = try Bits.TreeView.init(allocator, &pool, root);
+    defer v1.deinit();
+
+    try v1.set(1, true);
+    try v1.commit();
+
+    var v2 = try v1.clone(false);
+    defer v2.deinit();
+
+    try std.testing.expect(try v2.get(1));
+}
+
+test "BitListTreeView clone drops uncommitted changes" {
+    const allocator = std.testing.allocator;
+    const Bits = ssz.BitListType(64);
+
+    var pool = try Node.Pool.init(allocator, 4096);
+    defer pool.deinit();
+
+    var value = try Bits.Type.fromBitLen(allocator, 12);
+    defer value.deinit(allocator);
+
+    const root = try Bits.tree.fromValue(allocator, &pool, &value);
+    var v = try Bits.TreeView.init(allocator, &pool, root);
+    defer v.deinit();
+
+    try v.set(2, true);
+    try std.testing.expect(try v.get(2));
+
+    var dropped = try v.clone(false);
+    defer dropped.deinit();
+
+    try std.testing.expect(!try v.get(2));
+    try std.testing.expect(!try dropped.get(2));
+}
+
 test "BitListTreeView toBoolArray roundtrip" {
     const allocator = std.testing.allocator;
     const Bits = ssz.BitListType(16);

--- a/test/int/ssz/tree_view/bit_list.zig
+++ b/test/int/ssz/tree_view/bit_list.zig
@@ -58,7 +58,7 @@ test "BitListTreeView clone(true) does not transfer cache" {
     _ = try view.get(0);
     try std.testing.expect(view.base_view.data.children_nodes.count() > 0);
 
-    var cloned_no_cache = try view.clone(true);
+    var cloned_no_cache = try view.clone(.{ .transfer_cache = false });
     defer cloned_no_cache.deinit();
 
     try std.testing.expect(view.base_view.data.children_nodes.count() > 0);
@@ -84,7 +84,7 @@ test "BitListTreeView clone(false) transfers cache and clears source" {
     _ = try view.get(0);
     try std.testing.expect(view.base_view.data.children_nodes.count() > 0);
 
-    var cloned = try view.clone(false);
+    var cloned = try view.clone(.{});
     defer cloned.deinit();
 
     try std.testing.expectEqual(@as(usize, 0), view.base_view.data.children_nodes.count());
@@ -105,7 +105,7 @@ test "BitListTreeView clone isolates updates" {
     var v1 = try Bits.TreeView.init(allocator, &pool, root);
     defer v1.deinit();
 
-    var v2 = try v1.clone(false);
+    var v2 = try v1.clone(.{});
     defer v2.deinit();
 
     try v2.set(0, true);
@@ -132,7 +132,7 @@ test "BitListTreeView clone reads committed state" {
     try v1.set(1, true);
     try v1.commit();
 
-    var v2 = try v1.clone(false);
+    var v2 = try v1.clone(.{});
     defer v2.deinit();
 
     try std.testing.expect(try v2.get(1));
@@ -155,7 +155,7 @@ test "BitListTreeView clone drops uncommitted changes" {
     try v.set(2, true);
     try std.testing.expect(try v.get(2));
 
-    var dropped = try v.clone(false);
+    var dropped = try v.clone(.{});
     defer dropped.deinit();
 
     try std.testing.expect(!try v.get(2));

--- a/test/int/ssz/tree_view/bit_vector.zig
+++ b/test/int/ssz/tree_view/bit_vector.zig
@@ -38,6 +38,120 @@ test "BitVectorTreeView get/set roundtrip" {
     try std.testing.expectEqualSlices(u8, &expected_root, &view_root);
 }
 
+test "BitVectorTreeView clone(true) does not transfer cache" {
+    const allocator = std.testing.allocator;
+    const Bits = ssz.BitVectorType(44);
+
+    var pool = try Node.Pool.init(allocator, 2048);
+    defer pool.deinit();
+
+    var value: Bits.Type = Bits.default_value;
+    try value.set(1, true);
+    try value.set(7, true);
+    try value.set(31, true);
+
+    const root = try Bits.tree.fromValue(&pool, &value);
+    var view = try Bits.TreeView.init(allocator, &pool, root);
+    defer view.deinit();
+
+    _ = try view.get(0);
+    try std.testing.expect(view.base_view.data.children_nodes.count() > 0);
+
+    var cloned_no_cache = try view.clone(true);
+    defer cloned_no_cache.deinit();
+
+    try std.testing.expect(view.base_view.data.children_nodes.count() > 0);
+    try std.testing.expectEqual(@as(usize, 0), cloned_no_cache.base_view.data.children_nodes.count());
+}
+
+test "BitVectorTreeView clone(false) transfers cache and clears source" {
+    const allocator = std.testing.allocator;
+    const Bits = ssz.BitVectorType(44);
+
+    var pool = try Node.Pool.init(allocator, 2048);
+    defer pool.deinit();
+
+    var value: Bits.Type = Bits.default_value;
+    try value.set(1, true);
+    try value.set(7, true);
+    try value.set(31, true);
+
+    const root = try Bits.tree.fromValue(&pool, &value);
+    var view = try Bits.TreeView.init(allocator, &pool, root);
+    defer view.deinit();
+
+    _ = try view.get(0);
+    try std.testing.expect(view.base_view.data.children_nodes.count() > 0);
+
+    var cloned = try view.clone(false);
+    defer cloned.deinit();
+
+    try std.testing.expectEqual(@as(usize, 0), view.base_view.data.children_nodes.count());
+    try std.testing.expect(cloned.base_view.data.children_nodes.count() > 0);
+}
+
+test "BitVectorTreeView clone isolates updates" {
+    const allocator = std.testing.allocator;
+    const Bits = ssz.BitVectorType(44);
+
+    var pool = try Node.Pool.init(allocator, 2048);
+    defer pool.deinit();
+
+    const root = try Bits.tree.fromValue(&pool, &Bits.default_value);
+    var v1 = try Bits.TreeView.init(allocator, &pool, root);
+    defer v1.deinit();
+
+    var v2 = try v1.clone(false);
+    defer v2.deinit();
+
+    try v2.set(0, true);
+    try v2.commit();
+
+    try std.testing.expect(!try v1.get(0));
+    try std.testing.expect(try v2.get(0));
+}
+
+test "BitVectorTreeView clone reads committed state" {
+    const allocator = std.testing.allocator;
+    const Bits = ssz.BitVectorType(44);
+
+    var pool = try Node.Pool.init(allocator, 2048);
+    defer pool.deinit();
+
+    const root = try Bits.tree.fromValue(&pool, &Bits.default_value);
+    var v1 = try Bits.TreeView.init(allocator, &pool, root);
+    defer v1.deinit();
+
+    try v1.set(1, true);
+    try v1.commit();
+
+    var v2 = try v1.clone(false);
+    defer v2.deinit();
+
+    try std.testing.expect(try v2.get(1));
+}
+
+test "BitVectorTreeView clone drops uncommitted changes" {
+    const allocator = std.testing.allocator;
+    const Bits = ssz.BitVectorType(44);
+
+    var pool = try Node.Pool.init(allocator, 2048);
+    defer pool.deinit();
+
+    const root = try Bits.tree.fromValue(&pool, &Bits.default_value);
+    var v = try Bits.TreeView.init(allocator, &pool, root);
+    defer v.deinit();
+
+    try v.set(2, true);
+    try std.testing.expect(try v.get(2));
+
+    var dropped = try v.clone(false);
+    defer dropped.deinit();
+
+    try std.testing.expect(!try v.get(2));
+    try std.testing.expect(!try dropped.get(2));
+}
+
 test "BitVectorTreeView toBoolArray roundtrip" {
     const allocator = std.testing.allocator;
     const Bits = ssz.BitVectorType(16);

--- a/test/int/ssz/tree_view/bit_vector.zig
+++ b/test/int/ssz/tree_view/bit_vector.zig
@@ -57,7 +57,7 @@ test "BitVectorTreeView clone(true) does not transfer cache" {
     _ = try view.get(0);
     try std.testing.expect(view.base_view.data.children_nodes.count() > 0);
 
-    var cloned_no_cache = try view.clone(true);
+    var cloned_no_cache = try view.clone(.{ .transfer_cache = false });
     defer cloned_no_cache.deinit();
 
     try std.testing.expect(view.base_view.data.children_nodes.count() > 0);
@@ -83,7 +83,7 @@ test "BitVectorTreeView clone(false) transfers cache and clears source" {
     _ = try view.get(0);
     try std.testing.expect(view.base_view.data.children_nodes.count() > 0);
 
-    var cloned = try view.clone(false);
+    var cloned = try view.clone(.{});
     defer cloned.deinit();
 
     try std.testing.expectEqual(@as(usize, 0), view.base_view.data.children_nodes.count());
@@ -101,7 +101,7 @@ test "BitVectorTreeView clone isolates updates" {
     var v1 = try Bits.TreeView.init(allocator, &pool, root);
     defer v1.deinit();
 
-    var v2 = try v1.clone(false);
+    var v2 = try v1.clone(.{});
     defer v2.deinit();
 
     try v2.set(0, true);
@@ -125,7 +125,7 @@ test "BitVectorTreeView clone reads committed state" {
     try v1.set(1, true);
     try v1.commit();
 
-    var v2 = try v1.clone(false);
+    var v2 = try v1.clone(.{});
     defer v2.deinit();
 
     try std.testing.expect(try v2.get(1));
@@ -145,7 +145,7 @@ test "BitVectorTreeView clone drops uncommitted changes" {
     try v.set(2, true);
     try std.testing.expect(try v.get(2));
 
-    var dropped = try v.clone(false);
+    var dropped = try v.clone(.{});
     defer dropped.deinit();
 
     try std.testing.expect(!try v.get(2));

--- a/test/int/ssz/tree_view/container.zig
+++ b/test/int/ssz/tree_view/container.zig
@@ -211,6 +211,110 @@ test "TreeView container nested types set/get/commit" {
     try std.testing.expectEqualSlices(u8, &[_]u8{0x5A}, roundtrip.comp_list.items[0].payload.items);
 }
 
+test "TreeView container clone isolates updates" {
+    const allocator = std.testing.allocator;
+    var pool = try Node.Pool.init(allocator, 1024);
+    defer pool.deinit();
+
+    const Uint64 = ssz.UintType(64);
+    const C = ssz.FixedContainerType(struct {
+        n: Uint64,
+    });
+
+    const value: C.Type = .{ .n = 1 };
+    const root = try C.tree.fromValue(&pool, &value);
+
+    var v1 = try C.TreeView.init(allocator, &pool, root);
+    defer v1.deinit();
+
+    var v2 = try v1.clone(false);
+    defer v2.deinit();
+
+    try v2.set("n", @as(u64, 99));
+    try v2.commit();
+
+    try std.testing.expectEqual(@as(u64, 1), try v1.get("n"));
+    try std.testing.expectEqual(@as(u64, 99), try v2.get("n"));
+}
+
+test "TreeView container clone drops uncommitted changes" {
+    const allocator = std.testing.allocator;
+    var pool = try Node.Pool.init(allocator, 1024);
+    defer pool.deinit();
+
+    const Uint64 = ssz.UintType(64);
+    const C = ssz.FixedContainerType(struct {
+        n: Uint64,
+    });
+
+    const value: C.Type = .{ .n = 1 };
+    const root = try C.tree.fromValue(&pool, &value);
+
+    var v = try C.TreeView.init(allocator, &pool, root);
+    defer v.deinit();
+
+    try v.set("n", @as(u64, 7));
+    try std.testing.expectEqual(@as(u64, 7), try v.get("n"));
+
+    var dropped = try v.clone(false);
+    defer dropped.deinit();
+
+    try std.testing.expectEqual(@as(u64, 1), try v.get("n"));
+    try std.testing.expectEqual(@as(u64, 1), try dropped.get("n"));
+}
+
+test "TreeView container clone(true) does not transfer cache" {
+    const allocator = std.testing.allocator;
+    var pool = try Node.Pool.init(allocator, 1024);
+    defer pool.deinit();
+
+    const Uint64 = ssz.UintType(64);
+    const C = ssz.FixedContainerType(struct {
+        n: Uint64,
+    });
+
+    const value: C.Type = .{ .n = 1 };
+    const root = try C.tree.fromValue(&pool, &value);
+
+    var v = try C.TreeView.init(allocator, &pool, root);
+    defer v.deinit();
+
+    _ = try v.get("n");
+    try std.testing.expect(v.base_view.data.children_nodes.count() > 0);
+
+    var cloned_no_cache = try v.clone(true);
+    defer cloned_no_cache.deinit();
+
+    try std.testing.expect(v.base_view.data.children_nodes.count() > 0);
+    try std.testing.expectEqual(@as(usize, 0), cloned_no_cache.base_view.data.children_nodes.count());
+}
+
+test "TreeView container clone(false) transfers cache and clears source" {
+    const allocator = std.testing.allocator;
+    var pool = try Node.Pool.init(allocator, 1024);
+    defer pool.deinit();
+
+    const Uint64 = ssz.UintType(64);
+    const C = ssz.FixedContainerType(struct {
+        n: Uint64,
+    });
+
+    const value: C.Type = .{ .n = 1 };
+    const root = try C.tree.fromValue(&pool, &value);
+
+    var v = try C.TreeView.init(allocator, &pool, root);
+    defer v.deinit();
+
+    _ = try v.get("n");
+    try std.testing.expect(v.base_view.data.children_nodes.count() > 0);
+
+    var cloned = try v.clone(false);
+    defer cloned.deinit();
+
+    try std.testing.expectEqual(@as(usize, 0), v.base_view.data.children_nodes.count());
+    try std.testing.expect(cloned.base_view.data.children_nodes.count() > 0);
+}
+
 // Tests ported from TypeScript ssz packages/ssz/test/unit/byType/container/tree.test.ts
 test "ContainerTreeView - serialize (basic fields)" {
     const allocator = std.testing.allocator;

--- a/test/int/ssz/tree_view/container.zig
+++ b/test/int/ssz/tree_view/container.zig
@@ -227,7 +227,7 @@ test "TreeView container clone isolates updates" {
     var v1 = try C.TreeView.init(allocator, &pool, root);
     defer v1.deinit();
 
-    var v2 = try v1.clone(false);
+    var v2 = try v1.clone(.{});
     defer v2.deinit();
 
     try v2.set("n", @as(u64, 99));
@@ -256,7 +256,7 @@ test "TreeView container clone drops uncommitted changes" {
     try v.set("n", @as(u64, 7));
     try std.testing.expectEqual(@as(u64, 7), try v.get("n"));
 
-    var dropped = try v.clone(false);
+    var dropped = try v.clone(.{});
     defer dropped.deinit();
 
     try std.testing.expectEqual(@as(u64, 1), try v.get("n"));
@@ -282,7 +282,7 @@ test "TreeView container clone(true) does not transfer cache" {
     _ = try v.get("n");
     try std.testing.expect(v.base_view.data.children_nodes.count() > 0);
 
-    var cloned_no_cache = try v.clone(true);
+    var cloned_no_cache = try v.clone(.{ .transfer_cache = false });
     defer cloned_no_cache.deinit();
 
     try std.testing.expect(v.base_view.data.children_nodes.count() > 0);
@@ -308,7 +308,7 @@ test "TreeView container clone(false) transfers cache and clears source" {
     _ = try v.get("n");
     try std.testing.expect(v.base_view.data.children_nodes.count() > 0);
 
-    var cloned = try v.clone(false);
+    var cloned = try v.clone(.{});
     defer cloned.deinit();
 
     try std.testing.expectEqual(@as(usize, 0), v.base_view.data.children_nodes.count());

--- a/test/int/ssz/tree_view/list_basic.zig
+++ b/test/int/ssz/tree_view/list_basic.zig
@@ -247,7 +247,7 @@ test "TreeView list basic clone isolates updates" {
     var v1 = try ListType.TreeView.init(allocator, &pool, root);
     defer v1.deinit();
 
-    var v2 = try v1.clone(false);
+    var v2 = try v1.clone(.{});
     defer v2.deinit();
 
     try v2.set(1, @as(u32, 99));
@@ -276,7 +276,7 @@ test "TreeView list basic clone reads committed state" {
     try v1.set(0, @as(u32, 7));
     try v1.commit();
 
-    var v2 = try v1.clone(false);
+    var v2 = try v1.clone(.{});
     defer v2.deinit();
 
     try std.testing.expectEqual(@as(u32, 7), try v2.get(0));
@@ -301,7 +301,7 @@ test "TreeView list basic clone drops uncommitted changes" {
     try v.set(0, @as(u32, 7));
     try std.testing.expectEqual(@as(u32, 7), try v.get(0));
 
-    var dropped = try v.clone(false);
+    var dropped = try v.clone(.{});
     defer dropped.deinit();
 
     try std.testing.expectEqual(@as(u32, 1), try v.get(0));
@@ -327,7 +327,7 @@ test "TreeView list basic clone(true) does not transfer cache" {
     _ = try view.get(0);
     try std.testing.expect(view.base_view.data.children_nodes.count() > 0);
 
-    var cloned_no_cache = try view.clone(true);
+    var cloned_no_cache = try view.clone(.{ .transfer_cache = false });
     defer cloned_no_cache.deinit();
 
     try std.testing.expect(view.base_view.data.children_nodes.count() > 0);
@@ -353,7 +353,7 @@ test "TreeView list basic clone(false) transfers cache and clears source" {
     _ = try view.get(0);
     try std.testing.expect(view.base_view.data.children_nodes.count() > 0);
 
-    var cloned = try view.clone(false);
+    var cloned = try view.clone(.{});
     defer cloned.deinit();
 
     try std.testing.expectEqual(@as(usize, 0), view.base_view.data.children_nodes.count());

--- a/test/int/ssz/tree_view/list_basic.zig
+++ b/test/int/ssz/tree_view/list_basic.zig
@@ -231,6 +231,135 @@ test "TreeView list push enforces limit" {
     try std.testing.expectEqual(@as(usize, 2), try view.length());
 }
 
+test "TreeView list basic clone isolates updates" {
+    const allocator = std.testing.allocator;
+    var pool = try Node.Pool.init(allocator, 1024);
+    defer pool.deinit();
+
+    const Uint32 = ssz.UintType(32);
+    const ListType = ssz.FixedListType(Uint32, 16);
+
+    var list: ListType.Type = .empty;
+    defer list.deinit(allocator);
+    try list.appendSlice(allocator, &[_]u32{ 1, 2, 3 });
+
+    const root = try ListType.tree.fromValue(allocator, &pool, &list);
+    var v1 = try ListType.TreeView.init(allocator, &pool, root);
+    defer v1.deinit();
+
+    var v2 = try v1.clone(false);
+    defer v2.deinit();
+
+    try v2.set(1, @as(u32, 99));
+    try v2.commit();
+
+    try std.testing.expectEqual(@as(u32, 2), try v1.get(1));
+    try std.testing.expectEqual(@as(u32, 99), try v2.get(1));
+}
+
+test "TreeView list basic clone reads committed state" {
+    const allocator = std.testing.allocator;
+    var pool = try Node.Pool.init(allocator, 1024);
+    defer pool.deinit();
+
+    const Uint32 = ssz.UintType(32);
+    const ListType = ssz.FixedListType(Uint32, 16);
+
+    var list: ListType.Type = .empty;
+    defer list.deinit(allocator);
+    try list.appendSlice(allocator, &[_]u32{ 1, 2, 3 });
+
+    const root = try ListType.tree.fromValue(allocator, &pool, &list);
+    var v1 = try ListType.TreeView.init(allocator, &pool, root);
+    defer v1.deinit();
+
+    try v1.set(0, @as(u32, 7));
+    try v1.commit();
+
+    var v2 = try v1.clone(false);
+    defer v2.deinit();
+
+    try std.testing.expectEqual(@as(u32, 7), try v2.get(0));
+}
+
+test "TreeView list basic clone drops uncommitted changes" {
+    const allocator = std.testing.allocator;
+    var pool = try Node.Pool.init(allocator, 1024);
+    defer pool.deinit();
+
+    const Uint32 = ssz.UintType(32);
+    const ListType = ssz.FixedListType(Uint32, 16);
+
+    var list: ListType.Type = .empty;
+    defer list.deinit(allocator);
+    try list.appendSlice(allocator, &[_]u32{ 1, 2, 3 });
+
+    const root = try ListType.tree.fromValue(allocator, &pool, &list);
+    var v = try ListType.TreeView.init(allocator, &pool, root);
+    defer v.deinit();
+
+    try v.set(0, @as(u32, 7));
+    try std.testing.expectEqual(@as(u32, 7), try v.get(0));
+
+    var dropped = try v.clone(false);
+    defer dropped.deinit();
+
+    try std.testing.expectEqual(@as(u32, 1), try v.get(0));
+    try std.testing.expectEqual(@as(u32, 1), try dropped.get(0));
+}
+
+test "TreeView list basic clone(true) does not transfer cache" {
+    const allocator = std.testing.allocator;
+    var pool = try Node.Pool.init(allocator, 256);
+    defer pool.deinit();
+
+    const Uint32 = ssz.UintType(32);
+    const ListType = ssz.FixedListType(Uint32, 16);
+
+    var list: ListType.Type = .empty;
+    defer list.deinit(allocator);
+    try list.appendSlice(allocator, &[_]u32{ 1, 2, 3 });
+
+    const root_node = try ListType.tree.fromValue(allocator, &pool, &list);
+    var view = try ListType.TreeView.init(allocator, &pool, root_node);
+    defer view.deinit();
+
+    _ = try view.get(0);
+    try std.testing.expect(view.base_view.data.children_nodes.count() > 0);
+
+    var cloned_no_cache = try view.clone(true);
+    defer cloned_no_cache.deinit();
+
+    try std.testing.expect(view.base_view.data.children_nodes.count() > 0);
+    try std.testing.expectEqual(@as(usize, 0), cloned_no_cache.base_view.data.children_nodes.count());
+}
+
+test "TreeView list basic clone(false) transfers cache and clears source" {
+    const allocator = std.testing.allocator;
+    var pool = try Node.Pool.init(allocator, 256);
+    defer pool.deinit();
+
+    const Uint32 = ssz.UintType(32);
+    const ListType = ssz.FixedListType(Uint32, 16);
+
+    var list: ListType.Type = .empty;
+    defer list.deinit(allocator);
+    try list.appendSlice(allocator, &[_]u32{ 1, 2, 3 });
+
+    const root_node = try ListType.tree.fromValue(allocator, &pool, &list);
+    var view = try ListType.TreeView.init(allocator, &pool, root_node);
+    defer view.deinit();
+
+    _ = try view.get(0);
+    try std.testing.expect(view.base_view.data.children_nodes.count() > 0);
+
+    var cloned = try view.clone(false);
+    defer cloned.deinit();
+
+    try std.testing.expectEqual(@as(usize, 0), view.base_view.data.children_nodes.count());
+    try std.testing.expect(cloned.base_view.data.children_nodes.count() > 0);
+}
+
 // Refer to https://github.com/ChainSafe/ssz/blob/7f5580c2ea69f9307300ddb6010a8bc7ce2fc471/packages/ssz/test/unit/byType/listBasic/tree.test.ts#L180-L203
 test "TreeView basic list getAll reflects pushes" {
     const allocator = std.testing.allocator;

--- a/test/int/ssz/tree_view/list_composite.zig
+++ b/test/int/ssz/tree_view/list_composite.zig
@@ -209,7 +209,7 @@ test "TreeView composite list clone isolates updates" {
     var v1 = try ListType.TreeView.init(allocator, &pool, root);
     defer v1.deinit();
 
-    var v2 = try v1.clone(false);
+    var v2 = try v1.clone(.{});
     defer v2.deinit();
 
     const replacement = Checkpoint.Type{ .epoch = 9, .root = [_]u8{9} ** 32 };
@@ -255,7 +255,7 @@ test "TreeView composite list clone reads committed state" {
     replacement_view = null;
     try v1.commit();
 
-    var v2 = try v1.clone(false);
+    var v2 = try v1.clone(.{});
     defer v2.deinit();
 
     const v2_e0 = try v2.get(0);
@@ -292,7 +292,7 @@ test "TreeView composite list clone drops uncommitted changes" {
     try Checkpoint.tree.toValue(v_e0_before.base_view.data.root, &pool, &v_e0_before_value);
     try std.testing.expectEqual(@as(u64, 9), v_e0_before_value.epoch);
 
-    var dropped = try v.clone(false);
+    var dropped = try v.clone(.{});
     defer dropped.deinit();
 
     const v_e0_after = try v.get(0);
@@ -327,7 +327,7 @@ test "TreeView composite list clone(true) does not transfer cache" {
 
     try std.testing.expect(view.base_view.data.children_data.count() > 0);
 
-    var cloned_no_cache = try view.clone(true);
+    var cloned_no_cache = try view.clone(.{ .transfer_cache = false });
     defer cloned_no_cache.deinit();
 
     try std.testing.expect(view.base_view.data.children_data.count() > 0);
@@ -354,7 +354,7 @@ test "TreeView composite list clone(false) transfers cache and clears source" {
 
     try std.testing.expect(view.base_view.data.children_data.count() > 0);
 
-    var cloned = try view.clone(false);
+    var cloned = try view.clone(.{});
     defer cloned.deinit();
 
     try std.testing.expectEqual(@as(usize, 0), view.base_view.data.children_data.count());

--- a/test/int/ssz/tree_view/list_composite.zig
+++ b/test/int/ssz/tree_view/list_composite.zig
@@ -194,6 +194,173 @@ test "TreeView composite list push appends element" {
     try std.testing.expectEqual(next_checkpoint.epoch, roundtrip.items[1].epoch);
 }
 
+test "TreeView composite list clone isolates updates" {
+    const allocator = std.testing.allocator;
+    var pool = try Node.Pool.init(allocator, 1024);
+    defer pool.deinit();
+
+    const ListType = ssz.FixedListType(Checkpoint, 16);
+
+    var list: ListType.Type = .empty;
+    defer list.deinit(allocator);
+    try list.append(allocator, .{ .epoch = 1, .root = [_]u8{1} ** 32 });
+
+    const root = try ListType.tree.fromValue(allocator, &pool, &list);
+    var v1 = try ListType.TreeView.init(allocator, &pool, root);
+    defer v1.deinit();
+
+    var v2 = try v1.clone(false);
+    defer v2.deinit();
+
+    const replacement = Checkpoint.Type{ .epoch = 9, .root = [_]u8{9} ** 32 };
+    const replacement_root = try Checkpoint.tree.fromValue(&pool, &replacement);
+    var replacement_view: ?Checkpoint.TreeView = try Checkpoint.TreeView.init(allocator, &pool, replacement_root);
+    defer if (replacement_view) |*v| v.deinit();
+    try v2.set(0, replacement_view.?);
+    replacement_view = null;
+    try v2.commit();
+
+    const v1_e0 = try v1.get(0);
+    var v1_e0_value: Checkpoint.Type = undefined;
+    try Checkpoint.tree.toValue(v1_e0.base_view.data.root, &pool, &v1_e0_value);
+
+    const v2_e0 = try v2.get(0);
+    var v2_e0_value: Checkpoint.Type = undefined;
+    try Checkpoint.tree.toValue(v2_e0.base_view.data.root, &pool, &v2_e0_value);
+
+    try std.testing.expectEqual(@as(u64, 1), v1_e0_value.epoch);
+    try std.testing.expectEqual(@as(u64, 9), v2_e0_value.epoch);
+}
+
+test "TreeView composite list clone reads committed state" {
+    const allocator = std.testing.allocator;
+    var pool = try Node.Pool.init(allocator, 1024);
+    defer pool.deinit();
+
+    const ListType = ssz.FixedListType(Checkpoint, 16);
+
+    var list: ListType.Type = .empty;
+    defer list.deinit(allocator);
+    try list.append(allocator, .{ .epoch = 1, .root = [_]u8{1} ** 32 });
+
+    const root = try ListType.tree.fromValue(allocator, &pool, &list);
+    var v1 = try ListType.TreeView.init(allocator, &pool, root);
+    defer v1.deinit();
+
+    const replacement = Checkpoint.Type{ .epoch = 9, .root = [_]u8{9} ** 32 };
+    const replacement_root = try Checkpoint.tree.fromValue(&pool, &replacement);
+    var replacement_view: ?Checkpoint.TreeView = try Checkpoint.TreeView.init(allocator, &pool, replacement_root);
+    defer if (replacement_view) |*v| v.deinit();
+    try v1.set(0, replacement_view.?);
+    replacement_view = null;
+    try v1.commit();
+
+    var v2 = try v1.clone(false);
+    defer v2.deinit();
+
+    const v2_e0 = try v2.get(0);
+    var v2_e0_value: Checkpoint.Type = undefined;
+    try Checkpoint.tree.toValue(v2_e0.base_view.data.root, &pool, &v2_e0_value);
+
+    try std.testing.expectEqual(@as(u64, 9), v2_e0_value.epoch);
+}
+
+test "TreeView composite list clone drops uncommitted changes" {
+    const allocator = std.testing.allocator;
+    var pool = try Node.Pool.init(allocator, 1024);
+    defer pool.deinit();
+
+    const ListType = ssz.FixedListType(Checkpoint, 16);
+
+    var list: ListType.Type = .empty;
+    defer list.deinit(allocator);
+    try list.append(allocator, .{ .epoch = 1, .root = [_]u8{1} ** 32 });
+
+    const root = try ListType.tree.fromValue(allocator, &pool, &list);
+    var v = try ListType.TreeView.init(allocator, &pool, root);
+    defer v.deinit();
+
+    const replacement = Checkpoint.Type{ .epoch = 9, .root = [_]u8{9} ** 32 };
+    const replacement_root = try Checkpoint.tree.fromValue(&pool, &replacement);
+    var replacement_view: ?Checkpoint.TreeView = try Checkpoint.TreeView.init(allocator, &pool, replacement_root);
+    defer if (replacement_view) |*v0| v0.deinit();
+    try v.set(0, replacement_view.?);
+    replacement_view = null;
+
+    const v_e0_before = try v.get(0);
+    var v_e0_before_value: Checkpoint.Type = undefined;
+    try Checkpoint.tree.toValue(v_e0_before.base_view.data.root, &pool, &v_e0_before_value);
+    try std.testing.expectEqual(@as(u64, 9), v_e0_before_value.epoch);
+
+    var dropped = try v.clone(false);
+    defer dropped.deinit();
+
+    const v_e0_after = try v.get(0);
+    var v_e0_after_value: Checkpoint.Type = undefined;
+    try Checkpoint.tree.toValue(v_e0_after.base_view.data.root, &pool, &v_e0_after_value);
+
+    const dropped_e0 = try dropped.get(0);
+    var dropped_e0_value: Checkpoint.Type = undefined;
+    try Checkpoint.tree.toValue(dropped_e0.base_view.data.root, &pool, &dropped_e0_value);
+
+    try std.testing.expectEqual(@as(u64, 1), v_e0_after_value.epoch);
+    try std.testing.expectEqual(@as(u64, 1), dropped_e0_value.epoch);
+}
+
+test "TreeView composite list clone(true) does not transfer cache" {
+    const allocator = std.testing.allocator;
+    var pool = try Node.Pool.init(allocator, 512);
+    defer pool.deinit();
+
+    const ListType = ssz.FixedListType(Checkpoint, 16);
+
+    var list: ListType.Type = .empty;
+    defer list.deinit(allocator);
+    try list.append(allocator, .{ .epoch = 1, .root = [_]u8{1} ** 32 });
+
+    const root_node = try ListType.tree.fromValue(allocator, &pool, &list);
+    var view = try ListType.TreeView.init(allocator, &pool, root_node);
+    defer view.deinit();
+
+    _ = try view.get(0);
+    try view.commit();
+
+    try std.testing.expect(view.base_view.data.children_data.count() > 0);
+
+    var cloned_no_cache = try view.clone(true);
+    defer cloned_no_cache.deinit();
+
+    try std.testing.expect(view.base_view.data.children_data.count() > 0);
+    try std.testing.expectEqual(@as(usize, 0), cloned_no_cache.base_view.data.children_data.count());
+}
+
+test "TreeView composite list clone(false) transfers cache and clears source" {
+    const allocator = std.testing.allocator;
+    var pool = try Node.Pool.init(allocator, 512);
+    defer pool.deinit();
+
+    const ListType = ssz.FixedListType(Checkpoint, 16);
+
+    var list: ListType.Type = .empty;
+    defer list.deinit(allocator);
+    try list.append(allocator, .{ .epoch = 1, .root = [_]u8{1} ** 32 });
+
+    const root_node = try ListType.tree.fromValue(allocator, &pool, &list);
+    var view = try ListType.TreeView.init(allocator, &pool, root_node);
+    defer view.deinit();
+
+    _ = try view.get(0);
+    try view.commit();
+
+    try std.testing.expect(view.base_view.data.children_data.count() > 0);
+
+    var cloned = try view.clone(false);
+    defer cloned.deinit();
+
+    try std.testing.expectEqual(@as(usize, 0), view.base_view.data.children_data.count());
+    try std.testing.expect(cloned.base_view.data.children_data.count() > 0);
+}
+
 test "TreeView list of list commits inner length updates" {
     const allocator = std.testing.allocator;
     var pool = try Node.Pool.init(allocator, 1024);


### PR DESCRIPTION
**Motivation**

Implement the tree view `clone` like lodestar treeview.

**Description**

- Implemented `clone(dont_transfer_cache: bool)` on the base TreeView and exposed it across all TreeView wrappers, enabling creation of a new view sharing the same committed root and match the previous ts semantics.
- Added comprehensive integration tests covering `clone`.
