### PR TITLE
feat(treeview): Implement the basic list sliceFrom

### DIFF
--- a/src/ssz/tree_view/list_basic.zig
+++ b/src/ssz/tree_view/list_basic.zig
@@ -163,13 +163,11 @@ pub fn ListBasicTreeView(comptime ST: type) type {
 
             const list_length = try self.length();
 
-            // If index is 0, return a copy of the current view
             if (index == 0) {
                 return try Self.init(self.base_view.allocator, self.base_view.pool, self.base_view.data.root);
             }
 
             const target_length = if (index >= list_length) 0 else list_length - index;
-
             if (target_length == 0) {
                 const chunk_root: Node.Id = @enumFromInt(base_chunk_depth);
                 var length_node: ?Node.Id = try self.base_view.pool.createLeafFromUint(0);
@@ -198,77 +196,15 @@ pub fn ListBasicTreeView(comptime ST: type) type {
                 source_nodes,
             );
 
-            const new_chunk_nodes = try self.base_view.allocator.alloc(Node.Id, new_chunk_count);
-            defer self.base_view.allocator.free(new_chunk_nodes);
-
-            const chunk_root_value: Node.Id = blk: {
-                // Track newly created leaf nodes for error cleanup.
-                //
-                // - aligned case: at most 1 leaf is newly created (only if we need to zero-pad the last chunk)
-                // - unaligned case: all chunks are newly created leaves
-                var newly_created_count: usize = 0;
-                var newly_created_last_leaf: ?Node.Id = null;
-
-                errdefer {
-                    if (start_offset_in_chunk == 0) {
-                        if (newly_created_last_leaf) |id| self.base_view.pool.unref(id);
-                    } else {
-                        for (new_chunk_nodes[0..newly_created_count]) |node| self.base_view.pool.unref(node);
-                    }
-                }
-
-                if (start_offset_in_chunk == 0) {
-                    for (0..new_chunk_count) |i| {
-                        if (i < source_chunk_count - 1 or (list_length % items_per_chunk == 0)) {
-                            // Full chunk - reuse directly (no ref needed, fillWithContents handles it)
-                            new_chunk_nodes[i] = source_nodes[i];
-                        } else {
-                            // Last chunk - may need to zero trailing bytes for new length
-                            const elems_in_last = target_length % items_per_chunk;
-                            std.debug.assert(elems_in_last != 0);
-
-                            var chunk_bytes = source_nodes[i].getRoot(self.base_view.pool).*;
-                            const keep_bytes = elems_in_last * ST.Element.fixed_size;
-                            if (keep_bytes < BYTES_PER_CHUNK) {
-                                @memset(chunk_bytes[keep_bytes..], 0);
-                            }
-                            new_chunk_nodes[i] = try self.base_view.pool.createLeaf(&chunk_bytes);
-                            newly_created_count = 1;
-                            newly_created_last_leaf = new_chunk_nodes[i];
-                        }
-                    }
-                } else {
-                    for (0..new_chunk_count) |new_chunk_idx| {
-                        var chunk_bytes: [BYTES_PER_CHUNK]u8 = [_]u8{0} ** BYTES_PER_CHUNK;
-                        const start_elem = new_chunk_idx * items_per_chunk;
-                        const end_elem = @min(start_elem + items_per_chunk, target_length);
-
-                        for (start_elem..end_elem) |elem_idx| {
-                            const src_elem_idx = index + elem_idx;
-                            const src_chunk_idx = src_elem_idx / items_per_chunk - start_chunk_index;
-                            const src_offset = src_elem_idx % items_per_chunk;
-
-                            // Repack by copying the serialized bytes for each element.
-                            // This is safe because `ST.Element` is a basic type (uint/bool) and leaf chunks store the
-                            // canonical SSZ byte encoding for those elements.
-                            const src_leaf = source_nodes[src_chunk_idx].getRoot(self.base_view.pool);
-                            const src_byte_off = src_offset * ST.Element.fixed_size;
-                            const dst_offset = (elem_idx - start_elem) * ST.Element.fixed_size;
-                            @memcpy(
-                                chunk_bytes[dst_offset..][0..ST.Element.fixed_size],
-                                src_leaf[src_byte_off..][0..ST.Element.fixed_size],
-                            );
-                        }
-
-                        new_chunk_nodes[new_chunk_idx] = try self.base_view.pool.createLeaf(&chunk_bytes);
-                        newly_created_count += 1;
-                    }
-                }
-
-                break :blk try Node.fillWithContents(self.base_view.pool, new_chunk_nodes, base_chunk_depth);
-            };
-
-            var chunk_root: ?Node.Id = chunk_root_value;
+            var chunk_root: ?Node.Id = try self.createChunkRootForSliceFrom(
+                index,
+                start_chunk_index,
+                start_offset_in_chunk,
+                list_length,
+                target_length,
+                new_chunk_count,
+                source_nodes,
+            );
             defer if (chunk_root) |id| self.base_view.pool.unref(id);
 
             var length_node: ?Node.Id = try self.base_view.pool.createLeafFromUint(@intCast(target_length));
@@ -280,6 +216,105 @@ pub fn ListBasicTreeView(comptime ST: type) type {
             length_node = null;
 
             return try Self.init(self.base_view.allocator, self.base_view.pool, new_root);
+        }
+
+        fn createChunkRootForSliceFrom(
+            self: *Self,
+            slice_start_index: usize,
+            start_chunk_index: usize,
+            start_offset_in_chunk: usize,
+            list_length: usize,
+            target_length: usize,
+            new_chunk_count: usize,
+            source_nodes: []const Node.Id,
+        ) !Node.Id {
+            if (start_offset_in_chunk == 0) {
+                return try self.createChunkRootSliceFromAligned(list_length, target_length, new_chunk_count, source_nodes);
+            }
+            return try self.createChunkRootSliceFromUnaligned(
+                slice_start_index,
+                start_chunk_index,
+                target_length,
+                new_chunk_count,
+                source_nodes,
+            );
+        }
+
+        fn createChunkRootSliceFromAligned(
+            self: *Self,
+            list_length: usize,
+            target_length: usize,
+            new_chunk_count: usize,
+            source_nodes: []const Node.Id,
+        ) !Node.Id {
+            std.debug.assert(new_chunk_count == source_nodes.len);
+
+            const new_chunk_nodes = try self.base_view.allocator.alloc(Node.Id, new_chunk_count);
+            defer self.base_view.allocator.free(new_chunk_nodes);
+
+            var newly_created_last_leaf: ?Node.Id = null;
+            errdefer if (newly_created_last_leaf) |id| self.base_view.pool.unref(id);
+
+            for (0..new_chunk_count) |i| {
+                if (i < source_nodes.len - 1 or (list_length % items_per_chunk == 0)) {
+                    new_chunk_nodes[i] = source_nodes[i];
+                    continue;
+                }
+
+                const elems_in_last = target_length % items_per_chunk;
+                std.debug.assert(elems_in_last != 0);
+
+                var chunk_bytes = source_nodes[i].getRoot(self.base_view.pool).*;
+                const keep_bytes = elems_in_last * ST.Element.fixed_size;
+                if (keep_bytes < BYTES_PER_CHUNK) {
+                    @memset(chunk_bytes[keep_bytes..], 0);
+                }
+
+                new_chunk_nodes[i] = try self.base_view.pool.createLeaf(&chunk_bytes);
+                newly_created_last_leaf = new_chunk_nodes[i];
+            }
+
+            return try Node.fillWithContents(self.base_view.pool, new_chunk_nodes, base_chunk_depth);
+        }
+
+        fn createChunkRootSliceFromUnaligned(
+            self: *Self,
+            slice_start_index: usize,
+            start_chunk_index: usize,
+            target_length: usize,
+            new_chunk_count: usize,
+            source_nodes: []const Node.Id,
+        ) !Node.Id {
+            const new_chunk_nodes = try self.base_view.allocator.alloc(Node.Id, new_chunk_count);
+            defer self.base_view.allocator.free(new_chunk_nodes);
+
+            var newly_created_count: usize = 0;
+            errdefer for (new_chunk_nodes[0..newly_created_count]) |id| self.base_view.pool.unref(id);
+
+            for (0..new_chunk_count) |new_chunk_idx| {
+                var chunk_bytes: [BYTES_PER_CHUNK]u8 = [_]u8{0} ** BYTES_PER_CHUNK;
+                const start_elem = new_chunk_idx * items_per_chunk;
+                const end_elem = @min(start_elem + items_per_chunk, target_length);
+
+                for (start_elem..end_elem) |elem_idx| {
+                    const src_elem_idx = slice_start_index + elem_idx;
+                    const src_chunk_idx = src_elem_idx / items_per_chunk - start_chunk_index;
+                    const src_offset = src_elem_idx % items_per_chunk;
+
+                    const src_leaf = source_nodes[src_chunk_idx].getRoot(self.base_view.pool);
+                    const src_byte_off = src_offset * ST.Element.fixed_size;
+                    const dst_offset = (elem_idx - start_elem) * ST.Element.fixed_size;
+                    @memcpy(
+                        chunk_bytes[dst_offset..][0..ST.Element.fixed_size],
+                        src_leaf[src_byte_off..][0..ST.Element.fixed_size],
+                    );
+                }
+
+                new_chunk_nodes[new_chunk_idx] = try self.base_view.pool.createLeaf(&chunk_bytes);
+                newly_created_count += 1;
+            }
+
+            return try Node.fillWithContents(self.base_view.pool, new_chunk_nodes, base_chunk_depth);
         }
 
         fn updateListLength(self: *Self, new_length: usize) !void {


### PR DESCRIPTION
**Motivation**
Add `sliceFrom` for basic list tree view.

**Description**
- Adds `sliceFrom` to `ListBasicTreeView` to return suffix views with correct length/root
- Extends SSZ tree view tests to cover sliceFrom behavior

Fix #135 