### PR TITLE
feat: implement `loadState` API and binding

### DIFF
--- a/bindings/napi/BeaconStateView.zig
+++ b/bindings/napi/BeaconStateView.zig
@@ -848,6 +848,30 @@ pub fn createdWithTransferCache(self: *const BeaconStateView) !js.Boolean {
 
 // pub fn BeaconStateView_loadOtherState
 
+/// Bench-only: run loadState end-to-end and tear down. Mirrors what TS's
+/// loadState measures (no CachedBeaconState wrap, no EpochCache build) so
+/// native vs TS comparisons isolate the SSZ tree-rebuild cost.
+pub fn loadOtherStateBench(
+    self: *const BeaconStateView,
+    state_bytes: js.Uint8Array,
+    seed_validators_bytes: ?js.Uint8Array,
+) !void {
+    const cached_state = try self.requireState();
+    const state_bytes_slice = try state_bytes.toSlice();
+    const seed_validators_bytes_slice: ?[]const u8 =
+        if (seed_validators_bytes) |b| try b.toSlice() else null;
+
+    var result = try st.loadState(
+        allocator,
+        cached_state.config,
+        cached_state.state,
+        state_bytes_slice,
+        seed_validators_bytes_slice,
+    );
+    allocator.free(result.modified_validators);
+    result.state.deinit();
+}
+
 pub fn serialize(self: *const BeaconStateView) !js.Uint8Array {
     const env = js.env();
     const cached_state = try self.requireState();

--- a/bindings/perf/loadState.test.ts
+++ b/bindings/perf/loadState.test.ts
@@ -1,0 +1,54 @@
+import {bench, describe} from "@chainsafe/benchmark";
+import {config} from "@lodestar/config/default";
+import * as era from "@lodestar/era";
+import {loadState as loadStateTS} from "@lodestar/state-transition";
+import {ssz} from "@lodestar/types";
+import bindings from "../src/index.js";
+import {getFirstEraFilePath} from "../test/eraFiles.ts";
+
+const reader = await era.era.EraReader.open(config, getFirstEraFilePath());
+const stateBytes = await reader.readSerializedState();
+await reader.close();
+
+bindings.pool.ensureCapacity(10_000_000);
+bindings.pubkeys.ensureCapacity(2_000_000);
+try {
+  bindings.pubkeys.load("./mainnet.pkix");
+} catch (_e) {
+  // ignore
+}
+
+const seedState = bindings.BeaconStateView.createFromBytes(stateBytes);
+const seedValidatorsBytes = seedState.serializeValidators();
+
+const tsSeedState = ssz.fulu.BeaconState.deserializeToViewDU(stateBytes);
+
+describe("loadState: native vs TS (mainnet)", () => {
+  bench({
+    fn: () => {
+      seedState.loadOtherStateBench(stateBytes);
+    },
+    id: "native (internal serialize seed)",
+  });
+
+  bench({
+    fn: () => {
+      loadStateTS(config, tsSeedState, stateBytes);
+    },
+    id: "TS (internal serialize seed)",
+  });
+
+  bench({
+    fn: () => {
+      seedState.loadOtherStateBench(stateBytes, seedValidatorsBytes);
+    },
+    id: "native (prebuilt seedValidatorsBytes)",
+  });
+
+  bench({
+    fn: () => {
+      loadStateTS(config, tsSeedState, stateBytes, seedValidatorsBytes);
+    },
+    id: "TS (prebuilt seedValidatorsBytes)",
+  });
+});

--- a/bindings/src/index.d.ts
+++ b/bindings/src/index.d.ts
@@ -214,6 +214,7 @@ declare class BeaconStateView {
   // isStateValidatorsNodesPopulated(): boolean;
 
   // loadOtherState(stateBytes: Uint8Array, seedValidatorsBytes?: Uint8Array): void;
+  loadOtherStateBench(stateBytes: Uint8Array, seedValidatorsBytes?: Uint8Array): void;
   serialize(): Uint8Array;
   serializedSize(): number;
   serializeToBytes(output: Uint8Array, offset: number): number;

--- a/src/fork_types/any_beacon_state.zig
+++ b/src/fork_types/any_beacon_state.zig
@@ -30,54 +30,54 @@ pub const AnyBeaconState = union(ForkSeq) {
     electra: *ct.electra.BeaconState.TreeView,
     fulu: *ct.fulu.BeaconState.TreeView,
 
-    pub fn fromValue(allocator: Allocator, pool: *Node.Pool, comptime fork_seq: ForkSeq, value: anytype) !AnyBeaconState {
+    pub fn fromValue(allocator: Allocator, node_pool: *Node.Pool, comptime fork_seq: ForkSeq, value: anytype) !AnyBeaconState {
         return switch (fork_seq) {
             .phase0 => .{
-                .phase0 = try ct.phase0.BeaconState.TreeView.fromValue(allocator, pool, value),
+                .phase0 = try ct.phase0.BeaconState.TreeView.fromValue(allocator, node_pool, value),
             },
             .altair => .{
-                .altair = try ct.altair.BeaconState.TreeView.fromValue(allocator, pool, value),
+                .altair = try ct.altair.BeaconState.TreeView.fromValue(allocator, node_pool, value),
             },
             .bellatrix => .{
-                .bellatrix = try ct.bellatrix.BeaconState.TreeView.fromValue(allocator, pool, value),
+                .bellatrix = try ct.bellatrix.BeaconState.TreeView.fromValue(allocator, node_pool, value),
             },
             .capella => .{
-                .capella = try ct.capella.BeaconState.TreeView.fromValue(allocator, pool, value),
+                .capella = try ct.capella.BeaconState.TreeView.fromValue(allocator, node_pool, value),
             },
             .deneb => .{
-                .deneb = try ct.deneb.BeaconState.TreeView.fromValue(allocator, pool, value),
+                .deneb = try ct.deneb.BeaconState.TreeView.fromValue(allocator, node_pool, value),
             },
             .electra => .{
-                .electra = try ct.electra.BeaconState.TreeView.fromValue(allocator, pool, value),
+                .electra = try ct.electra.BeaconState.TreeView.fromValue(allocator, node_pool, value),
             },
             .fulu => .{
-                .fulu = try ct.fulu.BeaconState.TreeView.fromValue(allocator, pool, value),
+                .fulu = try ct.fulu.BeaconState.TreeView.fromValue(allocator, node_pool, value),
             },
         };
     }
 
-    pub fn deserialize(allocator: Allocator, pool: *Node.Pool, fork_seq: ForkSeq, bytes: []const u8) !AnyBeaconState {
+    pub fn deserialize(allocator: Allocator, node_pool: *Node.Pool, fork_seq: ForkSeq, bytes: []const u8) !AnyBeaconState {
         return switch (fork_seq) {
             .phase0 => .{
-                .phase0 = try ct.phase0.BeaconState.TreeView.deserialize(allocator, pool, bytes),
+                .phase0 = try ct.phase0.BeaconState.TreeView.deserialize(allocator, node_pool, bytes),
             },
             .altair => .{
-                .altair = try ct.altair.BeaconState.TreeView.deserialize(allocator, pool, bytes),
+                .altair = try ct.altair.BeaconState.TreeView.deserialize(allocator, node_pool, bytes),
             },
             .bellatrix => .{
-                .bellatrix = try ct.bellatrix.BeaconState.TreeView.deserialize(allocator, pool, bytes),
+                .bellatrix = try ct.bellatrix.BeaconState.TreeView.deserialize(allocator, node_pool, bytes),
             },
             .capella => .{
-                .capella = try ct.capella.BeaconState.TreeView.deserialize(allocator, pool, bytes),
+                .capella = try ct.capella.BeaconState.TreeView.deserialize(allocator, node_pool, bytes),
             },
             .deneb => .{
-                .deneb = try ct.deneb.BeaconState.TreeView.deserialize(allocator, pool, bytes),
+                .deneb = try ct.deneb.BeaconState.TreeView.deserialize(allocator, node_pool, bytes),
             },
             .electra => .{
-                .electra = try ct.electra.BeaconState.TreeView.deserialize(allocator, pool, bytes),
+                .electra = try ct.electra.BeaconState.TreeView.deserialize(allocator, node_pool, bytes),
             },
             .fulu => .{
-                .fulu = try ct.fulu.BeaconState.TreeView.deserialize(allocator, pool, bytes),
+                .fulu = try ct.fulu.BeaconState.TreeView.deserialize(allocator, node_pool, bytes),
             },
         };
     }
@@ -200,6 +200,13 @@ pub const AnyBeaconState = union(ForkSeq) {
 
     pub fn forkSeq(self: *AnyBeaconState) ForkSeq {
         return std.meta.activeTag(self.*);
+    }
+
+    /// Underlying persistent merkle tree pool, regardless of fork variant.
+    pub fn pool(self: *AnyBeaconState) *Node.Pool {
+        return switch (self.*) {
+            inline else => |state| state.pool,
+        };
     }
 
     // pub fn castFromFork(comptime f: ForkSeq, )
@@ -841,13 +848,13 @@ pub const AnyBeaconState = union(ForkSeq) {
         comptime F: type,
         comptime T: type,
         allocator: Allocator,
-        pool: *Node.Pool,
+        node_pool: *Node.Pool,
         state: *F.TreeView,
     ) !*T.TreeView {
         // first ensure that the source state is committed
         try state.commit();
 
-        var upgraded = try T.TreeView.fromValue(allocator, pool, &T.default_value);
+        var upgraded = try T.TreeView.fromValue(allocator, node_pool, &T.default_value);
         errdefer upgraded.deinit();
 
         inline for (F.fields) |f| {

--- a/src/fork_types/any_beacon_state.zig
+++ b/src/fork_types/any_beacon_state.zig
@@ -30,54 +30,54 @@ pub const AnyBeaconState = union(ForkSeq) {
     electra: *ct.electra.BeaconState.TreeView,
     fulu: *ct.fulu.BeaconState.TreeView,
 
-    pub fn fromValue(allocator: Allocator, node_pool: *Node.Pool, comptime fork_seq: ForkSeq, value: anytype) !AnyBeaconState {
+    pub fn fromValue(allocator: Allocator, pool: *Node.Pool, comptime fork_seq: ForkSeq, value: anytype) !AnyBeaconState {
         return switch (fork_seq) {
             .phase0 => .{
-                .phase0 = try ct.phase0.BeaconState.TreeView.fromValue(allocator, node_pool, value),
+                .phase0 = try ct.phase0.BeaconState.TreeView.fromValue(allocator, pool, value),
             },
             .altair => .{
-                .altair = try ct.altair.BeaconState.TreeView.fromValue(allocator, node_pool, value),
+                .altair = try ct.altair.BeaconState.TreeView.fromValue(allocator, pool, value),
             },
             .bellatrix => .{
-                .bellatrix = try ct.bellatrix.BeaconState.TreeView.fromValue(allocator, node_pool, value),
+                .bellatrix = try ct.bellatrix.BeaconState.TreeView.fromValue(allocator, pool, value),
             },
             .capella => .{
-                .capella = try ct.capella.BeaconState.TreeView.fromValue(allocator, node_pool, value),
+                .capella = try ct.capella.BeaconState.TreeView.fromValue(allocator, pool, value),
             },
             .deneb => .{
-                .deneb = try ct.deneb.BeaconState.TreeView.fromValue(allocator, node_pool, value),
+                .deneb = try ct.deneb.BeaconState.TreeView.fromValue(allocator, pool, value),
             },
             .electra => .{
-                .electra = try ct.electra.BeaconState.TreeView.fromValue(allocator, node_pool, value),
+                .electra = try ct.electra.BeaconState.TreeView.fromValue(allocator, pool, value),
             },
             .fulu => .{
-                .fulu = try ct.fulu.BeaconState.TreeView.fromValue(allocator, node_pool, value),
+                .fulu = try ct.fulu.BeaconState.TreeView.fromValue(allocator, pool, value),
             },
         };
     }
 
-    pub fn deserialize(allocator: Allocator, node_pool: *Node.Pool, fork_seq: ForkSeq, bytes: []const u8) !AnyBeaconState {
+    pub fn deserialize(allocator: Allocator, pool: *Node.Pool, fork_seq: ForkSeq, bytes: []const u8) !AnyBeaconState {
         return switch (fork_seq) {
             .phase0 => .{
-                .phase0 = try ct.phase0.BeaconState.TreeView.deserialize(allocator, node_pool, bytes),
+                .phase0 = try ct.phase0.BeaconState.TreeView.deserialize(allocator, pool, bytes),
             },
             .altair => .{
-                .altair = try ct.altair.BeaconState.TreeView.deserialize(allocator, node_pool, bytes),
+                .altair = try ct.altair.BeaconState.TreeView.deserialize(allocator, pool, bytes),
             },
             .bellatrix => .{
-                .bellatrix = try ct.bellatrix.BeaconState.TreeView.deserialize(allocator, node_pool, bytes),
+                .bellatrix = try ct.bellatrix.BeaconState.TreeView.deserialize(allocator, pool, bytes),
             },
             .capella => .{
-                .capella = try ct.capella.BeaconState.TreeView.deserialize(allocator, node_pool, bytes),
+                .capella = try ct.capella.BeaconState.TreeView.deserialize(allocator, pool, bytes),
             },
             .deneb => .{
-                .deneb = try ct.deneb.BeaconState.TreeView.deserialize(allocator, node_pool, bytes),
+                .deneb = try ct.deneb.BeaconState.TreeView.deserialize(allocator, pool, bytes),
             },
             .electra => .{
-                .electra = try ct.electra.BeaconState.TreeView.deserialize(allocator, node_pool, bytes),
+                .electra = try ct.electra.BeaconState.TreeView.deserialize(allocator, pool, bytes),
             },
             .fulu => .{
-                .fulu = try ct.fulu.BeaconState.TreeView.deserialize(allocator, node_pool, bytes),
+                .fulu = try ct.fulu.BeaconState.TreeView.deserialize(allocator, pool, bytes),
             },
         };
     }
@@ -203,7 +203,7 @@ pub const AnyBeaconState = union(ForkSeq) {
     }
 
     /// Underlying persistent merkle tree pool, regardless of fork variant.
-    pub fn pool(self: *AnyBeaconState) *Node.Pool {
+    pub fn nodePool(self: *AnyBeaconState) *Node.Pool {
         return switch (self.*) {
             inline else => |state| state.pool,
         };
@@ -848,13 +848,13 @@ pub const AnyBeaconState = union(ForkSeq) {
         comptime F: type,
         comptime T: type,
         allocator: Allocator,
-        node_pool: *Node.Pool,
+        pool: *Node.Pool,
         state: *F.TreeView,
     ) !*T.TreeView {
         // first ensure that the source state is committed
         try state.commit();
 
-        var upgraded = try T.TreeView.fromValue(allocator, node_pool, &T.default_value);
+        var upgraded = try T.TreeView.fromValue(allocator, pool, &T.default_value);
         errdefer upgraded.deinit();
 
         inline for (F.fields) |f| {

--- a/src/state_transition/load_state.zig
+++ b/src/state_transition/load_state.zig
@@ -195,6 +195,9 @@ fn loadValidators(
     seed_state_validators_bytes: ?[]const u8,
 ) ![]ValidatorIndex {
     if (new_validators_bytes.len % ssz_bytes.VALIDATOR_BYTES_SIZE != 0) return error.InvalidSize;
+    if (seed_state_validators_bytes) |bytes| {
+        if (bytes.len % ssz_bytes.VALIDATOR_BYTES_SIZE != 0) return error.InvalidSize;
+    }
 
     const seed_validators = try types.phase0.Validators.TreeView.init(allocator, pool, seed_validators_node);
     defer seed_validators.deinit();
@@ -917,6 +920,30 @@ test "loadValidators rejects non-multiple-of-VALIDATOR_BYTES_SIZE" {
     try std.testing.expectError(
         error.InvalidSize,
         loadValidators(allocator, StateST, migrated_view, &pool, seed_validators_node, bad_bytes[0..], null),
+    );
+}
+
+test "loadValidators rejects malformed seed_state_validators_bytes" {
+    const allocator = std.testing.allocator;
+    var pool = try Node.Pool.init(allocator, 1024);
+    defer pool.deinit();
+
+    const gen = @import("test_utils/generate_state.zig");
+    const chain_config = gen.getConfig(@import("config").minimal.chain_config, .electra, 0);
+    const state_ptr = try gen.generateElectraState(allocator, &pool, chain_config, 8);
+    defer {
+        state_ptr.deinit();
+        allocator.destroy(state_ptr);
+    }
+
+    const StateST = types.electra.BeaconState;
+    const migrated_view = state_ptr.castToFork(.electra).inner;
+    const seed_validators_node = try validatorsNodeId(state_ptr);
+    const good_new_bytes = [_]u8{0} ** (ssz_bytes.VALIDATOR_BYTES_SIZE * 2);
+    const bad_seed_bytes = [_]u8{0} ** (ssz_bytes.VALIDATOR_BYTES_SIZE + 1);
+    try std.testing.expectError(
+        error.InvalidSize,
+        loadValidators(allocator, StateST, migrated_view, &pool, seed_validators_node, good_new_bytes[0..], bad_seed_bytes[0..]),
     );
 }
 

--- a/src/state_transition/load_state.zig
+++ b/src/state_transition/load_state.zig
@@ -43,7 +43,7 @@ pub fn loadState(
 ) !MigrateStateOutput {
     const fork = try ssz_bytes.getForkFromStateBytes(config, state_bytes);
     const seed_fork = config.forkSeq(try seed_state.slot());
-    const pool = seed_state.pool();
+    const pool = seed_state.nodePool();
 
     return switch (fork) {
         inline else => |f| try loadStateForFork(allocator, pool, f, seed_fork, seed_state, ForkTypes(f).BeaconState, state_bytes, seed_validators_bytes),
@@ -432,12 +432,12 @@ fn inactivityScoresNodeId(state: *AnyBeaconState) !Node.Id {
 
 fn validatorsViewOwned(allocator: Allocator, state: *AnyBeaconState) !*types.phase0.Validators.TreeView {
     const root = try validatorsNodeId(state);
-    return try types.phase0.Validators.TreeView.init(allocator, state.pool(), root);
+    return try types.phase0.Validators.TreeView.init(allocator, state.nodePool(), root);
 }
 
 fn inactivityScoresViewOwned(allocator: Allocator, state: *AnyBeaconState) !*types.altair.InactivityScores.TreeView {
     const root = try inactivityScoresNodeId(state);
-    return try types.altair.InactivityScores.TreeView.init(allocator, state.pool(), root);
+    return try types.altair.InactivityScores.TreeView.init(allocator, state.nodePool(), root);
 }
 
 fn loadValidatorWithSeedReuse(

--- a/src/state_transition/load_state.zig
+++ b/src/state_transition/load_state.zig
@@ -632,6 +632,11 @@ test "loadValidatorWithSeedReuse: reuse vs rebuild" {
     try std.testing.expect(
         try seed_validator.root.getNodeAtDepth(seed_validator.pool, types.phase0.Validator.chunk_depth, withdrawal_i) != try new_validator.root.getNodeAtDepth(new_validator.pool, types.phase0.Validator.chunk_depth, withdrawal_i),
     );
+
+    const fresh_root = try types.phase0.Validator.tree.deserializeFromBytes(&pool, new_validator_bytes[0..]);
+    var fresh_validator = try types.phase0.Validator.TreeView.init(allocator, &pool, fresh_root);
+    defer fresh_validator.deinit();
+    try std.testing.expectEqualSlices(u8, try fresh_validator.hashTreeRoot(), try new_validator.hashTreeRoot());
 }
 
 test "loadState scenarios" {
@@ -806,6 +811,10 @@ test "loadState scenarios" {
             _ = try mv.serializeIntoBytes(&mv_bytes);
             try std.testing.expectEqualSlices(u8, mutated_bytes[base .. base + ssz_bytes.VALIDATOR_BYTES_SIZE], mv_bytes[0..]);
         }
+
+        var fresh_state = try AnyBeaconState.deserialize(allocator, &pool, .electra, mutated_bytes);
+        defer fresh_state.deinit();
+        try std.testing.expectEqualSlices(u8, try fresh_state.hashTreeRoot(), try out.state.hashTreeRoot());
     }
 }
 

--- a/src/state_transition/load_state.zig
+++ b/src/state_transition/load_state.zig
@@ -202,16 +202,16 @@ fn loadValidators(
     new_validators_bytes: []const u8,
     seed_state_validators_bytes: ?[]const u8,
 ) ![]ValidatorIndex {
-    if (new_validators_bytes.len % ssz_bytes.VALIDATOR_BYTES_SIZE != 0) return error.InvalidSize;
+    if (new_validators_bytes.len % types.phase0.Validator.fixed_size != 0) return error.InvalidSize;
     if (seed_state_validators_bytes) |bytes| {
-        if (bytes.len % ssz_bytes.VALIDATOR_BYTES_SIZE != 0) return error.InvalidSize;
+        if (bytes.len % types.phase0.Validator.fixed_size != 0) return error.InvalidSize;
     }
 
     const seed_validators = try types.phase0.Validators.TreeView.init(allocator, pool, seed_validators_node);
     defer seed_validators.deinit();
 
     const seed_count = try seed_validators.length();
-    const new_count = new_validators_bytes.len / ssz_bytes.VALIDATOR_BYTES_SIZE;
+    const new_count = new_validators_bytes.len / types.phase0.Validator.fixed_size;
     const min_count = @min(seed_count, new_count);
 
     var migrated_validators = try seed_validators.clone(.{ .transfer_cache = false });
@@ -235,8 +235,8 @@ fn loadValidators(
     var modified_validators: std.ArrayList(ValidatorIndex) = .empty;
     errdefer modified_validators.deinit(allocator);
 
-    const old_validators_slice = seed_bytes[0 .. min_count * ssz_bytes.VALIDATOR_BYTES_SIZE];
-    const new_validators_slice = new_validators_bytes[0 .. min_count * ssz_bytes.VALIDATOR_BYTES_SIZE];
+    const old_validators_slice = seed_bytes[0 .. min_count * types.phase0.Validator.fixed_size];
+    const new_validators_slice = new_validators_bytes[0 .. min_count * types.phase0.Validator.fixed_size];
     try findModifiedValidators(allocator, old_validators_slice, new_validators_slice, &modified_validators, 0);
 
     try applyModifiedValidators(
@@ -361,9 +361,9 @@ fn applyModifiedValidators(
 ) !void {
     for (modified_validators) |validator_index| {
         const i: usize = @intCast(validator_index);
-        const start = i * ssz_bytes.VALIDATOR_BYTES_SIZE;
-        const new_bytes = new_validators_bytes[start .. start + ssz_bytes.VALIDATOR_BYTES_SIZE];
-        const seed_val_bytes = seed_bytes[start .. start + ssz_bytes.VALIDATOR_BYTES_SIZE];
+        const start = i * types.phase0.Validator.fixed_size;
+        const new_bytes = new_validators_bytes[start .. start + types.phase0.Validator.fixed_size];
+        const seed_val_bytes = seed_bytes[start .. start + types.phase0.Validator.fixed_size];
 
         const seed_validator = try seed_validators.get(i);
         // seed_validator is borrowed from seed_validators; do not deinit.
@@ -392,8 +392,8 @@ fn appendNewValidators(
 ) !void {
     var idx: usize = start_index;
     while (idx < end_index) : (idx += 1) {
-        const start = idx * ssz_bytes.VALIDATOR_BYTES_SIZE;
-        const new_bytes = new_validators_bytes[start .. start + ssz_bytes.VALIDATOR_BYTES_SIZE];
+        const start = idx * types.phase0.Validator.fixed_size;
+        const new_bytes = new_validators_bytes[start .. start + types.phase0.Validator.fixed_size];
 
         const pool = migrated_validators.chunks.state.pool;
         var v: ?*types.phase0.Validator.TreeView = blk: {
@@ -509,7 +509,7 @@ fn loadValidatorWithSeedReuse(
 }
 
 /// Append the absolute indices (offset by `validator_offset`) of validators that
-/// differ between the two equal-length, VALIDATOR_BYTES_SIZE-aligned slices.
+/// differ between the two equal-length, validator-record-aligned slices.
 fn findModifiedValidators(
     allocator: Allocator,
     validators_bytes: []const u8,
@@ -518,18 +518,18 @@ fn findModifiedValidators(
     validator_offset: usize,
 ) !void {
     std.debug.assert(validators_bytes.len == validators_bytes2.len);
-    std.debug.assert(validators_bytes.len % ssz_bytes.VALIDATOR_BYTES_SIZE == 0);
+    std.debug.assert(validators_bytes.len % types.phase0.Validator.fixed_size == 0);
 
     if (std.mem.eql(u8, validators_bytes, validators_bytes2)) return;
 
-    if (validators_bytes.len == ssz_bytes.VALIDATOR_BYTES_SIZE) {
+    if (validators_bytes.len == types.phase0.Validator.fixed_size) {
         try modified_validators.append(allocator, @intCast(validator_offset));
         return;
     }
 
-    const num_validator = validators_bytes.len / ssz_bytes.VALIDATOR_BYTES_SIZE;
+    const num_validator = validators_bytes.len / types.phase0.Validator.fixed_size;
     const half_validator = num_validator / 2;
-    const split = half_validator * ssz_bytes.VALIDATOR_BYTES_SIZE;
+    const split = half_validator * types.phase0.Validator.fixed_size;
 
     try findModifiedValidators(
         allocator,
@@ -615,7 +615,7 @@ test "loadValidatorWithSeedReuse: reuse vs rebuild" {
     var seed_validator = try seed_validators.get(target_index);
     // seed_validator is borrowed from seed_validators; do not deinit.
 
-    var seed_validator_bytes: [ssz_bytes.VALIDATOR_BYTES_SIZE]u8 = undefined;
+    var seed_validator_bytes: [types.phase0.Validator.fixed_size]u8 = undefined;
     _ = try seed_validator.serializeIntoBytes(&seed_validator_bytes);
 
     var new_validator_bytes = seed_validator_bytes;
@@ -717,7 +717,7 @@ test "loadState scenarios" {
                     const ranges = try types.electra.BeaconState.readFieldRanges(seed_bytes);
                     const validators_range = ranges[validators_field_index];
                     const out = try allocator.dupe(u8, seed_bytes);
-                    const base = validators_range[0] + m.index * ssz_bytes.VALIDATOR_BYTES_SIZE;
+                    const base = validators_range[0] + m.index * types.phase0.Validator.fixed_size;
                     @memset(out[base + 48 .. base + 80], m.fill);
                     break :blk out;
                 },
@@ -726,7 +726,7 @@ test "loadState scenarios" {
                     const ranges = try types.electra.BeaconState.readFieldRanges(seed_bytes);
                     const validators_range = ranges[validators_field_index];
                     const out = try allocator.dupe(u8, seed_bytes);
-                    const base = validators_range[0] + m.index * ssz_bytes.VALIDATOR_BYTES_SIZE;
+                    const base = validators_range[0] + m.index * types.phase0.Validator.fixed_size;
                     @memset(out[base + 0 .. base + 48], m.pub_fill);
                     @memset(out[base + 48 .. base + 80], m.wd_fill);
                     break :blk out;
@@ -816,12 +816,12 @@ test "loadState scenarios" {
             const validators_field_index = comptime types.electra.BeaconState.getFieldIndex("validators");
             const ranges = try types.electra.BeaconState.readFieldRanges(mutated_bytes);
             const validators_range = ranges[validators_field_index];
-            const base = validators_range[0] + exp.index * ssz_bytes.VALIDATOR_BYTES_SIZE;
+            const base = validators_range[0] + exp.index * types.phase0.Validator.fixed_size;
             var mv = try migrated_validators.get(exp.index);
             // mv is borrowed from migrated_validators; do not deinit.
-            var mv_bytes: [ssz_bytes.VALIDATOR_BYTES_SIZE]u8 = undefined;
+            var mv_bytes: [types.phase0.Validator.fixed_size]u8 = undefined;
             _ = try mv.serializeIntoBytes(&mv_bytes);
-            try std.testing.expectEqualSlices(u8, mutated_bytes[base .. base + ssz_bytes.VALIDATOR_BYTES_SIZE], mv_bytes[0..]);
+            try std.testing.expectEqualSlices(u8, mutated_bytes[base .. base + types.phase0.Validator.fixed_size], mv_bytes[0..]);
         }
 
         var fresh_state = try AnyBeaconState.deserialize(allocator, &pool, .electra, mutated_bytes);
@@ -857,22 +857,22 @@ test "diff helpers cases" {
         defer got.deinit(allocator);
 
         if (case.kind == .validators) {
-            const total = case.count * ssz_bytes.VALIDATOR_BYTES_SIZE;
+            const total = case.count * types.phase0.Validator.fixed_size;
             const old_bytes = try allocator.alloc(u8, total);
             defer allocator.free(old_bytes);
             const new_bytes = try allocator.alloc(u8, total);
             defer allocator.free(new_bytes);
 
             for (0..case.count) |i| {
-                const start = i * ssz_bytes.VALIDATOR_BYTES_SIZE;
-                for (0..ssz_bytes.VALIDATOR_BYTES_SIZE) |j| {
+                const start = i * types.phase0.Validator.fixed_size;
+                for (0..types.phase0.Validator.fixed_size) |j| {
                     old_bytes[start + j] = @intCast((i + 31 * j) & 0xff);
                 }
             }
             @memcpy(new_bytes, old_bytes);
 
             for (case.modified) |idx| {
-                const start = idx * ssz_bytes.VALIDATOR_BYTES_SIZE;
+                const start = idx * types.phase0.Validator.fixed_size;
                 new_bytes[start] ^= 0x5a;
             }
 
@@ -922,9 +922,9 @@ test "loadValidators/loadInactivityScores: rejection scenarios" {
     const migrated_view = state_ptr.castToFork(.electra).inner;
 
     {
-        // new validators bytes length is not a multiple of VALIDATOR_BYTES_SIZE
+        // new validators bytes length is not a multiple of the validator record size
         const seed_validators_node = try validatorsNodeId(state_ptr);
-        const bad_bytes = [_]u8{0} ** (ssz_bytes.VALIDATOR_BYTES_SIZE + 1);
+        const bad_bytes = [_]u8{0} ** (types.phase0.Validator.fixed_size + 1);
         try std.testing.expectError(
             error.InvalidSize,
             loadValidators(allocator, StateST, migrated_view, &pool, seed_validators_node, bad_bytes[0..], null),
@@ -932,10 +932,10 @@ test "loadValidators/loadInactivityScores: rejection scenarios" {
     }
 
     {
-        // seed_state_validators_bytes length is not a multiple of VALIDATOR_BYTES_SIZE
+        // seed_state_validators_bytes length is not a multiple of the validator record size
         const seed_validators_node = try validatorsNodeId(state_ptr);
-        const good_new_bytes = [_]u8{0} ** (ssz_bytes.VALIDATOR_BYTES_SIZE * 2);
-        const bad_seed_bytes = [_]u8{0} ** (ssz_bytes.VALIDATOR_BYTES_SIZE + 1);
+        const good_new_bytes = [_]u8{0} ** (types.phase0.Validator.fixed_size * 2);
+        const bad_seed_bytes = [_]u8{0} ** (types.phase0.Validator.fixed_size + 1);
         try std.testing.expectError(
             error.InvalidSize,
             loadValidators(allocator, StateST, migrated_view, &pool, seed_validators_node, good_new_bytes[0..], bad_seed_bytes[0..]),

--- a/src/state_transition/load_state.zig
+++ b/src/state_transition/load_state.zig
@@ -509,7 +509,7 @@ fn loadValidatorWithSeedReuse(
 }
 
 /// Append the absolute indices (offset by `validator_offset`) of validators that
-/// differ between the two equal-length, validator-record-aligned slices.
+/// differ between the two equal-length, validator-fixed-size-aligned slices.
 fn findModifiedValidators(
     allocator: Allocator,
     validators_bytes: []const u8,
@@ -922,7 +922,7 @@ test "loadValidators/loadInactivityScores: rejection scenarios" {
     const migrated_view = state_ptr.castToFork(.electra).inner;
 
     {
-        // new validators bytes length is not a multiple of the validator record size
+        // new validators bytes length is not a multiple of the validator fixed size
         const seed_validators_node = try validatorsNodeId(state_ptr);
         const bad_bytes = [_]u8{0} ** (types.phase0.Validator.fixed_size + 1);
         try std.testing.expectError(
@@ -932,7 +932,7 @@ test "loadValidators/loadInactivityScores: rejection scenarios" {
     }
 
     {
-        // seed_state_validators_bytes length is not a multiple of the validator record size
+        // seed_state_validators_bytes length is not a multiple of the validator fixed size
         const seed_validators_node = try validatorsNodeId(state_ptr);
         const good_new_bytes = [_]u8{0} ** (types.phase0.Validator.fixed_size * 2);
         const bad_seed_bytes = [_]u8{0} ** (types.phase0.Validator.fixed_size + 1);

--- a/src/state_transition/load_state.zig
+++ b/src/state_transition/load_state.zig
@@ -155,6 +155,8 @@ fn loadInactivityScores(
     seed_scores_node: Node.Id,
     inactivity_scores_bytes: []const u8,
 ) !void {
+    if (inactivity_scores_bytes.len % INACTIVITY_SCORE_SIZE != 0) return error.InvalidSize;
+
     const seed_scores = try types.altair.InactivityScores.TreeView.init(allocator, pool, seed_scores_node);
     defer seed_scores.deinit();
 
@@ -192,6 +194,8 @@ fn loadValidators(
     new_validators_bytes: []const u8,
     seed_state_validators_bytes: ?[]const u8,
 ) ![]ValidatorIndex {
+    if (new_validators_bytes.len % ssz_bytes.VALIDATOR_BYTES_SIZE != 0) return error.InvalidSize;
+
     const seed_validators = try types.phase0.Validators.TreeView.init(allocator, pool, seed_validators_node);
     defer seed_validators.deinit();
 
@@ -891,4 +895,50 @@ test "diff helpers cases" {
             try std.testing.expectEqual(@as(ValidatorIndex, @intCast(e)), g);
         }
     }
+}
+
+test "loadValidators rejects non-multiple-of-VALIDATOR_BYTES_SIZE" {
+    const allocator = std.testing.allocator;
+    var pool = try Node.Pool.init(allocator, 1024);
+    defer pool.deinit();
+
+    const gen = @import("test_utils/generate_state.zig");
+    const chain_config = gen.getConfig(@import("config").minimal.chain_config, .electra, 0);
+    const state_ptr = try gen.generateElectraState(allocator, &pool, chain_config, 8);
+    defer {
+        state_ptr.deinit();
+        allocator.destroy(state_ptr);
+    }
+
+    const StateST = types.electra.BeaconState;
+    const migrated_view = state_ptr.castToFork(.electra).inner;
+    const seed_validators_node = try validatorsNodeId(state_ptr);
+    const bad_bytes = [_]u8{0} ** (ssz_bytes.VALIDATOR_BYTES_SIZE + 1);
+    try std.testing.expectError(
+        error.InvalidSize,
+        loadValidators(allocator, StateST, migrated_view, &pool, seed_validators_node, bad_bytes[0..], null),
+    );
+}
+
+test "loadInactivityScores rejects non-multiple-of-INACTIVITY_SCORE_SIZE" {
+    const allocator = std.testing.allocator;
+    var pool = try Node.Pool.init(allocator, 1024);
+    defer pool.deinit();
+
+    const gen = @import("test_utils/generate_state.zig");
+    const chain_config = gen.getConfig(@import("config").minimal.chain_config, .electra, 0);
+    const state_ptr = try gen.generateElectraState(allocator, &pool, chain_config, 8);
+    defer {
+        state_ptr.deinit();
+        allocator.destroy(state_ptr);
+    }
+
+    const StateST = types.electra.BeaconState;
+    const migrated_view = state_ptr.castToFork(.electra).inner;
+    const seed_scores_node = try inactivityScoresNodeId(state_ptr);
+    const bad_bytes = [_]u8{0} ** (INACTIVITY_SCORE_SIZE + 1);
+    try std.testing.expectError(
+        error.InvalidSize,
+        loadInactivityScores(allocator, StateST, migrated_view, &pool, seed_scores_node, bad_bytes[0..]),
+    );
 }

--- a/src/state_transition/load_state.zig
+++ b/src/state_transition/load_state.zig
@@ -7,6 +7,7 @@ const Gindex = @import("persistent_merkle_tree").Gindex;
 const ForkSeq = @import("config").ForkSeq;
 const BeaconConfig = @import("config").BeaconConfig;
 const AnyBeaconState = @import("fork_types").AnyBeaconState;
+const ForkTypes = @import("fork_types").ForkTypes;
 
 const ssz_bytes = @import("ssz_bytes.zig");
 const ssz_container = @import("ssz_container.zig");
@@ -47,13 +48,7 @@ pub fn loadState(
     };
 
     return switch (fork) {
-        .phase0 => try loadStateForFork(allocator, pool, .phase0, seed_fork, seed_state, types.phase0.BeaconState, state_bytes, seed_validators_bytes),
-        .altair => try loadStateForFork(allocator, pool, .altair, seed_fork, seed_state, types.altair.BeaconState, state_bytes, seed_validators_bytes),
-        .bellatrix => try loadStateForFork(allocator, pool, .bellatrix, seed_fork, seed_state, types.bellatrix.BeaconState, state_bytes, seed_validators_bytes),
-        .capella => try loadStateForFork(allocator, pool, .capella, seed_fork, seed_state, types.capella.BeaconState, state_bytes, seed_validators_bytes),
-        .deneb => try loadStateForFork(allocator, pool, .deneb, seed_fork, seed_state, types.deneb.BeaconState, state_bytes, seed_validators_bytes),
-        .electra => try loadStateForFork(allocator, pool, .electra, seed_fork, seed_state, types.electra.BeaconState, state_bytes, seed_validators_bytes),
-        .fulu => try loadStateForFork(allocator, pool, .fulu, seed_fork, seed_state, types.fulu.BeaconState, state_bytes, seed_validators_bytes),
+        inline else => |f| try loadStateForFork(allocator, pool, f, seed_fork, seed_state, ForkTypes(f).BeaconState, state_bytes, seed_validators_bytes),
     };
 }
 
@@ -150,15 +145,7 @@ fn loadStateForFork(
 
     try migrated_view.commit();
 
-    const migrated_state: AnyBeaconState = switch (out_fork) {
-        .phase0 => .{ .phase0 = migrated_view },
-        .altair => .{ .altair = migrated_view },
-        .bellatrix => .{ .bellatrix = migrated_view },
-        .capella => .{ .capella = migrated_view },
-        .deneb => .{ .deneb = migrated_view },
-        .electra => .{ .electra = migrated_view },
-        .fulu => .{ .fulu = migrated_view },
-    };
+    const migrated_state = @unionInit(AnyBeaconState, @tagName(out_fork), migrated_view);
     return .{ .state = migrated_state, .modified_validators = modified_validators };
 }
 

--- a/src/state_transition/load_state.zig
+++ b/src/state_transition/load_state.zig
@@ -1,0 +1,898 @@
+const std = @import("std");
+const Allocator = std.mem.Allocator;
+
+const types = @import("consensus_types");
+const Node = @import("persistent_merkle_tree").Node;
+const Gindex = @import("persistent_merkle_tree").Gindex;
+const ForkSeq = @import("config").ForkSeq;
+const BeaconConfig = @import("config").BeaconConfig;
+const AnyBeaconState = @import("fork_types").AnyBeaconState;
+
+const ssz_bytes = @import("ssz_bytes.zig");
+const ssz_container = @import("ssz_container.zig");
+
+const ValidatorIndex = types.primitive.ValidatorIndex.Type;
+
+/// Inactivity score is `uint64` (8 bytes).
+const INACTIVITY_SCORE_SIZE: usize = 8;
+
+// BeaconState field indices are stable across forks.
+const BEACON_STATE_VALIDATORS_FIELD_INDEX: usize = types.phase0.BeaconState.getFieldIndex("validators");
+const BEACON_STATE_INACTIVITY_SCORES_FIELD_INDEX: usize = types.altair.BeaconState.getFieldIndex("inactivity_scores");
+
+pub const MigrateStateOutput = struct {
+    state: AnyBeaconState,
+    modified_validators: []ValidatorIndex,
+};
+
+/// Load BeaconState from SSZ bytes using a seed state to reuse unchanged subtrees.
+///
+/// This avoids full deserialization for large fields (validators/inactivity_scores)
+/// by diffing bytes and reusing the seed state's TreeView nodes.
+///
+/// Returns the migrated state and indices of modified validators.
+///
+/// Errors are propagated from SSZ parsing and tree operations when bytes are invalid.
+pub fn loadState(
+    allocator: Allocator,
+    config: *const BeaconConfig,
+    seed_state: *AnyBeaconState,
+    state_bytes: []const u8,
+    seed_validators_bytes: ?[]const u8,
+) !MigrateStateOutput {
+    const fork = try ssz_bytes.getForkFromStateBytes(config, state_bytes);
+    const seed_fork = config.forkSeq(try seed_state.slot());
+    const pool = switch (seed_state.*) {
+        inline else => |s| s.pool,
+    };
+
+    return switch (fork) {
+        .phase0 => try loadStateForFork(allocator, pool, .phase0, seed_fork, seed_state, types.phase0.BeaconState, state_bytes, seed_validators_bytes),
+        .altair => try loadStateForFork(allocator, pool, .altair, seed_fork, seed_state, types.altair.BeaconState, state_bytes, seed_validators_bytes),
+        .bellatrix => try loadStateForFork(allocator, pool, .bellatrix, seed_fork, seed_state, types.bellatrix.BeaconState, state_bytes, seed_validators_bytes),
+        .capella => try loadStateForFork(allocator, pool, .capella, seed_fork, seed_state, types.capella.BeaconState, state_bytes, seed_validators_bytes),
+        .deneb => try loadStateForFork(allocator, pool, .deneb, seed_fork, seed_state, types.deneb.BeaconState, state_bytes, seed_validators_bytes),
+        .electra => try loadStateForFork(allocator, pool, .electra, seed_fork, seed_state, types.electra.BeaconState, state_bytes, seed_validators_bytes),
+        .fulu => try loadStateForFork(allocator, pool, .fulu, seed_fork, seed_state, types.fulu.BeaconState, state_bytes, seed_validators_bytes),
+    };
+}
+
+fn deserializeBeaconStateTreeViewWithSeedOverrides(
+    allocator: Allocator,
+    pool: *Node.Pool,
+    comptime out_fork: ForkSeq,
+    seed_fork: ForkSeq,
+    seed_state: *AnyBeaconState,
+    comptime StateST: type,
+    state_bytes: []const u8,
+    ranges: *const [StateST.fields.len][2]usize,
+    seed_validators_node: Node.Id,
+) !*StateST.TreeView {
+    if (comptime out_fork.gte(.altair)) {
+        const scores_field_index = comptime StateST.getFieldIndex("inactivity_scores");
+        const scores_range = ranges[scores_field_index];
+        const inactivity_scores_bytes = state_bytes[scores_range[0]..scores_range[1]];
+        const ScoresType = comptime StateST.getFieldType("inactivity_scores");
+
+        // If the seed fork is pre-altair, there are no scores to reuse, so we fully
+        // deserialize inactivity_scores here (diff optimization only applies when seed_fork >= altair).
+        const scores_node = if (seed_fork.gte(.altair)) blk: {
+            break :blk try inactivityScoresNodeId(seed_state);
+        } else blk: {
+            const node_id = try ScoresType.tree.deserializeFromBytes(pool, inactivity_scores_bytes);
+            errdefer pool.unref(node_id);
+            break :blk node_id;
+        };
+
+        return try ssz_container.deserializeContainerOverrideFieldsWithRanges(
+            allocator,
+            pool,
+            StateST,
+            state_bytes,
+            ranges,
+            .{ .validators = seed_validators_node, .inactivity_scores = scores_node },
+        );
+    }
+
+    return try ssz_container.deserializeContainerOverrideFieldsWithRanges(
+        allocator,
+        pool,
+        StateST,
+        state_bytes,
+        ranges,
+        .{ .validators = seed_validators_node },
+    );
+}
+
+fn loadStateForFork(
+    allocator: Allocator,
+    pool: *Node.Pool,
+    comptime out_fork: ForkSeq,
+    seed_fork: ForkSeq,
+    seed_state: *AnyBeaconState,
+    comptime StateST: type,
+    state_bytes: []const u8,
+    seed_validators_bytes: ?[]const u8,
+) !MigrateStateOutput {
+    const ranges = try StateST.readFieldRanges(state_bytes);
+
+    const validators_field_index = comptime StateST.getFieldIndex("validators");
+
+    const seed_validators_node = try validatorsNodeId(seed_state);
+
+    const migrated_view = try deserializeBeaconStateTreeViewWithSeedOverrides(
+        allocator,
+        pool,
+        out_fork,
+        seed_fork,
+        seed_state,
+        StateST,
+        state_bytes,
+        &ranges,
+        seed_validators_node,
+    );
+    errdefer migrated_view.deinit();
+
+    const validators_range = ranges[validators_field_index];
+    const new_validators_bytes = state_bytes[validators_range[0]..validators_range[1]];
+    const modified_validators = try loadValidators(allocator, StateST, migrated_view, pool, seed_validators_node, new_validators_bytes, seed_validators_bytes);
+    errdefer allocator.free(modified_validators);
+
+    if (comptime out_fork.gte(.altair)) {
+        if (seed_fork.gte(.altair)) {
+            const scores_field_index = comptime StateST.getFieldIndex("inactivity_scores");
+            const scores_range = ranges[scores_field_index];
+            const inactivity_scores_bytes = state_bytes[scores_range[0]..scores_range[1]];
+            const seed_scores_node = try inactivityScoresNodeId(seed_state);
+            try loadInactivityScores(allocator, StateST, migrated_view, pool, seed_scores_node, inactivity_scores_bytes);
+        }
+    }
+
+    try migrated_view.commit();
+
+    const migrated_state: AnyBeaconState = switch (out_fork) {
+        .phase0 => .{ .phase0 = migrated_view },
+        .altair => .{ .altair = migrated_view },
+        .bellatrix => .{ .bellatrix = migrated_view },
+        .capella => .{ .capella = migrated_view },
+        .deneb => .{ .deneb = migrated_view },
+        .electra => .{ .electra = migrated_view },
+        .fulu => .{ .fulu = migrated_view },
+    };
+    return .{ .state = migrated_state, .modified_validators = modified_validators };
+}
+
+fn loadInactivityScores(
+    allocator: Allocator,
+    comptime StateST: type,
+    migrated_view: *StateST.TreeView,
+    pool: *Node.Pool,
+    seed_scores_node: Node.Id,
+    inactivity_scores_bytes: []const u8,
+) !void {
+    const seed_scores = try types.altair.InactivityScores.TreeView.init(allocator, pool, seed_scores_node);
+    defer seed_scores.deinit();
+
+    var migrated_scores = try seed_scores.clone(.{});
+    errdefer migrated_scores.deinit();
+
+    const diff_ctx = try buildScoresDiffContext(allocator, migrated_scores, inactivity_scores_bytes);
+    defer allocator.free(diff_ctx.old_bytes);
+
+    var modified_validators: std.ArrayList(ValidatorIndex) = .empty;
+    defer modified_validators.deinit(allocator);
+
+    const old_scores_slice = if (diff_ctx.has_more_validators)
+        diff_ctx.old_bytes
+    else
+        diff_ctx.old_bytes[0 .. diff_ctx.min_validator_count * INACTIVITY_SCORE_SIZE];
+    const new_scores_slice = if (diff_ctx.has_more_validators)
+        inactivity_scores_bytes[0 .. diff_ctx.min_validator_count * INACTIVITY_SCORE_SIZE]
+    else
+        inactivity_scores_bytes;
+
+    try findModifiedInactivityScores(allocator, old_scores_slice, new_scores_slice, &modified_validators, 0);
+    try applyScoreDiffs(migrated_scores, inactivity_scores_bytes, modified_validators.items);
+    migrated_scores = try syncScoresLength(allocator, migrated_scores, inactivity_scores_bytes, diff_ctx.old_validator_count, diff_ctx.new_validator_count);
+
+    try migrated_view.set("inactivity_scores", migrated_scores);
+}
+
+fn loadValidators(
+    allocator: Allocator,
+    comptime StateST: type,
+    migrated_view: *StateST.TreeView,
+    pool: *Node.Pool,
+    seed_validators_node: Node.Id,
+    new_validators_bytes: []const u8,
+    seed_state_validators_bytes: ?[]const u8,
+) ![]ValidatorIndex {
+    const seed_validators = try types.phase0.Validators.TreeView.init(allocator, pool, seed_validators_node);
+    defer seed_validators.deinit();
+
+    const seed_count = try seed_validators.length();
+    const new_count = new_validators_bytes.len / ssz_bytes.VALIDATOR_BYTES_SIZE;
+    const min_count = @min(seed_count, new_count);
+
+    var migrated_validators = try seed_validators.clone(.{});
+    errdefer migrated_validators.deinit();
+
+    const seed_bytes = try getSeedValidatorsBytes(allocator, seed_validators, seed_state_validators_bytes);
+    defer if (seed_bytes.owned) allocator.free(seed_bytes.bytes);
+
+    var modified_validators: std.ArrayList(ValidatorIndex) = .empty;
+    errdefer modified_validators.deinit(allocator);
+
+    const old_validators_slice = seed_bytes.bytes[0 .. min_count * ssz_bytes.VALIDATOR_BYTES_SIZE];
+    const new_validators_slice = new_validators_bytes[0 .. min_count * ssz_bytes.VALIDATOR_BYTES_SIZE];
+    try findModifiedValidators(allocator, old_validators_slice, new_validators_slice, &modified_validators, 0);
+
+    try applyModifiedValidators(
+        allocator,
+        seed_validators,
+        migrated_validators,
+        seed_bytes.bytes,
+        new_validators_bytes,
+        modified_validators.items,
+    );
+
+    if (new_count >= seed_count) {
+        const extra_count = new_count - seed_count;
+        try modified_validators.ensureUnusedCapacity(allocator, extra_count);
+
+        try appendNewValidators(allocator, migrated_validators, new_validators_bytes, seed_count, new_count, &modified_validators);
+    } else {
+        migrated_validators = try trimValidators(allocator, migrated_validators, new_count);
+    }
+
+    const out_slice = try modified_validators.toOwnedSlice(allocator);
+    errdefer allocator.free(out_slice);
+
+    try migrated_view.set("validators", migrated_validators);
+    return out_slice;
+}
+
+const ScoresDiffContext = struct {
+    old_bytes: []u8,
+    has_more_validators: bool,
+    min_validator_count: usize,
+    old_validator_count: usize,
+    new_validator_count: usize,
+};
+
+fn buildScoresDiffContext(
+    allocator: Allocator,
+    migrated_scores: *types.altair.InactivityScores.TreeView,
+    inactivity_scores_bytes: []const u8,
+) !ScoresDiffContext {
+    const old_validator_count = try migrated_scores.length();
+    const new_validator_count = inactivity_scores_bytes.len / INACTIVITY_SCORE_SIZE;
+    const has_more_validators = new_validator_count >= old_validator_count;
+    const min_validator_count = @min(old_validator_count, new_validator_count);
+
+    const old_size = try migrated_scores.serializedSize();
+    const old_bytes = try allocator.alloc(u8, old_size);
+    errdefer allocator.free(old_bytes);
+    _ = try migrated_scores.serializeIntoBytes(old_bytes);
+
+    return .{
+        .old_bytes = old_bytes,
+        .has_more_validators = has_more_validators,
+        .min_validator_count = min_validator_count,
+        .old_validator_count = old_validator_count,
+        .new_validator_count = new_validator_count,
+    };
+}
+
+fn applyScoreDiffs(
+    migrated_scores: *types.altair.InactivityScores.TreeView,
+    inactivity_scores_bytes: []const u8,
+    modified_validators: []const ValidatorIndex,
+) !void {
+    for (modified_validators) |validator_index| {
+        const i: usize = @intCast(validator_index);
+        const start = i * INACTIVITY_SCORE_SIZE;
+        const chunk: *const [INACTIVITY_SCORE_SIZE]u8 = @ptrCast(inactivity_scores_bytes[start .. start + INACTIVITY_SCORE_SIZE].ptr);
+        const value = std.mem.readInt(u64, chunk, .little);
+        try migrated_scores.set(i, @intCast(value));
+    }
+}
+
+fn syncScoresLength(
+    allocator: Allocator,
+    migrated_scores: *types.altair.InactivityScores.TreeView,
+    inactivity_scores_bytes: []const u8,
+    old_validator_count: usize,
+    new_validator_count: usize,
+) !*types.altair.InactivityScores.TreeView {
+    if (new_validator_count >= old_validator_count) {
+        var idx: usize = old_validator_count;
+        while (idx < new_validator_count) : (idx += 1) {
+            const start = idx * INACTIVITY_SCORE_SIZE;
+            const chunk: *const [INACTIVITY_SCORE_SIZE]u8 = @ptrCast(inactivity_scores_bytes[start .. start + INACTIVITY_SCORE_SIZE].ptr);
+            const value = std.mem.readInt(u64, chunk, .little);
+            try migrated_scores.push(@intCast(value));
+        }
+        return migrated_scores;
+    }
+
+    if (new_validator_count == 0) {
+        const pool = migrated_scores.chunks.state.pool;
+        const empty_root = try types.altair.InactivityScores.tree.fromValue(
+            pool,
+            &types.altair.InactivityScores.default_value,
+        );
+        errdefer pool.unref(empty_root);
+        const empty_scores = try types.altair.InactivityScores.TreeView.init(allocator, pool, empty_root);
+        migrated_scores.deinit();
+        return empty_scores;
+    }
+
+    const trimmed = try migrated_scores.sliceTo(new_validator_count - 1);
+    migrated_scores.deinit();
+    return trimmed;
+}
+
+const SeedBytes = struct {
+    bytes: []const u8,
+    owned: bool,
+};
+
+fn getSeedValidatorsBytes(
+    allocator: Allocator,
+    seed_validators: *types.phase0.Validators.TreeView,
+    seed_state_validators_bytes: ?[]const u8,
+) !SeedBytes {
+    if (seed_state_validators_bytes) |bytes| {
+        return .{ .bytes = bytes, .owned = false };
+    }
+
+    const size = try seed_validators.serializedSize();
+    const out = try allocator.alloc(u8, size);
+    errdefer allocator.free(out);
+    _ = try seed_validators.serializeIntoBytes(out);
+    return .{ .bytes = out, .owned = true };
+}
+
+fn applyModifiedValidators(
+    allocator: Allocator,
+    seed_validators: *types.phase0.Validators.TreeView,
+    migrated_validators: *types.phase0.Validators.TreeView,
+    seed_bytes: []const u8,
+    new_validators_bytes: []const u8,
+    modified_validators: []const ValidatorIndex,
+) !void {
+    for (modified_validators) |validator_index| {
+        const i: usize = @intCast(validator_index);
+        const start = i * ssz_bytes.VALIDATOR_BYTES_SIZE;
+        const new_bytes = new_validators_bytes[start .. start + ssz_bytes.VALIDATOR_BYTES_SIZE];
+        const seed_val_bytes = seed_bytes[start .. start + ssz_bytes.VALIDATOR_BYTES_SIZE];
+
+        const seed_validator = try seed_validators.get(i);
+        // seed_validator is borrowed from seed_validators; do not deinit.
+
+        const new_validator = try loadValidatorWithSeedReuse(
+            allocator,
+            migrated_validators.chunks.state.pool,
+            seed_validator,
+            seed_val_bytes,
+            new_bytes,
+        );
+        errdefer new_validator.deinit();
+        try migrated_validators.set(i, new_validator);
+    }
+}
+
+fn appendNewValidators(
+    allocator: Allocator,
+    migrated_validators: *types.phase0.Validators.TreeView,
+    new_validators_bytes: []const u8,
+    start_index: usize,
+    end_index: usize,
+    modified_validators: *std.ArrayList(ValidatorIndex),
+) !void {
+    var idx: usize = start_index;
+    while (idx < end_index) : (idx += 1) {
+        const start = idx * ssz_bytes.VALIDATOR_BYTES_SIZE;
+        const new_bytes = new_validators_bytes[start .. start + ssz_bytes.VALIDATOR_BYTES_SIZE];
+
+        const pool = migrated_validators.chunks.state.pool;
+        var v: ?*types.phase0.Validator.TreeView = blk: {
+            const root = try types.phase0.Validator.tree.deserializeFromBytes(pool, new_bytes);
+            errdefer pool.unref(root);
+            break :blk try types.phase0.Validator.TreeView.init(allocator, pool, root);
+        };
+        errdefer if (v) |vv| vv.deinit();
+
+        try migrated_validators.push(v.?);
+        v = null;
+        modified_validators.appendAssumeCapacity(@intCast(idx));
+    }
+}
+
+fn trimValidators(
+    allocator: Allocator,
+    migrated_validators: *types.phase0.Validators.TreeView,
+    new_count: usize,
+) !*types.phase0.Validators.TreeView {
+    if (new_count == 0) {
+        const pool = migrated_validators.chunks.state.pool;
+        const empty_root = try types.phase0.Validators.tree.fromValue(
+            pool,
+            &types.phase0.Validators.default_value,
+        );
+        errdefer pool.unref(empty_root);
+        const empty_validators = try types.phase0.Validators.TreeView.init(allocator, pool, empty_root);
+        migrated_validators.deinit();
+        return empty_validators;
+    }
+
+    const trimmed = try migrated_validators.sliceTo(new_count - 1);
+    migrated_validators.deinit();
+    return trimmed;
+}
+
+fn validatorsNodeId(state: *AnyBeaconState) !Node.Id {
+    return switch (state.*) {
+        inline else => |s| s.root.getNodeAtDepth(s.pool, @TypeOf(s.*).SszType.chunk_depth, BEACON_STATE_VALIDATORS_FIELD_INDEX),
+    };
+}
+
+fn inactivityScoresNodeId(state: *AnyBeaconState) !Node.Id {
+    return switch (state.*) {
+        .phase0 => error.InvalidAtFork,
+        inline else => |s| s.root.getNodeAtDepth(s.pool, @TypeOf(s.*).SszType.chunk_depth, BEACON_STATE_INACTIVITY_SCORES_FIELD_INDEX),
+    };
+}
+
+fn validatorsViewOwned(allocator: Allocator, state: *AnyBeaconState) !*types.phase0.Validators.TreeView {
+    const root = try validatorsNodeId(state);
+    const pool = switch (state.*) {
+        inline else => |s| s.pool,
+    };
+    return try types.phase0.Validators.TreeView.init(allocator, pool, root);
+}
+
+fn inactivityScoresViewOwned(allocator: Allocator, state: *AnyBeaconState) !*types.altair.InactivityScores.TreeView {
+    const root = try inactivityScoresNodeId(state);
+    const pool = switch (state.*) {
+        inline else => |s| s.pool,
+    };
+    return try types.altair.InactivityScores.TreeView.init(allocator, pool, root);
+}
+
+fn loadValidatorWithSeedReuse(
+    allocator: Allocator,
+    pool: *Node.Pool,
+    seed_validator: *types.phase0.Validator.TreeView,
+    seed_validator_bytes: []const u8,
+    new_validator_bytes: []const u8,
+) !*types.phase0.Validator.TreeView {
+    // Pubkey: [0..48), withdrawal_credentials: [48..80)
+    const pubkey_same = std.mem.eql(u8, new_validator_bytes[0..48], seed_validator_bytes[0..48]);
+    const withdrawal_same = std.mem.eql(u8, new_validator_bytes[48..80], seed_validator_bytes[48..80]);
+
+    if (!pubkey_same) {
+        if (!withdrawal_same) {
+            const root = try types.phase0.Validator.tree.deserializeFromBytes(pool, new_validator_bytes);
+            errdefer pool.unref(root);
+            return try types.phase0.Validator.TreeView.init(allocator, pool, root);
+        }
+    }
+
+    var nodes: [types.phase0.Validator.chunk_count]Node.Id = undefined;
+    var owned_nodes: [types.phase0.Validator.chunk_count]Node.Id = undefined;
+    var owned_len: usize = 0;
+    errdefer {
+        for (owned_nodes[0..owned_len]) |node_id| {
+            pool.unref(node_id);
+        }
+    }
+
+    inline for (types.phase0.Validator.fields, 0..) |field, i| {
+        const reuse = if (comptime std.mem.eql(u8, field.name, "pubkey"))
+            pubkey_same
+        else if (comptime std.mem.eql(u8, field.name, "withdrawal_credentials"))
+            withdrawal_same
+        else
+            false;
+
+        if (reuse) {
+            nodes[i] = try seed_validator.root.getNodeAtDepth(seed_validator.pool, types.phase0.Validator.chunk_depth, i);
+        } else {
+            const start = types.phase0.Validator.field_offsets[i];
+            const end = start + field.type.fixed_size;
+            const bytes = new_validator_bytes[start..end];
+            const node_id = try field.type.tree.deserializeFromBytes(pool, bytes);
+            owned_nodes[owned_len] = node_id;
+            owned_len += 1;
+            nodes[i] = node_id;
+        }
+    }
+
+    const root = try Node.fillWithContents(pool, &nodes, types.phase0.Validator.chunk_depth);
+    errdefer pool.unref(root);
+    owned_len = 0;
+    return try types.phase0.Validator.TreeView.init(allocator, pool, root);
+}
+
+fn findModifiedValidators(
+    allocator: Allocator,
+    validators_bytes: []const u8,
+    validators_bytes2: []const u8,
+    modified_validators: *std.ArrayList(ValidatorIndex),
+    validator_offset: usize,
+) !void {
+    std.debug.assert(validators_bytes.len == validators_bytes2.len);
+    std.debug.assert(validators_bytes.len % ssz_bytes.VALIDATOR_BYTES_SIZE == 0);
+
+    if (std.mem.eql(u8, validators_bytes, validators_bytes2)) return;
+
+    if (validators_bytes.len == ssz_bytes.VALIDATOR_BYTES_SIZE) {
+        try modified_validators.append(allocator, @intCast(validator_offset));
+        return;
+    }
+
+    const num_validator = validators_bytes.len / ssz_bytes.VALIDATOR_BYTES_SIZE;
+    const half_validator = num_validator / 2;
+    const split = half_validator * ssz_bytes.VALIDATOR_BYTES_SIZE;
+
+    try findModifiedValidators(
+        allocator,
+        validators_bytes[0..split],
+        validators_bytes2[0..split],
+        modified_validators,
+        validator_offset,
+    );
+    try findModifiedValidators(
+        allocator,
+        validators_bytes[split..],
+        validators_bytes2[split..],
+        modified_validators,
+        validator_offset + half_validator,
+    );
+}
+
+fn findModifiedInactivityScores(
+    allocator: Allocator,
+    inactivity_scores_bytes: []const u8,
+    inactivity_scores_bytes2: []const u8,
+    modified_validators: *std.ArrayList(ValidatorIndex),
+    validator_offset: usize,
+) !void {
+    std.debug.assert(inactivity_scores_bytes.len == inactivity_scores_bytes2.len);
+    std.debug.assert(inactivity_scores_bytes.len % INACTIVITY_SCORE_SIZE == 0);
+
+    if (std.mem.eql(u8, inactivity_scores_bytes, inactivity_scores_bytes2)) return;
+
+    if (inactivity_scores_bytes.len == INACTIVITY_SCORE_SIZE) {
+        try modified_validators.append(allocator, @intCast(validator_offset));
+        return;
+    }
+
+    const num_validator = inactivity_scores_bytes.len / INACTIVITY_SCORE_SIZE;
+    const half_validator = num_validator / 2;
+    const split = half_validator * INACTIVITY_SCORE_SIZE;
+
+    try findModifiedInactivityScores(
+        allocator,
+        inactivity_scores_bytes[0..split],
+        inactivity_scores_bytes2[0..split],
+        modified_validators,
+        validator_offset,
+    );
+    try findModifiedInactivityScores(
+        allocator,
+        inactivity_scores_bytes[split..],
+        inactivity_scores_bytes2[split..],
+        modified_validators,
+        validator_offset + half_validator,
+    );
+}
+
+test "loadValidatorWithSeedReuse: reuse vs rebuild" {
+    const allocator = std.testing.allocator;
+
+    var pool = try Node.Pool.init(allocator, 1024);
+    defer pool.deinit();
+
+    const gen = @import("test_utils/generate_state.zig");
+    const chain_config = gen.getConfig(@import("config").minimal.chain_config, .electra, 0);
+
+    const state_ptr = try gen.generateElectraState(allocator, &pool, chain_config, 64);
+    defer {
+        state_ptr.deinit();
+        allocator.destroy(state_ptr);
+    }
+
+    // Build a seed BeaconState TreeView in this pool, then take a validator element as the seed.
+    const seed_state_bytes = try state_ptr.serialize(allocator);
+    defer allocator.free(seed_state_bytes);
+
+    var seed_state = try AnyBeaconState.deserialize(allocator, &pool, .electra, seed_state_bytes);
+    defer seed_state.deinit();
+
+    var seed_validators = try validatorsViewOwned(allocator, &seed_state);
+    defer seed_validators.deinit();
+
+    const target_index: usize = 3;
+    var seed_validator = try seed_validators.get(target_index);
+    // seed_validator is borrowed from seed_validators; do not deinit.
+
+    var seed_validator_bytes: [ssz_bytes.VALIDATOR_BYTES_SIZE]u8 = undefined;
+    _ = try seed_validator.serializeIntoBytes(&seed_validator_bytes);
+
+    var new_validator_bytes = seed_validator_bytes;
+    // Modify only withdrawal_credentials ([48..80))
+    @memset(new_validator_bytes[48..80], 0x11);
+
+    const new_validator = try loadValidatorWithSeedReuse(
+        allocator,
+        &pool,
+        seed_validator,
+        seed_validator_bytes[0..],
+        new_validator_bytes[0..],
+    );
+    defer new_validator.deinit();
+
+    const pubkey_i = comptime types.phase0.Validator.getFieldIndex("pubkey");
+    const withdrawal_i = comptime types.phase0.Validator.getFieldIndex("withdrawal_credentials");
+
+    try std.testing.expectEqual(
+        try seed_validator.root.getNodeAtDepth(seed_validator.pool, types.phase0.Validator.chunk_depth, pubkey_i),
+        try new_validator.root.getNodeAtDepth(new_validator.pool, types.phase0.Validator.chunk_depth, pubkey_i),
+    );
+    try std.testing.expect(
+        try seed_validator.root.getNodeAtDepth(seed_validator.pool, types.phase0.Validator.chunk_depth, withdrawal_i) != try new_validator.root.getNodeAtDepth(new_validator.pool, types.phase0.Validator.chunk_depth, withdrawal_i),
+    );
+}
+
+test "loadState scenarios" {
+    const allocator = std.testing.allocator;
+    const gen = @import("test_utils/generate_state.zig");
+    const chain_config = gen.getConfig(@import("config").minimal.chain_config, .electra, 0);
+
+    const Mutation = union(enum) {
+        none,
+        validator_withdrawal_bytes: struct { index: usize, fill: u8 },
+        validator_pubkey_and_withdrawal_bytes: struct { index: usize, pub_fill: u8, wd_fill: u8 },
+        scores_struct: struct { index: usize, value: u64 },
+        append_one_validator_struct: struct { pub_fill: u8 },
+        trim_struct: struct { new_len: usize },
+    };
+
+    const Case = struct {
+        name: []const u8,
+        mutation: Mutation,
+        expect_modified: []const ValidatorIndex,
+        expect_validators_len: usize,
+        expect_scores_len: usize,
+        expect_score: ?struct { index: usize, value: u64 } = null,
+        expect_validator_bytes_match_state_bytes: ?struct { index: usize } = null,
+    };
+
+    const expect_none = [_]ValidatorIndex{};
+    const expect_one_3 = [_]ValidatorIndex{@intCast(3)};
+    const expect_one_5 = [_]ValidatorIndex{@intCast(5)};
+    const expect_one_64 = [_]ValidatorIndex{@intCast(64)};
+
+    const cases = [_]Case{
+        .{ .name = "no changes", .mutation = .none, .expect_modified = expect_none[0..], .expect_validators_len = 64, .expect_scores_len = 64 },
+        .{ .name = "validator withdrawal change (bytes)", .mutation = .{ .validator_withdrawal_bytes = .{ .index = 3, .fill = 0x11 } }, .expect_modified = expect_one_3[0..], .expect_validators_len = 64, .expect_scores_len = 64, .expect_validator_bytes_match_state_bytes = .{ .index = 3 } },
+        .{ .name = "validator pubkey+withdrawal change (bytes)", .mutation = .{ .validator_pubkey_and_withdrawal_bytes = .{ .index = 5, .pub_fill = 0x22, .wd_fill = 0x33 } }, .expect_modified = expect_one_5[0..], .expect_validators_len = 64, .expect_scores_len = 64, .expect_validator_bytes_match_state_bytes = .{ .index = 5 } },
+        .{ .name = "scores-only change (struct)", .mutation = .{ .scores_struct = .{ .index = 7, .value = 123 } }, .expect_modified = expect_none[0..], .expect_validators_len = 64, .expect_scores_len = 64, .expect_score = .{ .index = 7, .value = 123 } },
+        .{ .name = "append one validator (struct)", .mutation = .{ .append_one_validator_struct = .{ .pub_fill = 0x44 } }, .expect_modified = expect_one_64[0..], .expect_validators_len = 65, .expect_scores_len = 65 },
+        .{ .name = "trim validators to 63 (struct)", .mutation = .{ .trim_struct = .{ .new_len = 63 } }, .expect_modified = expect_none[0..], .expect_validators_len = 63, .expect_scores_len = 63 },
+        .{ .name = "trim validators to 0 (struct)", .mutation = .{ .trim_struct = .{ .new_len = 0 } }, .expect_modified = expect_none[0..], .expect_validators_len = 0, .expect_scores_len = 0 },
+    };
+
+    inline for (cases) |case| {
+        var pool = try Node.Pool.init(allocator, 8192);
+        defer pool.deinit();
+
+        const state_ptr = try gen.generateElectraState(allocator, &pool, chain_config, 64);
+        defer {
+            state_ptr.deinit();
+            allocator.destroy(state_ptr);
+        }
+
+        const genesis_root = (try state_ptr.genesisValidatorsRoot()).*;
+        const beacon_config = @import("config").BeaconConfig.init(chain_config, genesis_root);
+
+        const seed_bytes = try state_ptr.serialize(allocator);
+        defer allocator.free(seed_bytes);
+
+        var seed_all = try AnyBeaconState.deserialize(allocator, &pool, .electra, seed_bytes);
+        defer seed_all.deinit();
+
+        const mutated_bytes = blk: {
+            switch (case.mutation) {
+                .none => break :blk seed_bytes,
+                .validator_withdrawal_bytes => |m| {
+                    const validators_field_index = comptime types.electra.BeaconState.getFieldIndex("validators");
+                    const ranges = try types.electra.BeaconState.readFieldRanges(seed_bytes);
+                    const validators_range = ranges[validators_field_index];
+                    const out = try allocator.dupe(u8, seed_bytes);
+                    const base = validators_range[0] + m.index * ssz_bytes.VALIDATOR_BYTES_SIZE;
+                    @memset(out[base + 48 .. base + 80], m.fill);
+                    break :blk out;
+                },
+                .validator_pubkey_and_withdrawal_bytes => |m| {
+                    const validators_field_index = comptime types.electra.BeaconState.getFieldIndex("validators");
+                    const ranges = try types.electra.BeaconState.readFieldRanges(seed_bytes);
+                    const validators_range = ranges[validators_field_index];
+                    const out = try allocator.dupe(u8, seed_bytes);
+                    const base = validators_range[0] + m.index * ssz_bytes.VALIDATOR_BYTES_SIZE;
+                    @memset(out[base + 0 .. base + 48], m.pub_fill);
+                    @memset(out[base + 48 .. base + 80], m.wd_fill);
+                    break :blk out;
+                },
+                .scores_struct => |m| {
+                    var scores = try state_ptr.inactivityScores();
+                    try scores.set(m.index, m.value);
+                    break :blk try state_ptr.serialize(allocator);
+                },
+                .append_one_validator_struct => |m| {
+                    var validators = try state_ptr.validators();
+                    var v: types.phase0.Validator.Type = undefined;
+                    try validators.getValue(allocator, 0, &v);
+                    v.pubkey = @as(@TypeOf(v.pubkey), [_]u8{m.pub_fill} ** 48);
+                    try validators.pushValue(&v);
+
+                    var balances = try state_ptr.balances();
+                    try balances.push(try balances.get(0));
+
+                    var scores = try state_ptr.inactivityScores();
+                    try scores.push(try scores.get(0));
+
+                    var previous_epoch_participation = try state_ptr.previousEpochParticipation();
+                    try previous_epoch_participation.push(try previous_epoch_participation.get(0));
+
+                    var current_epoch_participation = try state_ptr.currentEpochParticipation();
+                    try current_epoch_participation.push(try current_epoch_participation.get(0));
+
+                    var eth1_data = try state_ptr.eth1Data();
+                    const deposit_count = try eth1_data.get("deposit_count");
+                    try eth1_data.set("deposit_count", deposit_count + 1);
+                    try state_ptr.setEth1DepositIndex(try state_ptr.eth1DepositIndex() + 1);
+                    break :blk try state_ptr.serialize(allocator);
+                },
+                .trim_struct => |m| {
+                    var validators = try state_ptr.validators();
+                    try validators.setLength(m.new_len);
+
+                    var balances = try state_ptr.balances();
+                    try balances.setLength(m.new_len);
+
+                    var scores = try state_ptr.inactivityScores();
+                    try scores.setLength(m.new_len);
+
+                    var previous_epoch_participation = try state_ptr.previousEpochParticipation();
+                    try previous_epoch_participation.setLength(m.new_len);
+
+                    var current_epoch_participation = try state_ptr.currentEpochParticipation();
+                    try current_epoch_participation.setLength(m.new_len);
+
+                    if (m.new_len == 0) {
+                        var eth1_data = try state_ptr.eth1Data();
+                        try eth1_data.set("deposit_count", 0);
+                        try state_ptr.setEth1DepositIndex(0);
+                    }
+                    break :blk try state_ptr.serialize(allocator);
+                },
+            }
+        };
+        defer if (mutated_bytes.ptr != seed_bytes.ptr) allocator.free(mutated_bytes);
+
+        var out = try loadState(allocator, &beacon_config, &seed_all, mutated_bytes, null);
+        defer {
+            allocator.free(out.modified_validators);
+            var s = out.state;
+            s.deinit();
+        }
+
+        try std.testing.expectEqual(case.expect_modified.len, out.modified_validators.len);
+        for (case.expect_modified, out.modified_validators) |e, got| {
+            try std.testing.expectEqual(e, got);
+        }
+
+        var migrated_validators = try validatorsViewOwned(allocator, &out.state);
+        defer migrated_validators.deinit();
+        try std.testing.expectEqual(case.expect_validators_len, try migrated_validators.length());
+
+        var scores = try inactivityScoresViewOwned(allocator, &out.state);
+        defer scores.deinit();
+        try std.testing.expectEqual(case.expect_scores_len, try scores.length());
+
+        if (case.expect_score) |exp| {
+            try std.testing.expectEqual(exp.value, try scores.get(exp.index));
+        }
+
+        if (case.expect_validator_bytes_match_state_bytes) |exp| {
+            const validators_field_index = comptime types.electra.BeaconState.getFieldIndex("validators");
+            const ranges = try types.electra.BeaconState.readFieldRanges(mutated_bytes);
+            const validators_range = ranges[validators_field_index];
+            const base = validators_range[0] + exp.index * ssz_bytes.VALIDATOR_BYTES_SIZE;
+            var mv = try migrated_validators.get(exp.index);
+            // mv is borrowed from migrated_validators; do not deinit.
+            var mv_bytes: [ssz_bytes.VALIDATOR_BYTES_SIZE]u8 = undefined;
+            _ = try mv.serializeIntoBytes(&mv_bytes);
+            try std.testing.expectEqualSlices(u8, mutated_bytes[base .. base + ssz_bytes.VALIDATOR_BYTES_SIZE], mv_bytes[0..]);
+        }
+    }
+}
+
+test "diff helpers cases" {
+    const allocator = std.testing.allocator;
+
+    const Kind = enum { validators, scores };
+    const Case = struct {
+        name: []const u8,
+        kind: Kind,
+        count: usize,
+        modified: []const usize,
+    };
+
+    const mod_none = [_]usize{};
+    const mod_some_validators = [_]usize{ 0, 1, 63, 64, 127 };
+    const mod_some_scores = [_]usize{ 0, 7, 31, 32, 63 };
+
+    const cases = [_]Case{
+        .{ .name = "validators: no diff", .kind = .validators, .count = 128, .modified = mod_none[0..] },
+        .{ .name = "validators: some diff", .kind = .validators, .count = 128, .modified = mod_some_validators[0..] },
+        .{ .name = "scores: no diff", .kind = .scores, .count = 64, .modified = mod_none[0..] },
+        .{ .name = "scores: some diff", .kind = .scores, .count = 64, .modified = mod_some_scores[0..] },
+    };
+
+    for (cases) |case| {
+        var got: std.ArrayList(ValidatorIndex) = .empty;
+        defer got.deinit(allocator);
+
+        if (case.kind == .validators) {
+            const total = case.count * ssz_bytes.VALIDATOR_BYTES_SIZE;
+            const old_bytes = try allocator.alloc(u8, total);
+            defer allocator.free(old_bytes);
+            const new_bytes = try allocator.alloc(u8, total);
+            defer allocator.free(new_bytes);
+
+            for (0..case.count) |i| {
+                const start = i * ssz_bytes.VALIDATOR_BYTES_SIZE;
+                for (0..ssz_bytes.VALIDATOR_BYTES_SIZE) |j| {
+                    old_bytes[start + j] = @intCast((i + 31 * j) & 0xff);
+                }
+            }
+            @memcpy(new_bytes, old_bytes);
+
+            for (case.modified) |idx| {
+                const start = idx * ssz_bytes.VALIDATOR_BYTES_SIZE;
+                new_bytes[start] ^= 0x5a;
+            }
+
+            try findModifiedValidators(allocator, old_bytes, new_bytes, &got, 0);
+        } else {
+            const total = case.count * INACTIVITY_SCORE_SIZE;
+            const old_bytes = try allocator.alloc(u8, total);
+            defer allocator.free(old_bytes);
+            const new_bytes = try allocator.alloc(u8, total);
+            defer allocator.free(new_bytes);
+
+            for (0..case.count) |i| {
+                const start = i * INACTIVITY_SCORE_SIZE;
+                std.mem.writeInt(u64, @ptrCast(old_bytes[start .. start + INACTIVITY_SCORE_SIZE].ptr), @intCast(i * 3), .little);
+            }
+            @memcpy(new_bytes, old_bytes);
+
+            for (case.modified) |idx| {
+                const start = idx * INACTIVITY_SCORE_SIZE;
+                new_bytes[start] ^= 0xa5;
+            }
+
+            try findModifiedInactivityScores(allocator, old_bytes, new_bytes, &got, 0);
+        }
+
+        try std.testing.expectEqual(case.modified.len, got.items.len);
+        for (case.modified, got.items) |e, g| {
+            try std.testing.expectEqual(@as(ValidatorIndex, @intCast(e)), g);
+        }
+    }
+}

--- a/src/state_transition/load_state.zig
+++ b/src/state_transition/load_state.zig
@@ -15,7 +15,7 @@ const ssz_container = @import("ssz_container.zig");
 const ValidatorIndex = types.primitive.ValidatorIndex.Type;
 
 /// Inactivity score is `uint64` (8 bytes).
-const INACTIVITY_SCORE_SIZE: usize = 8;
+const INACTIVITY_SCORE_SIZE: usize = types.primitive.Uint64.fixed_size;
 
 // BeaconState field indices are stable across forks.
 const BEACON_STATE_VALIDATORS_FIELD_INDEX: usize = types.phase0.BeaconState.getFieldIndex("validators");
@@ -147,6 +147,10 @@ fn loadStateForFork(
     return .{ .state = migrated_state, .modified_validators = modified_validators };
 }
 
+/// Migrate the `inactivity_scores` list onto `migrated_view`, reusing the seed's subtree.
+///
+/// Inactivity scores rarely change between two states (mostly 0 on mainnet), so reusing
+/// the seed's unchanged score subtrees saves ~500ms of state hashTreeRoot time.
 fn loadInactivityScores(
     allocator: Allocator,
     comptime StateST: type,
@@ -160,7 +164,7 @@ fn loadInactivityScores(
     const seed_scores = try types.altair.InactivityScores.TreeView.init(allocator, pool, seed_scores_node);
     defer seed_scores.deinit();
 
-    var migrated_scores = try seed_scores.clone(.{});
+    var migrated_scores = try seed_scores.clone(.{ .transfer_cache = false });
     errdefer migrated_scores.deinit();
 
     const diff_ctx = try buildScoresDiffContext(allocator, migrated_scores, inactivity_scores_bytes);
@@ -185,6 +189,10 @@ fn loadInactivityScores(
     try migrated_view.set("inactivity_scores", migrated_scores);
 }
 
+/// Migrate the `validators` list onto `migrated_view`, reusing the seed's subtree
+/// for unchanged validators and deserializing only the modified ones.
+///
+/// Returns the absolute indices of validators that differ from the seed (caller owns the slice).
 fn loadValidators(
     allocator: Allocator,
     comptime StateST: type,
@@ -206,16 +214,28 @@ fn loadValidators(
     const new_count = new_validators_bytes.len / ssz_bytes.VALIDATOR_BYTES_SIZE;
     const min_count = @min(seed_count, new_count);
 
-    var migrated_validators = try seed_validators.clone(.{});
+    var migrated_validators = try seed_validators.clone(.{ .transfer_cache = false });
     errdefer migrated_validators.deinit();
 
-    const seed_bytes = try getSeedValidatorsBytes(allocator, seed_validators, seed_state_validators_bytes);
-    defer if (seed_bytes.owned) allocator.free(seed_bytes.bytes);
+    // Only set when we serialize the seed ourselves; the cleanup frees exactly that case.
+    var serialized_seed: ?[]u8 = null;
+    defer if (serialized_seed) |bytes| allocator.free(bytes);
+
+    // 80% of validators serialization time comes from memory allocation.
+    // seed_state_validators_bytes is an optimization at the beacon-node side to avoid
+    // memory allocation here.
+    const seed_bytes: []const u8 = seed_state_validators_bytes orelse blk: {
+        const size = try seed_validators.serializedSize();
+        const out = try allocator.alloc(u8, size);
+        serialized_seed = out;
+        _ = try seed_validators.serializeIntoBytes(out);
+        break :blk out;
+    };
 
     var modified_validators: std.ArrayList(ValidatorIndex) = .empty;
     errdefer modified_validators.deinit(allocator);
 
-    const old_validators_slice = seed_bytes.bytes[0 .. min_count * ssz_bytes.VALIDATOR_BYTES_SIZE];
+    const old_validators_slice = seed_bytes[0 .. min_count * ssz_bytes.VALIDATOR_BYTES_SIZE];
     const new_validators_slice = new_validators_bytes[0 .. min_count * ssz_bytes.VALIDATOR_BYTES_SIZE];
     try findModifiedValidators(allocator, old_validators_slice, new_validators_slice, &modified_validators, 0);
 
@@ -223,7 +243,7 @@ fn loadValidators(
         allocator,
         seed_validators,
         migrated_validators,
-        seed_bytes.bytes,
+        seed_bytes,
         new_validators_bytes,
         modified_validators.items,
     );
@@ -252,6 +272,7 @@ const ScoresDiffContext = struct {
     new_validator_count: usize,
 };
 
+/// Snapshot the seed scores (serialized bytes plus counts) needed to diff against the new bytes.
 fn buildScoresDiffContext(
     allocator: Allocator,
     migrated_scores: *types.altair.InactivityScores.TreeView,
@@ -276,6 +297,7 @@ fn buildScoresDiffContext(
     };
 }
 
+/// Write each modified inactivity score into `migrated_scores` from `inactivity_scores_bytes`.
 fn applyScoreDiffs(
     migrated_scores: *types.altair.InactivityScores.TreeView,
     inactivity_scores_bytes: []const u8,
@@ -286,10 +308,12 @@ fn applyScoreDiffs(
         const start = i * INACTIVITY_SCORE_SIZE;
         const chunk: *const [INACTIVITY_SCORE_SIZE]u8 = @ptrCast(inactivity_scores_bytes[start .. start + INACTIVITY_SCORE_SIZE].ptr);
         const value = std.mem.readInt(u64, chunk, .little);
-        try migrated_scores.set(i, @intCast(value));
+        try migrated_scores.set(i, value);
     }
 }
 
+/// Resize `migrated_scores` to `new_validator_count`: append new scores when growing,
+/// or return a trimmed (or empty) view when shrinking. Returns the resulting view.
 fn syncScoresLength(
     allocator: Allocator,
     migrated_scores: *types.altair.InactivityScores.TreeView,
@@ -303,7 +327,7 @@ fn syncScoresLength(
             const start = idx * INACTIVITY_SCORE_SIZE;
             const chunk: *const [INACTIVITY_SCORE_SIZE]u8 = @ptrCast(inactivity_scores_bytes[start .. start + INACTIVITY_SCORE_SIZE].ptr);
             const value = std.mem.readInt(u64, chunk, .little);
-            try migrated_scores.push(@intCast(value));
+            try migrated_scores.push(value);
         }
         return migrated_scores;
     }
@@ -325,27 +349,8 @@ fn syncScoresLength(
     return trimmed;
 }
 
-const SeedBytes = struct {
-    bytes: []const u8,
-    owned: bool,
-};
-
-fn getSeedValidatorsBytes(
-    allocator: Allocator,
-    seed_validators: *types.phase0.Validators.TreeView,
-    seed_state_validators_bytes: ?[]const u8,
-) !SeedBytes {
-    if (seed_state_validators_bytes) |bytes| {
-        return .{ .bytes = bytes, .owned = false };
-    }
-
-    const size = try seed_validators.serializedSize();
-    const out = try allocator.alloc(u8, size);
-    errdefer allocator.free(out);
-    _ = try seed_validators.serializeIntoBytes(out);
-    return .{ .bytes = out, .owned = true };
-}
-
+/// Overwrite each modified validator in `migrated_validators` with a view rebuilt
+/// from `new_validators_bytes`, reusing the seed validator's pubkey/withdrawal subtrees.
 fn applyModifiedValidators(
     allocator: Allocator,
     seed_validators: *types.phase0.Validators.TreeView,
@@ -375,6 +380,8 @@ fn applyModifiedValidators(
     }
 }
 
+/// Deserialize and push validators at indices [start_index, end_index) from
+/// `new_validators_bytes`, recording each appended index in `modified_validators`.
 fn appendNewValidators(
     allocator: Allocator,
     migrated_validators: *types.phase0.Validators.TreeView,
@@ -402,6 +409,7 @@ fn appendNewValidators(
     }
 }
 
+/// Shrink `migrated_validators` to `new_count`, returning a trimmed (or empty) view.
 fn trimValidators(
     allocator: Allocator,
     migrated_validators: *types.phase0.Validators.TreeView,
@@ -437,16 +445,9 @@ fn inactivityScoresNodeId(state: *AnyBeaconState) !Node.Id {
     };
 }
 
-fn validatorsViewOwned(allocator: Allocator, state: *AnyBeaconState) !*types.phase0.Validators.TreeView {
-    const root = try validatorsNodeId(state);
-    return try types.phase0.Validators.TreeView.init(allocator, state.nodePool(), root);
-}
-
-fn inactivityScoresViewOwned(allocator: Allocator, state: *AnyBeaconState) !*types.altair.InactivityScores.TreeView {
-    const root = try inactivityScoresNodeId(state);
-    return try types.altair.InactivityScores.TreeView.init(allocator, state.nodePool(), root);
-}
-
+/// Load a validator from bytes given a seed validator.
+/// - Reuse pubkey and withdrawal credentials subtrees if they are unchanged, to save memory.
+/// - Otherwise deserialize the validator fresh.
 fn loadValidatorWithSeedReuse(
     allocator: Allocator,
     pool: *Node.Pool,
@@ -507,6 +508,8 @@ fn loadValidatorWithSeedReuse(
     return try types.phase0.Validator.TreeView.init(allocator, pool, root);
 }
 
+/// Append the absolute indices (offset by `validator_offset`) of validators that
+/// differ between the two equal-length, VALIDATOR_BYTES_SIZE-aligned slices.
 fn findModifiedValidators(
     allocator: Allocator,
     validators_bytes: []const u8,
@@ -544,6 +547,8 @@ fn findModifiedValidators(
     );
 }
 
+/// Append the absolute indices (offset by `validator_offset`) of inactivity scores
+/// that differ between the two equal-length, INACTIVITY_SCORE_SIZE-aligned slices.
 fn findModifiedInactivityScores(
     allocator: Allocator,
     inactivity_scores_bytes: []const u8,
@@ -603,7 +608,7 @@ test "loadValidatorWithSeedReuse: reuse vs rebuild" {
     var seed_state = try AnyBeaconState.deserialize(allocator, &pool, .electra, seed_state_bytes);
     defer seed_state.deinit();
 
-    var seed_validators = try validatorsViewOwned(allocator, &seed_state);
+    var seed_validators = try types.phase0.Validators.TreeView.init(allocator, seed_state.nodePool(), try validatorsNodeId(&seed_state));
     defer seed_validators.deinit();
 
     const target_index: usize = 3;
@@ -795,11 +800,11 @@ test "loadState scenarios" {
             try std.testing.expectEqual(e, got);
         }
 
-        var migrated_validators = try validatorsViewOwned(allocator, &out.state);
+        var migrated_validators = try types.phase0.Validators.TreeView.init(allocator, out.state.nodePool(), try validatorsNodeId(&out.state));
         defer migrated_validators.deinit();
         try std.testing.expectEqual(case.expect_validators_len, try migrated_validators.length());
 
-        var scores = try inactivityScoresViewOwned(allocator, &out.state);
+        var scores = try types.altair.InactivityScores.TreeView.init(allocator, out.state.nodePool(), try inactivityScoresNodeId(&out.state));
         defer scores.deinit();
         try std.testing.expectEqual(case.expect_scores_len, try scores.length());
 
@@ -900,7 +905,7 @@ test "diff helpers cases" {
     }
 }
 
-test "loadValidators rejects non-multiple-of-VALIDATOR_BYTES_SIZE" {
+test "loadValidators/loadInactivityScores: rejection scenarios" {
     const allocator = std.testing.allocator;
     var pool = try Node.Pool.init(allocator, 1024);
     defer pool.deinit();
@@ -915,57 +920,35 @@ test "loadValidators rejects non-multiple-of-VALIDATOR_BYTES_SIZE" {
 
     const StateST = types.electra.BeaconState;
     const migrated_view = state_ptr.castToFork(.electra).inner;
-    const seed_validators_node = try validatorsNodeId(state_ptr);
-    const bad_bytes = [_]u8{0} ** (ssz_bytes.VALIDATOR_BYTES_SIZE + 1);
-    try std.testing.expectError(
-        error.InvalidSize,
-        loadValidators(allocator, StateST, migrated_view, &pool, seed_validators_node, bad_bytes[0..], null),
-    );
-}
 
-test "loadValidators rejects malformed seed_state_validators_bytes" {
-    const allocator = std.testing.allocator;
-    var pool = try Node.Pool.init(allocator, 1024);
-    defer pool.deinit();
-
-    const gen = @import("test_utils/generate_state.zig");
-    const chain_config = gen.getConfig(@import("config").minimal.chain_config, .electra, 0);
-    const state_ptr = try gen.generateElectraState(allocator, &pool, chain_config, 8);
-    defer {
-        state_ptr.deinit();
-        allocator.destroy(state_ptr);
+    {
+        // new validators bytes length is not a multiple of VALIDATOR_BYTES_SIZE
+        const seed_validators_node = try validatorsNodeId(state_ptr);
+        const bad_bytes = [_]u8{0} ** (ssz_bytes.VALIDATOR_BYTES_SIZE + 1);
+        try std.testing.expectError(
+            error.InvalidSize,
+            loadValidators(allocator, StateST, migrated_view, &pool, seed_validators_node, bad_bytes[0..], null),
+        );
     }
 
-    const StateST = types.electra.BeaconState;
-    const migrated_view = state_ptr.castToFork(.electra).inner;
-    const seed_validators_node = try validatorsNodeId(state_ptr);
-    const good_new_bytes = [_]u8{0} ** (ssz_bytes.VALIDATOR_BYTES_SIZE * 2);
-    const bad_seed_bytes = [_]u8{0} ** (ssz_bytes.VALIDATOR_BYTES_SIZE + 1);
-    try std.testing.expectError(
-        error.InvalidSize,
-        loadValidators(allocator, StateST, migrated_view, &pool, seed_validators_node, good_new_bytes[0..], bad_seed_bytes[0..]),
-    );
-}
-
-test "loadInactivityScores rejects non-multiple-of-INACTIVITY_SCORE_SIZE" {
-    const allocator = std.testing.allocator;
-    var pool = try Node.Pool.init(allocator, 1024);
-    defer pool.deinit();
-
-    const gen = @import("test_utils/generate_state.zig");
-    const chain_config = gen.getConfig(@import("config").minimal.chain_config, .electra, 0);
-    const state_ptr = try gen.generateElectraState(allocator, &pool, chain_config, 8);
-    defer {
-        state_ptr.deinit();
-        allocator.destroy(state_ptr);
+    {
+        // seed_state_validators_bytes length is not a multiple of VALIDATOR_BYTES_SIZE
+        const seed_validators_node = try validatorsNodeId(state_ptr);
+        const good_new_bytes = [_]u8{0} ** (ssz_bytes.VALIDATOR_BYTES_SIZE * 2);
+        const bad_seed_bytes = [_]u8{0} ** (ssz_bytes.VALIDATOR_BYTES_SIZE + 1);
+        try std.testing.expectError(
+            error.InvalidSize,
+            loadValidators(allocator, StateST, migrated_view, &pool, seed_validators_node, good_new_bytes[0..], bad_seed_bytes[0..]),
+        );
     }
 
-    const StateST = types.electra.BeaconState;
-    const migrated_view = state_ptr.castToFork(.electra).inner;
-    const seed_scores_node = try inactivityScoresNodeId(state_ptr);
-    const bad_bytes = [_]u8{0} ** (INACTIVITY_SCORE_SIZE + 1);
-    try std.testing.expectError(
-        error.InvalidSize,
-        loadInactivityScores(allocator, StateST, migrated_view, &pool, seed_scores_node, bad_bytes[0..]),
-    );
+    {
+        // inactivity scores bytes length is not a multiple of INACTIVITY_SCORE_SIZE
+        const seed_scores_node = try inactivityScoresNodeId(state_ptr);
+        const bad_bytes = [_]u8{0} ** (INACTIVITY_SCORE_SIZE + 1);
+        try std.testing.expectError(
+            error.InvalidSize,
+            loadInactivityScores(allocator, StateST, migrated_view, &pool, seed_scores_node, bad_bytes[0..]),
+        );
+    }
 }

--- a/src/state_transition/load_state.zig
+++ b/src/state_transition/load_state.zig
@@ -455,9 +455,14 @@ fn loadValidatorWithSeedReuse(
     seed_validator_bytes: []const u8,
     new_validator_bytes: []const u8,
 ) !*types.phase0.Validator.TreeView {
-    // Pubkey: [0..48), withdrawal_credentials: [48..80)
-    const pubkey_same = std.mem.eql(u8, new_validator_bytes[0..48], seed_validator_bytes[0..48]);
-    const withdrawal_same = std.mem.eql(u8, new_validator_bytes[48..80], seed_validator_bytes[48..80]);
+    const Validator = types.phase0.Validator;
+    const PUBKEY_OFFSET = comptime Validator.field_offsets[Validator.getFieldIndex("pubkey")];
+    const PUBKEY_END = PUBKEY_OFFSET + comptime Validator.getFieldType("pubkey").fixed_size;
+    const WCRED_OFFSET = comptime Validator.field_offsets[Validator.getFieldIndex("withdrawal_credentials")];
+    const WCRED_END = WCRED_OFFSET + comptime Validator.getFieldType("withdrawal_credentials").fixed_size;
+
+    const pubkey_same = std.mem.eql(u8, new_validator_bytes[PUBKEY_OFFSET..PUBKEY_END], seed_validator_bytes[PUBKEY_OFFSET..PUBKEY_END]);
+    const withdrawal_same = std.mem.eql(u8, new_validator_bytes[WCRED_OFFSET..WCRED_END], seed_validator_bytes[WCRED_OFFSET..WCRED_END]);
 
     if (!pubkey_same) {
         if (!withdrawal_same) {
@@ -610,8 +615,11 @@ test "loadValidatorWithSeedReuse: reuse vs rebuild" {
     _ = try seed_validator.serializeIntoBytes(&seed_validator_bytes);
 
     var new_validator_bytes = seed_validator_bytes;
-    // Modify only withdrawal_credentials ([48..80))
-    @memset(new_validator_bytes[48..80], 0x11);
+    // Modify only withdrawal_credentials so the reuse path keeps pubkey but rebuilds wcred.
+    const Validator = types.phase0.Validator;
+    const WCRED_OFFSET = comptime Validator.field_offsets[Validator.getFieldIndex("withdrawal_credentials")];
+    const WCRED_END = WCRED_OFFSET + comptime Validator.getFieldType("withdrawal_credentials").fixed_size;
+    @memset(new_validator_bytes[WCRED_OFFSET..WCRED_END], 0x11);
 
     const new_validator = try loadValidatorWithSeedReuse(
         allocator,

--- a/src/state_transition/load_state.zig
+++ b/src/state_transition/load_state.zig
@@ -74,6 +74,7 @@ fn deserializeBeaconStateTreeViewWithSeedOverrides(
         } else blk: {
             const node_id = try ScoresType.tree.deserializeFromBytes(pool, inactivity_scores_bytes);
             errdefer pool.unref(node_id);
+
             break :blk node_id;
         };
 
@@ -286,6 +287,7 @@ fn buildScoresDiffContext(
     const old_size = try migrated_scores.serializedSize();
     const old_bytes = try allocator.alloc(u8, old_size);
     errdefer allocator.free(old_bytes);
+
     _ = try migrated_scores.serializeIntoBytes(old_bytes);
 
     return .{
@@ -339,6 +341,7 @@ fn syncScoresLength(
             &types.altair.InactivityScores.default_value,
         );
         errdefer pool.unref(empty_root);
+
         const empty_scores = try types.altair.InactivityScores.TreeView.init(allocator, pool, empty_root);
         migrated_scores.deinit();
         return empty_scores;
@@ -376,6 +379,7 @@ fn applyModifiedValidators(
             new_bytes,
         );
         errdefer new_validator.deinit();
+
         try migrated_validators.set(i, new_validator);
     }
 }
@@ -399,6 +403,7 @@ fn appendNewValidators(
         var v: ?*types.phase0.Validator.TreeView = blk: {
             const root = try types.phase0.Validator.tree.deserializeFromBytes(pool, new_bytes);
             errdefer pool.unref(root);
+
             break :blk try types.phase0.Validator.TreeView.init(allocator, pool, root);
         };
         errdefer if (v) |vv| vv.deinit();
@@ -422,6 +427,7 @@ fn trimValidators(
             &types.phase0.Validators.default_value,
         );
         errdefer pool.unref(empty_root);
+
         const empty_validators = try types.phase0.Validators.TreeView.init(allocator, pool, empty_root);
         migrated_validators.deinit();
         return empty_validators;
@@ -468,6 +474,7 @@ fn loadValidatorWithSeedReuse(
         if (!withdrawal_same) {
             const root = try types.phase0.Validator.tree.deserializeFromBytes(pool, new_validator_bytes);
             errdefer pool.unref(root);
+
             return try types.phase0.Validator.TreeView.init(allocator, pool, root);
         }
     }
@@ -504,6 +511,7 @@ fn loadValidatorWithSeedReuse(
 
     const root = try Node.fillWithContents(pool, &nodes, types.phase0.Validator.chunk_depth);
     errdefer pool.unref(root);
+
     owned_len = 0;
     return try types.phase0.Validator.TreeView.init(allocator, pool, root);
 }
@@ -648,6 +656,7 @@ test "loadValidatorWithSeedReuse: reuse vs rebuild" {
     const fresh_root = try types.phase0.Validator.tree.deserializeFromBytes(&pool, new_validator_bytes[0..]);
     var fresh_validator = try types.phase0.Validator.TreeView.init(allocator, &pool, fresh_root);
     defer fresh_validator.deinit();
+
     try std.testing.expectEqualSlices(u8, try fresh_validator.hashTreeRoot(), try new_validator.hashTreeRoot());
 }
 
@@ -802,10 +811,12 @@ test "loadState scenarios" {
 
         var migrated_validators = try types.phase0.Validators.TreeView.init(allocator, out.state.nodePool(), try validatorsNodeId(&out.state));
         defer migrated_validators.deinit();
+
         try std.testing.expectEqual(case.expect_validators_len, try migrated_validators.length());
 
         var scores = try types.altair.InactivityScores.TreeView.init(allocator, out.state.nodePool(), try inactivityScoresNodeId(&out.state));
         defer scores.deinit();
+
         try std.testing.expectEqual(case.expect_scores_len, try scores.length());
 
         if (case.expect_score) |exp| {
@@ -826,6 +837,7 @@ test "loadState scenarios" {
 
         var fresh_state = try AnyBeaconState.deserialize(allocator, &pool, .electra, mutated_bytes);
         defer fresh_state.deinit();
+
         try std.testing.expectEqualSlices(u8, try fresh_state.hashTreeRoot(), try out.state.hashTreeRoot());
     }
 }
@@ -860,6 +872,7 @@ test "diff helpers cases" {
             const total = case.count * types.phase0.Validator.fixed_size;
             const old_bytes = try allocator.alloc(u8, total);
             defer allocator.free(old_bytes);
+
             const new_bytes = try allocator.alloc(u8, total);
             defer allocator.free(new_bytes);
 
@@ -881,6 +894,7 @@ test "diff helpers cases" {
             const total = case.count * INACTIVITY_SCORE_SIZE;
             const old_bytes = try allocator.alloc(u8, total);
             defer allocator.free(old_bytes);
+
             const new_bytes = try allocator.alloc(u8, total);
             defer allocator.free(new_bytes);
 

--- a/src/state_transition/load_state.zig
+++ b/src/state_transition/load_state.zig
@@ -43,9 +43,7 @@ pub fn loadState(
 ) !MigrateStateOutput {
     const fork = try ssz_bytes.getForkFromStateBytes(config, state_bytes);
     const seed_fork = config.forkSeq(try seed_state.slot());
-    const pool = switch (seed_state.*) {
-        inline else => |s| s.pool,
-    };
+    const pool = seed_state.pool();
 
     return switch (fork) {
         inline else => |f| try loadStateForFork(allocator, pool, f, seed_fork, seed_state, ForkTypes(f).BeaconState, state_bytes, seed_validators_bytes),
@@ -434,18 +432,12 @@ fn inactivityScoresNodeId(state: *AnyBeaconState) !Node.Id {
 
 fn validatorsViewOwned(allocator: Allocator, state: *AnyBeaconState) !*types.phase0.Validators.TreeView {
     const root = try validatorsNodeId(state);
-    const pool = switch (state.*) {
-        inline else => |s| s.pool,
-    };
-    return try types.phase0.Validators.TreeView.init(allocator, pool, root);
+    return try types.phase0.Validators.TreeView.init(allocator, state.pool(), root);
 }
 
 fn inactivityScoresViewOwned(allocator: Allocator, state: *AnyBeaconState) !*types.altair.InactivityScores.TreeView {
     const root = try inactivityScoresNodeId(state);
-    const pool = switch (state.*) {
-        inline else => |s| s.pool,
-    };
-    return try types.altair.InactivityScores.TreeView.init(allocator, pool, root);
+    return try types.altair.InactivityScores.TreeView.init(allocator, state.pool(), root);
 }
 
 fn loadValidatorWithSeedReuse(

--- a/src/state_transition/root.zig
+++ b/src/state_transition/root.zig
@@ -105,9 +105,14 @@ const EpochShuffling = @import("./utils/epoch_shuffling.zig");
 pub const calculateShufflingDecisionRoot = EpochShuffling.calculateShufflingDecisionRoot;
 pub const processProposerLookahead = @import("./epoch/process_proposer_lookahead.zig").processProposerLookahead;
 
+const load_state_mod = @import("load_state.zig");
+pub const loadState = load_state_mod.loadState;
+pub const MigrateStateOutput = load_state_mod.MigrateStateOutput;
+
 test {
     testing.refAllDecls(@This());
     testing.refAllDecls(seed);
     testing.refAllDecls(state_transition);
     testing.refAllDecls(EpochShuffling);
+    testing.refAllDecls(load_state_mod);
 }

--- a/src/state_transition/root.zig
+++ b/src/state_transition/root.zig
@@ -105,14 +105,14 @@ const EpochShuffling = @import("./utils/epoch_shuffling.zig");
 pub const calculateShufflingDecisionRoot = EpochShuffling.calculateShufflingDecisionRoot;
 pub const processProposerLookahead = @import("./epoch/process_proposer_lookahead.zig").processProposerLookahead;
 
-const load_state_mod = @import("load_state.zig");
-pub const loadState = load_state_mod.loadState;
-pub const MigrateStateOutput = load_state_mod.MigrateStateOutput;
+const load_state = @import("load_state.zig");
+pub const loadState = load_state.loadState;
+pub const MigrateStateOutput = load_state.MigrateStateOutput;
 
 test {
     testing.refAllDecls(@This());
     testing.refAllDecls(seed);
     testing.refAllDecls(state_transition);
     testing.refAllDecls(EpochShuffling);
-    testing.refAllDecls(load_state_mod);
+    testing.refAllDecls(load_state);
 }

--- a/src/state_transition/ssz_bytes.zig
+++ b/src/state_transition/ssz_bytes.zig
@@ -1,0 +1,48 @@
+const std = @import("std");
+
+const types = @import("consensus_types");
+const ForkSeq = @import("config").ForkSeq;
+const BeaconConfig = @import("config").BeaconConfig;
+
+const Slot = types.primitive.Slot.Type;
+
+///
+/// 8 + 32 = 40
+///
+/// ```
+/// class BeaconState(Container):
+///   genesis_time: uint64 [fixed - 8 bytes]
+///   genesis_validators_root: Root [fixed - 32 bytes]
+///   slot: Slot [fixed - 8 bytes]
+///   ...
+/// ```
+const SLOT_BYTES_POSITION_IN_STATE: usize = 40;
+
+/// Slot is `uint64`.
+const SLOT_BYTE_COUNT: usize = 8;
+
+/// 48 + 32 + 8 + 1 + 8 + 8 + 8 + 8 = 121
+///
+/// ```
+/// class Validator(Container):
+///   pubkey: BLSPubkey [fixed - 48 bytes]
+///   withdrawal_credentials: Bytes32 [fixed - 32 bytes]
+///   effective_balance: Gwei [fixed - 8 bytes]
+///   slashed: boolean [fixed - 1 byte]
+///   # Status epochs
+///   activation_eligibility_epoch: Epoch [fixed - 8 bytes]
+///   activation_epoch: Epoch [fixed - 8 bytes]
+///   exit_epoch: Epoch [fixed - 8 bytes]
+///   withdrawable_epoch: Epoch [fixed - 8 bytes]
+/// ```
+pub const VALIDATOR_BYTES_SIZE: usize = 121;
+
+pub fn getStateSlotFromBytes(bytes: []const u8) !Slot {
+    if (bytes.len < SLOT_BYTES_POSITION_IN_STATE + SLOT_BYTE_COUNT) return error.InvalidSize;
+    return @intCast(std.mem.readInt(u64, bytes[SLOT_BYTES_POSITION_IN_STATE .. SLOT_BYTES_POSITION_IN_STATE + SLOT_BYTE_COUNT], .little));
+}
+
+pub fn getForkFromStateBytes(config: *const BeaconConfig, bytes: []const u8) !ForkSeq {
+    const slot = try getStateSlotFromBytes(bytes);
+    return config.forkSeq(slot);
+}

--- a/src/state_transition/ssz_bytes.zig
+++ b/src/state_transition/ssz_bytes.zig
@@ -18,9 +18,6 @@ const Slot = types.primitive.Slot.Type;
 /// ```
 const SLOT_BYTES_POSITION_IN_STATE: usize = 40;
 
-/// SSZ-serialized size of a phase0 Validator. Stable across forks.
-pub const VALIDATOR_BYTES_SIZE: usize = types.phase0.Validator.fixed_size;
-
 pub fn getStateSlotFromBytes(bytes: []const u8) !Slot {
     const slot_size = types.primitive.Slot.fixed_size;
     if (bytes.len < SLOT_BYTES_POSITION_IN_STATE + slot_size) return error.InvalidSize;

--- a/src/state_transition/ssz_bytes.zig
+++ b/src/state_transition/ssz_bytes.zig
@@ -21,21 +21,8 @@ const SLOT_BYTES_POSITION_IN_STATE: usize = 40;
 /// Slot is `uint64`.
 const SLOT_BYTE_COUNT: usize = 8;
 
-/// 48 + 32 + 8 + 1 + 8 + 8 + 8 + 8 = 121
-///
-/// ```
-/// class Validator(Container):
-///   pubkey: BLSPubkey [fixed - 48 bytes]
-///   withdrawal_credentials: Bytes32 [fixed - 32 bytes]
-///   effective_balance: Gwei [fixed - 8 bytes]
-///   slashed: boolean [fixed - 1 byte]
-///   # Status epochs
-///   activation_eligibility_epoch: Epoch [fixed - 8 bytes]
-///   activation_epoch: Epoch [fixed - 8 bytes]
-///   exit_epoch: Epoch [fixed - 8 bytes]
-///   withdrawable_epoch: Epoch [fixed - 8 bytes]
-/// ```
-pub const VALIDATOR_BYTES_SIZE: usize = 121;
+/// SSZ-serialized size of a phase0 Validator. Stable across forks.
+pub const VALIDATOR_BYTES_SIZE: usize = types.phase0.Validator.fixed_size;
 
 pub fn getStateSlotFromBytes(bytes: []const u8) !Slot {
     if (bytes.len < SLOT_BYTES_POSITION_IN_STATE + SLOT_BYTE_COUNT) return error.InvalidSize;

--- a/src/state_transition/ssz_bytes.zig
+++ b/src/state_transition/ssz_bytes.zig
@@ -18,15 +18,13 @@ const Slot = types.primitive.Slot.Type;
 /// ```
 const SLOT_BYTES_POSITION_IN_STATE: usize = 40;
 
-/// Slot is `uint64`.
-const SLOT_BYTE_COUNT: usize = 8;
-
 /// SSZ-serialized size of a phase0 Validator. Stable across forks.
 pub const VALIDATOR_BYTES_SIZE: usize = types.phase0.Validator.fixed_size;
 
 pub fn getStateSlotFromBytes(bytes: []const u8) !Slot {
-    if (bytes.len < SLOT_BYTES_POSITION_IN_STATE + SLOT_BYTE_COUNT) return error.InvalidSize;
-    return @intCast(std.mem.readInt(u64, bytes[SLOT_BYTES_POSITION_IN_STATE .. SLOT_BYTES_POSITION_IN_STATE + SLOT_BYTE_COUNT], .little));
+    const slot_size = types.primitive.Slot.fixed_size;
+    if (bytes.len < SLOT_BYTES_POSITION_IN_STATE + slot_size) return error.InvalidSize;
+    return std.mem.readInt(u64, bytes[SLOT_BYTES_POSITION_IN_STATE .. SLOT_BYTES_POSITION_IN_STATE + slot_size], .little);
 }
 
 pub fn getForkFromStateBytes(config: *const BeaconConfig, bytes: []const u8) !ForkSeq {

--- a/src/state_transition/ssz_container.zig
+++ b/src/state_transition/ssz_container.zig
@@ -1,0 +1,88 @@
+const std = @import("std");
+const Allocator = std.mem.Allocator;
+
+const ssz = @import("ssz");
+const Node = @import("persistent_merkle_tree").Node;
+
+/// Deserialize an SSZ container into its TreeView, while ignoring (not deserializing) selected
+/// fields by name and overriding them with precomputed subtrees.
+///
+/// `overrides` should be a struct literal where field names match container field names,
+/// e.g. `. { .validators = seed_validators_node }`.
+pub fn deserializeContainerOverrideFieldsWithRanges(
+    allocator: Allocator,
+    pool: *Node.Pool,
+    comptime ContainerST: type,
+    bytes: []const u8,
+    ranges: *const [ContainerST.fields.len][2]usize,
+    overrides: anytype,
+) !*ContainerST.TreeView {
+    var nodes: [ContainerST.chunk_count]Node.Id = undefined;
+    var owned_nodes: [ContainerST.chunk_count]Node.Id = undefined;
+    var owned_len: usize = 0;
+
+    // Important: `deserializeFromBytes` returns nodes with refcount 0. If we error out before
+    // they're anchored under a committed root, they must be `unref`'d to avoid leaking Pool nodes.
+    // Once container root is created, it becomes the sole owner: unref'ing the root is enough
+    // and unref'ing child nodes again would be a double-unref.
+    errdefer {
+        var i: usize = 0;
+        while (i < owned_len) : (i += 1) pool.unref(owned_nodes[i]);
+    }
+
+    inline for (ContainerST.fields, 0..) |field, i| {
+        if (comptime @hasField(@TypeOf(overrides), field.name)) {
+            nodes[i] = @field(overrides, field.name);
+            continue;
+        }
+
+        const start = ranges[i][0];
+        const end = ranges[i][1];
+        const field_bytes = bytes[start..end];
+
+        nodes[i] = try field.type.tree.deserializeFromBytes(pool, field_bytes);
+        owned_nodes[owned_len] = nodes[i];
+        owned_len += 1;
+    }
+
+    const root = try Node.fillWithContents(pool, &nodes, ContainerST.chunk_depth);
+    errdefer pool.unref(root);
+    owned_len = 0;
+
+    return try ContainerST.TreeView.init(allocator, pool, root);
+}
+
+test "deserializeContainerOverrideFields... cleans up pool nodes on error" {
+    const allocator = std.testing.allocator;
+
+    var pool = try Node.Pool.init(allocator, 64);
+    defer pool.deinit();
+
+    const U64 = ssz.UintType(64);
+    const U64List = ssz.FixedListType(U64, 4);
+    const Fields = struct {
+        a: U64,
+        b: U64List,
+    };
+    const ContainerST = ssz.VariableContainerType(Fields);
+
+    // Valid offsets for `b`, but `b` payload length is 1 which is not divisible by 8.
+    var bytes: [13]u8 = undefined;
+    @memset(&bytes, 0);
+    std.mem.writeInt(u32, bytes[8..12], 12, .little);
+
+    const baseline_in_use = pool.getNodesInUse();
+    const ranges = try ContainerST.readFieldRanges(bytes[0..]);
+    try std.testing.expectError(
+        error.UnexpectedRemainder,
+        deserializeContainerOverrideFieldsWithRanges(
+            allocator,
+            &pool,
+            ContainerST,
+            bytes[0..],
+            &ranges,
+            .{},
+        ),
+    );
+    try std.testing.expectEqual(baseline_in_use, pool.getNodesInUse());
+}


### PR DESCRIPTION
**Motivation**

It need `loadState` API to integrate state-transition-z to lodestar

**Description**

- Implement `loadState()` migration semantics aligned with Lodestar: migrate a new BeaconState from SSZ bytes using a seed state, returning the migrated state plus the list of modified validator indices.
- Optimize validator/inactivity_scores handling by reusing seed subtrees where bytes are unchanged, and by computing modified indices via recursive byte-level diff (avoids full SSZ decoding for comparison).

Fix #159 