### PR TITLE
refactor: rm `utils/sha256.zig`

### DIFF
--- a/src/state_transition/block/process_bls_to_execution_change.zig
+++ b/src/state_transition/block/process_bls_to_execution_change.zig
@@ -4,8 +4,8 @@ const types = @import("consensus_types");
 const Root = types.primitive.Root.Type;
 const SignedBLSToExecutionChange = types.capella.SignedBLSToExecutionChange.Type;
 const c = @import("constants");
-const digest = @import("../utils/sha256.zig").digest;
 const verifyBlsToExecutionChangeSignature = @import("../signature_sets/bls_to_execution_change.zig").verifyBlsToExecutionChangeSignature;
+const Sha256 = std.crypto.hash.sha2.Sha256;
 
 pub fn processBlsToExecutionChange(cached_state: *CachedBeaconState, signed_bls_to_execution_change: *const SignedBLSToExecutionChange) !void {
     const address_change = signed_bls_to_execution_change.message;
@@ -41,7 +41,7 @@ pub fn isValidBlsToExecutionChange(cached_state: *CachedBeaconState, signed_bls_
     }
 
     var digest_credentials: Root = undefined;
-    digest(&address_change.from_bls_pubkey, &digest_credentials);
+    Sha256.hash(&address_change.from_bls_pubkey, &digest_credentials, .{});
     // Set the BLS_WITHDRAWAL_PREFIX on the digest_credentials for direct match
     digest_credentials[0] = c.BLS_WITHDRAWAL_PREFIX;
     if (!std.mem.eql(u8, withdrawal_credentials, &digest_credentials)) {

--- a/src/state_transition/block/process_randao.zig
+++ b/src/state_transition/block/process_randao.zig
@@ -9,7 +9,7 @@ const Body = @import("../types/block.zig").Body;
 const Bytes32 = types.primitive.Bytes32.Type;
 const getRandaoMix = @import("../utils/seed.zig").getRandaoMix;
 const verifyRandaoSignature = @import("../signature_sets/randao.zig").verifyRandaoSignature;
-const digest = @import("../utils/sha256.zig").digest;
+const Sha256 = std.crypto.hash.sha2.Sha256;
 
 pub fn processRandao(
     cached_state: *CachedBeaconState,
@@ -31,7 +31,7 @@ pub fn processRandao(
 
     // mix in RANDAO reveal
     var randao_reveal_digest: [32]u8 = undefined;
-    digest(&randao_reveal, &randao_reveal_digest);
+    Sha256.hash(&randao_reveal, &randao_reveal_digest, .{});
 
     var randao_mix: [32]u8 = undefined;
     const current_mix = try getRandaoMix(state, epoch);

--- a/src/state_transition/utils/aggregator.zig
+++ b/src/state_transition/utils/aggregator.zig
@@ -2,8 +2,8 @@ const std = @import("std");
 const types = @import("consensus_types");
 const preset = @import("preset").preset;
 const c = @import("constants");
-const digest = @import("./sha256.zig").digest;
 const BLSSignature = types.primitive.BLSSignature.Type;
+const Sha256 = std.crypto.hash.sha2.Sha256;
 const ZERO_BIGINT = 0;
 
 pub fn isSyncCommitteeAggregator(selection_proof: BLSSignature) bool {
@@ -18,7 +18,7 @@ pub fn isAggregatorFromCommitteeLength(committee_len: usize, slot_signature: BLS
 
 pub fn isSelectionProofValid(sig: BLSSignature, modulo: u64) bool {
     var root: [32]u8 = undefined;
-    digest(sig.toBytes(), &root);
+    Sha256.hash(sig.toBytes(), &root, .{});
     const value = std.mem.readInt(u64, root[0..8], .little);
     return (value % modulo) == ZERO_BIGINT;
 }

--- a/src/state_transition/utils/seed.zig
+++ b/src/state_transition/utils/seed.zig
@@ -3,7 +3,7 @@ const Allocator = std.mem.Allocator;
 const types = @import("consensus_types");
 const preset = @import("preset").preset;
 const BeaconState = @import("../types/beacon_state.zig").BeaconState;
-const digest = @import("./sha256.zig").digest;
+const Sha256 = std.crypto.hash.sha2.Sha256;
 const Epoch = types.primitive.Epoch.Type;
 const Bytes32 = types.primitive.Bytes32.Type;
 const DomainType = types.primitive.DomainType.Type;
@@ -30,7 +30,7 @@ pub fn computeProposers(allocator: Allocator, fork_seq: ForkSeq, epoch_seed: [32
         std.mem.copyForwards(u8, buffer[0..32], epoch_seed[0..]);
         std.mem.copyForwards(u8, buffer[32..], slot_buf[0..]);
         var seed: [32]u8 = undefined;
-        digest(buffer[0..], &seed);
+        Sha256.hash(buffer[0..], &seed, .{});
 
         const rand_byte_count: ByteCount = if (fork_seq.gte(.electra)) ByteCount.Two else ByteCount.One;
         const max_effective_balance: u64 = if (fork_seq.gte(.electra)) preset.MAX_EFFECTIVE_BALANCE_ELECTRA else preset.MAX_EFFECTIVE_BALANCE;
@@ -76,5 +76,5 @@ pub fn getSeed(state: *BeaconState, epoch: Epoch, domain_type: DomainType, out: 
     std.mem.copyForwards(u8, buffer[0..domain_type.len], domain_type[0..]);
     std.mem.copyForwards(u8, buffer[domain_type.len..(domain_type.len + 8)], epoch_buf[0..]);
     std.mem.copyForwards(u8, buffer[(domain_type.len + 8)..], mix[0..]);
-    digest(buffer[0..], out);
+    Sha256.hash(buffer[0..], out, .{});
 }

--- a/src/state_transition/utils/sha256.zig
+++ b/src/state_transition/utils/sha256.zig
@@ -1,6 +1,0 @@
-const std = @import("std");
-const Sha256 = std.crypto.hash.sha2.Sha256;
-
-pub fn digest(data: []const u8, out: *[32]u8) void {
-    Sha256.hash(data, out, .{});
-}

--- a/src/state_transition/utils/verify_merkle_branch.zig
+++ b/src/state_transition/utils/verify_merkle_branch.zig
@@ -1,6 +1,6 @@
 const std = @import("std");
 const types = @import("consensus_types");
-const digest = @import("./sha256.zig").digest;
+const Sha256 = std.crypto.hash.sha2.Sha256;
 const Root = types.primitive.Root.Type;
 
 pub fn verifyMerkleBranch(leaf: Root, proof: *const [33]Root, depth: usize, index: usize, root: Root) bool {
@@ -14,7 +14,7 @@ pub fn verifyMerkleBranch(leaf: Root, proof: *const [33]Root, depth: usize, inde
             @memcpy(tmp[0..32], &value);
             @memcpy(tmp[32..], &proof[i]);
         }
-        digest(&tmp, &value);
+        Sha256.hash(&tmp, &value, .{});
     }
     return std.mem.eql(u8, &root, &value);
 }

--- a/src/state_transition/utils_test_root.zig
+++ b/src/state_transition/utils_test_root.zig
@@ -26,7 +26,6 @@ test "state_transition utils" {
     _ = @import("utils/reference_count.zig");
     _ = @import("utils/root_cache.zig");
     _ = @import("utils/seed.zig");
-    _ = @import("utils/sha256.zig");
     _ = @import("utils/shuffle.zig");
     _ = @import("utils/signature_sets.zig");
     _ = @import("utils/signing_root.zig");


### PR DESCRIPTION
We were just re-exporting std sha256, so let's just use it directly.

part of #169 