### PR TITLE
fix: make `verify_signatures` default to `false` for `TransitionOpt`

### DIFF
--- a/bindings/src/index.ts
+++ b/bindings/src/index.ts
@@ -293,7 +293,7 @@ type Bindings = {
   deinit: () => void;
 };
 
-import { join } from "node:path";
-import { requireNapiLibrary } from "@chainsafe/zapi";
+import {join} from "node:path";
+import {requireNapiLibrary} from "@chainsafe/zapi";
 
 export default requireNapiLibrary(join(import.meta.dirname, "../..")) as Bindings;

--- a/bindings/src/index.ts
+++ b/bindings/src/index.ts
@@ -64,7 +64,7 @@ interface TransitionOpts {
   verifyStateRoot?: boolean;
   /** Verify the proposer signature on the signed block. Default: true. */
   verifyProposer?: boolean;
-  /** Verify BLS signatures during block processing. Default: false. */
+  /** Verify BLS signatures during block processing. Default: true. */
   verifySignatures?: boolean;
   /** Clone the state with transfer cache for memory efficiency. Default: true. */
   transferCache?: boolean;
@@ -293,7 +293,7 @@ type Bindings = {
   deinit: () => void;
 };
 
-import {join} from "node:path";
-import {requireNapiLibrary} from "@chainsafe/zapi";
+import { join } from "node:path";
+import { requireNapiLibrary } from "@chainsafe/zapi";
 
 export default requireNapiLibrary(join(import.meta.dirname, "../..")) as Bindings;

--- a/src/state_transition/state_transition.zig
+++ b/src/state_transition/state_transition.zig
@@ -157,7 +157,8 @@ pub fn processSlots(
 pub const TransitionOpt = struct {
     verify_state_root: bool = true,
     verify_proposer: bool = true,
-    verify_signatures: bool = false,
+    /// NOTE: verifying BLS signatures is expensive - make sure to turn this off for tests.
+    verify_signatures: bool = true,
     transfer_cache: bool = true,
 };
 
@@ -287,7 +288,7 @@ const Node = @import("persistent_merkle_tree").Node;
 
 test "state transition - electra block" {
     const test_cases = [_]TestCase{
-        .{ .transition_opt = .{ .verify_signatures = true }, .expect_error = true },
+        .{ .transition_opt = .{}, .expect_error = true },
         .{ .transition_opt = .{ .verify_signatures = false, .verify_proposer = true }, .expect_error = true },
         .{ .transition_opt = .{ .verify_signatures = false, .verify_proposer = false, .verify_state_root = true }, .expect_error = true },
         // this runs through epoch transition + process block without verifications


### PR DESCRIPTION
Verifying BLS signatures is expensive, but we should make verifying them the default behaviour since it's saner and safer. Make it opt out to turn it off.

Followup to #210 