### PR TITLE
fix(state-transition): fix race in `putPubkeysAtIndices`

### DIFF
--- a/src/state_transition/cache/pubkey_cache.zig
+++ b/src/state_transition/cache/pubkey_cache.zig
@@ -42,6 +42,10 @@ fn uncompressPubkeys(
     index_to_pubkey: *Index2PubkeyCache,
     uncompress_error: *std.atomic.Value(bool),
 ) void {
+    std.debug.assert(start_index <= end_index_exclusive);
+    std.debug.assert(end_index_exclusive <= validators.len);
+    std.debug.assert(end_index_exclusive <= index_to_pubkey.items.len);
+
     for (start_index..end_index_exclusive) |i| {
         if (uncompress_error.load(.monotonic)) return;
         const pubkey = &validators[i].pubkey;
@@ -103,7 +107,7 @@ pub fn syncPubkeysParallel(
         return error.InvalidPubkey;
     }
 
-    // update the shared map in single thread
+    // Update the shared map in single thread
     for (old_len..new_count) |j| {
         pubkey_to_index.putAssumeCapacity(validators[j].pubkey, @intCast(j));
     }

--- a/src/state_transition/cache/pubkey_cache.zig
+++ b/src/state_transition/cache/pubkey_cache.zig
@@ -35,11 +35,20 @@ pub fn syncPubkeys(
     }
 }
 
-fn putPubkeysAtIndices(start_index: usize, end_index_exclusive: usize, validators: []const Validator, pubkey_to_index: *PubkeyIndexMap, index_to_pubkey: *Index2PubkeyCache) void {
+fn uncompressPubkeys(
+    start_index: usize,
+    end_index_exclusive: usize,
+    validators: []const Validator,
+    index_to_pubkey: *Index2PubkeyCache,
+    uncompress_error: *std.atomic.Value(bool),
+) void {
     for (start_index..end_index_exclusive) |i| {
+        if (uncompress_error.load(.monotonic)) return;
         const pubkey = &validators[i].pubkey;
-        pubkey_to_index.putAssumeCapacity(pubkey.*, @intCast(i));
-        index_to_pubkey.items[i] = blst.PublicKey.uncompress(pubkey) catch unreachable;
+        index_to_pubkey.items[i] = blst.PublicKey.uncompress(pubkey) catch {
+            uncompress_error.store(true, .release);
+            return;
+        };
     }
 }
 
@@ -69,6 +78,7 @@ pub fn syncPubkeysParallel(
     defer thread_pool.deinit();
 
     var wg = std.Thread.WaitGroup{};
+    var uncompress_error = std.atomic.Value(bool).init(false);
 
     var i = old_len;
     const batch_size = 1000;
@@ -76,18 +86,27 @@ pub fn syncPubkeysParallel(
     while (i < new_count) : (i += batch_size) {
         thread_pool.spawnWg(
             &wg,
-            putPubkeysAtIndices,
+            uncompressPubkeys,
             .{
                 i,
                 @min(i + batch_size, new_count),
                 validators,
-                pubkey_to_index,
                 index_to_pubkey,
+                &uncompress_error,
             },
         );
     }
 
     wg.wait();
+
+    if (uncompress_error.load(.acquire)) {
+        return error.InvalidPubkey;
+    }
+
+    // update the shared map in single thread
+    for (old_len..new_count) |j| {
+        pubkey_to_index.putAssumeCapacity(validators[j].pubkey, @intCast(j));
+    }
 }
 
 // TODO: unit tests

--- a/src/state_transition/cache/pubkey_cache.zig
+++ b/src/state_transition/cache/pubkey_cache.zig
@@ -75,6 +75,8 @@ pub fn syncPubkeysParallel(
     }
 
     try index_to_pubkey.resize(new_count);
+    errdefer index_to_pubkey.shrinkRetainingCapacity(old_len);
+
     try pubkey_to_index.ensureTotalCapacity(@intCast(new_count));
 
     var thread_pool: std.Thread.Pool = undefined;


### PR DESCRIPTION
**Motivation**

`syncPubkeysParallel` has two issues: multiple threads concurrently call `putAssumeCapacity` on a shared `std.AutoHashMap` (data race), and catch unreachable in thread workers aborts the process on malformed pubkeys instead of propagating errors.

**Description**
- Move HashMap inserts to the main thread after wg.wait() — thread workers now only do blst.PublicKey.uncompress into non-overlapping `index_to_pubkey` slots, it may be a little perf impact
- Replace catch unreachable with an atomic error flag to propagate error.InvalidPubkey to the caller