### PR TITLE
feat: mt verify with benchmarks

### DIFF
--- a/bindings/napi/blst.zig
+++ b/bindings/napi/blst.zig
@@ -507,8 +507,8 @@ pub fn blst_verify(env: napi.Env, cb: napi.CallbackInfo(5)) !napi.Value {
 // All per-dispatch buffers (pairing contexts, scratch arrays) are preallocated in the pool.
 // For n_elems <= SCRATCH_MAX, zero per-call heap allocations are needed.
 
-const RAND_BITS: usize = 64;
-const SCRATCH_MAX: usize = 512;
+const RAND_BITS: u32 = 64;
+const SCRATCH_MAX: u32 = 512;
 
 const WorkItem = union(enum) {
     aggregate_verify: *AggVerifyJob,
@@ -634,6 +634,7 @@ const PairingPool = struct {
 
     fn execAggVerify(job: *AggVerifyJob, id: usize) void {
         var pairing = Pairing.init(@ptrCast(@alignCast(&job.pairing_bufs[id])), true, job.dst);
+
         var did_work = false;
 
         while (!job.err_flag.load(.acquire)) {
@@ -699,6 +700,8 @@ const PairingPool = struct {
     }
 
     fn dispatch(pool: *PairingPool, item: WorkItem, n_active: usize) void {
+        std.debug.assert(n_active <= pool.n_workers);
+
         const n_bg = if (n_active > 1) n_active - 1 else 0;
         for (0..n_bg) |i| {
             pool.work_done[i + 1].reset();

--- a/bindings/napi/blst.zig
+++ b/bindings/napi/blst.zig
@@ -1061,6 +1061,13 @@ pub fn blst_aggregatePublicKeys(env: napi.Env, cb: napi.CallbackInfo(2)) !napi.V
 
     if (pks_len == 0) {
         return error.EmptyPublicKeyArray;
+    } else if (pks_len == 1) {
+        const pk_value_in = try pks_array.getElement(0);
+        const pk_in = try env.unwrap(PublicKey, pk_value_in);
+        const pk_value = try newPublicKeyInstance(env);
+        const pk = try env.unwrap(PublicKey, pk_value);
+        pk.* = pk_in.*;
+        return pk_value;
     }
 
     const pks = try allocator.alloc(PublicKey, pks_len);

--- a/bindings/napi/blst.zig
+++ b/bindings/napi/blst.zig
@@ -502,6 +502,316 @@ pub fn blst_verify(env: napi.Env, cb: napi.CallbackInfo(5)) !napi.Value {
     return try env.getBoolean(true);
 }
 
+// --- Persistent thread pool for parallel pairing verification ---
+// Workers park on futex-backed ResetEvents between jobs, eliminating spawn/join overhead.
+// All per-dispatch buffers (pairing contexts, scratch arrays) are preallocated in the pool.
+// For n_elems <= SCRATCH_MAX, zero per-call heap allocations are needed.
+
+const RAND_BITS: usize = 64;
+const SCRATCH_MAX: usize = 512;
+
+const WorkItem = union(enum) {
+    aggregate_verify: *AggVerifyJob,
+    verify_multi: *VerifyMultiJob,
+};
+
+/// Job for parallel aggregateVerify. Uses pointer types for zero-copy from JS.
+const AggVerifyJob = struct {
+    pairing_bufs: [][Pairing.sizeOf()]u8,
+    has_work: []bool,
+    counter: std.atomic.Value(usize),
+    err_flag: std.atomic.Value(bool),
+    sig: *const Signature,
+    sig_groupcheck: bool,
+    msgs: []const *const [32]u8,
+    dst: []const u8,
+    pks: []const *const PublicKey,
+    pks_validate: bool,
+    n_elems: usize,
+};
+
+/// Job for parallel verifyMultipleAggregateSignatures. Uses pointer types for zero-copy.
+const VerifyMultiJob = struct {
+    pairing_bufs: [][Pairing.sizeOf()]u8,
+    has_work: []bool,
+    counter: std.atomic.Value(usize),
+    err_flag: std.atomic.Value(bool),
+    msgs: []const *const [32]u8,
+    dst: []const u8,
+    pks: []const *const PublicKey,
+    pks_validate: bool,
+    sigs: []const *const Signature,
+    sigs_groupcheck: bool,
+    rands: []const [32]u8,
+    n_elems: usize,
+};
+
+/// Persistent thread pool with preallocated buffers for parallel pairing verification.
+/// Workers park on ResetEvents between jobs. All dispatch buffers are preallocated.
+/// Scratch arrays for NAPI callers eliminate per-call allocs for n <= SCRATCH_MAX.
+const PairingPool = struct {
+    const max_workers = 256;
+
+    n_workers: usize,
+    workers: []std.Thread,
+    work_items: []?WorkItem,
+    work_ready: []std.Thread.ResetEvent,
+    work_done: []std.Thread.ResetEvent,
+
+    // Preallocated per-dispatch buffers (safe to reuse: dispatch is synchronous)
+    pairing_bufs: [][Pairing.sizeOf()]u8,
+    has_work: []bool,
+
+    // Scratch buffers for NAPI callers (eliminates per-call allocs for n <= SCRATCH_MAX)
+    scratch_msg_ptrs: []*const [32]u8,
+    scratch_pk_ptrs: []*const PublicKey,
+    scratch_sig_ptrs: []*const Signature,
+    scratch_rands: [][32]u8,
+
+    var instance: ?*PairingPool = null;
+
+    fn get() *PairingPool {
+        if (@as(*const ?*PairingPool, &instance).*) |p| return p;
+        return init();
+    }
+
+    fn init() *PairingPool {
+        const cpu_count = std.Thread.getCpuCount() catch 1;
+        const n_workers = @min(cpu_count, max_workers);
+        const n_bg = if (n_workers > 1) n_workers - 1 else 0;
+
+        const pool = allocator.create(PairingPool) catch @panic("PairingPool: OOM");
+        const work_items = allocator.alloc(?WorkItem, n_workers) catch @panic("PairingPool: OOM");
+        const work_ready = allocator.alloc(std.Thread.ResetEvent, n_workers) catch @panic("PairingPool: OOM");
+        const work_done = allocator.alloc(std.Thread.ResetEvent, n_workers) catch @panic("PairingPool: OOM");
+
+        @memset(work_items, null);
+        for (work_ready) |*e| e.* = .{};
+        for (work_done) |*e| e.* = .{};
+
+        const threads = allocator.alloc(std.Thread, n_bg) catch @panic("PairingPool: OOM");
+
+        pool.* = .{
+            .n_workers = n_workers,
+            .workers = threads,
+            .work_items = work_items,
+            .work_ready = work_ready,
+            .work_done = work_done,
+            .pairing_bufs = allocator.alloc([Pairing.sizeOf()]u8, n_workers) catch @panic("PairingPool: OOM"),
+            .has_work = allocator.alloc(bool, n_workers) catch @panic("PairingPool: OOM"),
+            .scratch_msg_ptrs = allocator.alloc(*const [32]u8, SCRATCH_MAX) catch @panic("PairingPool: OOM"),
+            .scratch_pk_ptrs = allocator.alloc(*const PublicKey, SCRATCH_MAX) catch @panic("PairingPool: OOM"),
+            .scratch_sig_ptrs = allocator.alloc(*const Signature, SCRATCH_MAX) catch @panic("PairingPool: OOM"),
+            .scratch_rands = allocator.alloc([32]u8, SCRATCH_MAX) catch @panic("PairingPool: OOM"),
+        };
+
+        for (0..n_bg) |i| {
+            threads[i] = std.Thread.spawn(.{}, workerLoop, .{ pool, i + 1 }) catch @panic("PairingPool: spawn failed");
+            threads[i].detach();
+        }
+
+        instance = pool;
+        return pool;
+    }
+
+    fn workerLoop(pool: *PairingPool, id: usize) void {
+        while (true) {
+            pool.work_ready[id].wait();
+            pool.work_ready[id].reset();
+
+            const item = pool.work_items[id] orelse {
+                pool.work_done[id].set();
+                continue;
+            };
+            switch (item) {
+                .aggregate_verify => |job| execAggVerify(job, id),
+                .verify_multi => |job| execVerifyMulti(job, id),
+            }
+            pool.work_items[id] = null;
+            pool.work_done[id].set();
+        }
+    }
+
+    fn execAggVerify(job: *AggVerifyJob, id: usize) void {
+        var pairing = Pairing.init(@ptrCast(@alignCast(&job.pairing_bufs[id])), true, job.dst);
+        var did_work = false;
+
+        while (!job.err_flag.load(.acquire)) {
+            const work = job.counter.fetchAdd(1, .monotonic);
+            if (work >= job.n_elems) break;
+            did_work = true;
+            const sig_ptr: ?*const Signature = if (work == 0) job.sig else null;
+            const sgc = if (work == 0) job.sig_groupcheck else false;
+            pairing.aggregate(job.pks[work], job.pks_validate, sig_ptr, sgc, job.msgs[work], null) catch {
+                job.err_flag.store(true, .release);
+                return;
+            };
+        }
+
+        if (did_work) {
+            pairing.commit();
+            job.has_work[id] = true;
+        }
+    }
+
+    fn execVerifyMulti(job: *VerifyMultiJob, id: usize) void {
+        var pairing = Pairing.init(@ptrCast(@alignCast(&job.pairing_bufs[id])), true, job.dst);
+        var did_work = false;
+
+        while (!job.err_flag.load(.acquire)) {
+            const work = job.counter.fetchAdd(1, .monotonic);
+            if (work >= job.n_elems) break;
+            did_work = true;
+            if (work == 0) {
+                // First element: r_0 = 1 (no scalar multiplication needed).
+                // See https://ethresear.ch/t/fast-verification-of-multiple-bls-signatures/5407
+                pairing.aggregate(
+                    job.pks[0],
+                    job.pks_validate,
+                    job.sigs[0],
+                    job.sigs_groupcheck,
+                    job.msgs[0],
+                    null,
+                ) catch {
+                    job.err_flag.store(true, .release);
+                    return;
+                };
+            } else {
+                pairing.mulAndAggregate(
+                    job.pks[work],
+                    job.pks_validate,
+                    job.sigs[work],
+                    job.sigs_groupcheck,
+                    &job.rands[work],
+                    RAND_BITS,
+                    job.msgs[work],
+                ) catch {
+                    job.err_flag.store(true, .release);
+                    return;
+                };
+            }
+        }
+
+        if (did_work) {
+            pairing.commit();
+            job.has_work[id] = true;
+        }
+    }
+
+    fn dispatch(pool: *PairingPool, item: WorkItem, n_active: usize) void {
+        const n_bg = if (n_active > 1) n_active - 1 else 0;
+        for (0..n_bg) |i| {
+            pool.work_done[i + 1].reset();
+            pool.work_items[i + 1] = item;
+            pool.work_ready[i + 1].set();
+        }
+
+        switch (item) {
+            .aggregate_verify => |job| execAggVerify(job, 0),
+            .verify_multi => |job| execVerifyMulti(job, 0),
+        }
+
+        for (0..n_bg) |i| {
+            pool.work_done[i + 1].wait();
+            pool.work_done[i + 1].reset();
+        }
+    }
+
+    /// Parallel aggregate verification using preallocated pool buffers.
+    fn aggregateVerify(
+        pool: *PairingPool,
+        sig: *const Signature,
+        sig_groupcheck: bool,
+        msg_ptrs: []const *const [32]u8,
+        dst: []const u8,
+        pk_ptrs: []const *const PublicKey,
+        pks_validate: bool,
+    ) bool {
+        const n_elems = pk_ptrs.len;
+        if (n_elems == 0 or msg_ptrs.len != n_elems) return false;
+
+        const n_active = @min(pool.n_workers, n_elems);
+        @memset(pool.has_work[0..n_active], false);
+
+        var job = AggVerifyJob{
+            .pairing_bufs = pool.pairing_bufs[0..n_active],
+            .has_work = pool.has_work[0..n_active],
+            .counter = std.atomic.Value(usize).init(0),
+            .err_flag = std.atomic.Value(bool).init(false),
+            .sig = sig,
+            .sig_groupcheck = sig_groupcheck,
+            .msgs = msg_ptrs,
+            .dst = dst,
+            .pks = pk_ptrs,
+            .pks_validate = pks_validate,
+            .n_elems = n_elems,
+        };
+
+        pool.dispatch(.{ .aggregate_verify = &job }, n_active);
+
+        if (job.err_flag.load(.acquire)) return false;
+
+        var acc: Pairing = .{ .ctx = @ptrCast(&pool.pairing_bufs[0]) };
+        for (1..n_active) |i| {
+            if (pool.has_work[i]) {
+                const other: Pairing = .{ .ctx = @ptrCast(&pool.pairing_bufs[i]) };
+                acc.merge(&other) catch return false;
+            }
+        }
+
+        var gtsig = blst.c.blst_fp12{};
+        Pairing.aggregated(&gtsig, sig);
+        return acc.finalVerify(&gtsig);
+    }
+
+    /// Parallel batch verification using preallocated pool buffers.
+    fn verifyMultiAggSig(
+        pool: *PairingPool,
+        msg_ptrs: []const *const [32]u8,
+        dst: []const u8,
+        pk_ptrs: []const *const PublicKey,
+        pks_validate: bool,
+        sig_ptrs: []const *const Signature,
+        sigs_groupcheck: bool,
+        rands: []const [32]u8,
+    ) bool {
+        const n_elems = msg_ptrs.len;
+        if (n_elems == 0) return false;
+
+        const n_active = @min(pool.n_workers, n_elems);
+        @memset(pool.has_work[0..n_active], false);
+
+        var job = VerifyMultiJob{
+            .pairing_bufs = pool.pairing_bufs[0..n_active],
+            .has_work = pool.has_work[0..n_active],
+            .counter = std.atomic.Value(usize).init(0),
+            .err_flag = std.atomic.Value(bool).init(false),
+            .msgs = msg_ptrs,
+            .dst = dst,
+            .pks = pk_ptrs,
+            .pks_validate = pks_validate,
+            .sigs = sig_ptrs,
+            .sigs_groupcheck = sigs_groupcheck,
+            .rands = rands,
+            .n_elems = n_elems,
+        };
+
+        pool.dispatch(.{ .verify_multi = &job }, n_active);
+
+        if (job.err_flag.load(.acquire)) return false;
+
+        var acc: Pairing = .{ .ctx = @ptrCast(&pool.pairing_bufs[0]) };
+        for (1..n_active) |i| {
+            if (pool.has_work[i]) {
+                const other: Pairing = .{ .ctx = @ptrCast(&pool.pairing_bufs[i]) };
+                acc.merge(&other) catch return false;
+            }
+        }
+
+        return acc.finalVerify(null);
+    }
+};
+
 /// Verify an aggregated signature against multiple messages and multiple public keys.
 /// 1) msgs: Uint8Array[]
 /// 2) pks: PublicKey[]
@@ -530,34 +840,31 @@ pub fn blst_aggregateVerify(
         return error.InvalidAggregateVerifyInput;
     }
 
-    const msgs = try allocator.alloc([32]u8, msgs_len);
-    defer allocator.free(msgs);
-    const pks = try allocator.alloc(PublicKey, pks_len);
-    defer allocator.free(pks);
+    const pool = PairingPool.get();
+
+    const msg_ptrs: []*const [32]u8 = if (msgs_len <= SCRATCH_MAX)
+        pool.scratch_msg_ptrs[0..msgs_len]
+    else
+        try allocator.alloc(*const [32]u8, msgs_len);
+    defer if (msgs_len > SCRATCH_MAX) allocator.free(msg_ptrs);
+
+    const pk_ptrs: []*const PublicKey = if (msgs_len <= SCRATCH_MAX)
+        pool.scratch_pk_ptrs[0..msgs_len]
+    else
+        try allocator.alloc(*const PublicKey, msgs_len);
+    defer if (msgs_len > SCRATCH_MAX) allocator.free(pk_ptrs);
 
     for (0..msgs_len) |i| {
         const msg_value = try msgs_array.getElement(@intCast(i));
         const msg_info = try msg_value.getTypedarrayInfo();
         if (msg_info.data.len != 32) return error.InvalidMessageLength;
-        @memcpy(&msgs[i], msg_info.data[0..32]);
+        msg_ptrs[i] = @ptrCast(msg_info.data.ptr);
 
         const pk_value = try pks_array.getElement(@intCast(i));
-        const pk = try env.unwrap(PublicKey, pk_value);
-        pks[i] = pk.*;
+        pk_ptrs[i] = try env.unwrap(PublicKey, pk_value);
     }
 
-    var pairing_buf: [Pairing.sizeOf()]u8 = undefined;
-
-    const result = sig.aggregateVerify(
-        sig_groupcheck,
-        @alignCast(&pairing_buf),
-        msgs,
-        DST,
-        pks,
-        pks_validate,
-    ) catch {
-        return try env.getBoolean(false);
-    };
+    const result = pool.aggregateVerify(sig, sig_groupcheck, msg_ptrs, DST, pk_ptrs, pks_validate);
 
     return try env.getBoolean(result);
 }
@@ -629,17 +936,32 @@ pub fn blst_verifyMultipleAggregateSignatures(env: napi.Env, cb: napi.CallbackIn
         return try env.getBoolean(false);
     }
 
-    const msgs = try allocator.alloc([32]u8, n_elems);
-    defer allocator.free(msgs);
+    const pool = PairingPool.get();
 
-    const pks = try allocator.alloc(*const PublicKey, n_elems);
-    defer allocator.free(pks);
+    // Zero-copy: store pointers into JS memory; use pool scratch to avoid allocs
+    const msg_ptrs: []*const [32]u8 = if (n_elems <= SCRATCH_MAX)
+        pool.scratch_msg_ptrs[0..n_elems]
+    else
+        try allocator.alloc(*const [32]u8, n_elems);
+    defer if (n_elems > SCRATCH_MAX) allocator.free(msg_ptrs);
 
-    const sigs = try allocator.alloc(*const Signature, n_elems);
-    defer allocator.free(sigs);
+    const pk_ptrs: []*const PublicKey = if (n_elems <= SCRATCH_MAX)
+        pool.scratch_pk_ptrs[0..n_elems]
+    else
+        try allocator.alloc(*const PublicKey, n_elems);
+    defer if (n_elems > SCRATCH_MAX) allocator.free(pk_ptrs);
 
-    const rands = try allocator.alloc([32]u8, n_elems);
-    defer allocator.free(rands);
+    const sig_ptrs: []*const Signature = if (n_elems <= SCRATCH_MAX)
+        pool.scratch_sig_ptrs[0..n_elems]
+    else
+        try allocator.alloc(*const Signature, n_elems);
+    defer if (n_elems > SCRATCH_MAX) allocator.free(sig_ptrs);
+
+    const rands: [][32]u8 = if (n_elems <= SCRATCH_MAX)
+        pool.scratch_rands[0..n_elems]
+    else
+        try allocator.alloc([32]u8, n_elems);
+    defer if (n_elems > SCRATCH_MAX) allocator.free(rands);
 
     var prng = std.Random.DefaultPrng.init(std.crypto.random.int(u64));
     const rand = prng.random();
@@ -650,30 +972,19 @@ pub fn blst_verifyMultipleAggregateSignatures(env: napi.Env, cb: napi.CallbackIn
         const msg_value = try set_value.getNamedProperty("msg");
         const msg = try msg_value.getTypedarrayInfo();
         if (msg.data.len != 32) return error.InvalidMessageLength;
-        @memcpy(&msgs[i], msg.data[0..32]);
+        msg_ptrs[i] = @ptrCast(msg.data.ptr);
 
-        // Use unwrapped pointers directly - no copy needed
         const pk_value = try set_value.getNamedProperty("pk");
-        pks[i] = try env.unwrap(PublicKey, pk_value);
+        pk_ptrs[i] = try env.unwrap(PublicKey, pk_value);
 
         const sig_value = try set_value.getNamedProperty("sig");
-        sigs[i] = try env.unwrap(Signature, sig_value);
+        sig_ptrs[i] = try env.unwrap(Signature, sig_value);
 
-        rand.bytes(&rands[i]);
+        // Skip random for element 0: r_0 = 1 (no scalar mul needed)
+        if (i > 0) rand.bytes(&rands[i]);
     }
 
-    const result = blst.verifyMultipleAggregateSignatures(
-        msgs,
-        DST,
-        pks,
-        pks_validate,
-        sigs,
-        sigs_groupcheck,
-        rands,
-        allocator,
-    ) catch {
-        return try env.getBoolean(false);
-    };
+    const result = pool.verifyMultiAggSig(msg_ptrs, DST, pk_ptrs, pks_validate, sig_ptrs, sigs_groupcheck, rands);
 
     return try env.getBoolean(result);
 }

--- a/bindings/napi/blst.zig
+++ b/bindings/napi/blst.zig
@@ -641,9 +641,9 @@ const PairingPool = struct {
             const work = job.counter.fetchAdd(1, .monotonic);
             if (work >= job.n_elems) break;
             did_work = true;
-            const sig_ptr: ?*const Signature = if (work == 0) job.sig else null;
-            const sgc = if (work == 0) job.sig_groupcheck else false;
-            pairing.aggregate(job.pks[work], job.pks_validate, sig_ptr, sgc, job.msgs[work], null) catch {
+            // No worker handles the signature — sig validation and sig→GT
+            // computation run on the main thread concurrently with workers.
+            pairing.aggregate(job.pks[work], job.pks_validate, null, false, job.msgs[work], null) catch {
                 job.err_flag.store(true, .release);
                 return;
             };
@@ -734,6 +734,7 @@ const PairingPool = struct {
         if (n_elems == 0 or msg_ptrs.len != n_elems) return false;
 
         const n_active = @min(pool.n_workers, n_elems);
+        const n_bg = if (n_active > 1) n_active - 1 else 0;
         @memset(pool.has_work[0..n_active], false);
 
         var job = AggVerifyJob{
@@ -750,7 +751,24 @@ const PairingPool = struct {
             .n_elems = n_elems,
         };
 
-        pool.dispatch(.{ .aggregate_verify = &job }, n_active);
+        for (0..n_bg) |i| {
+            pool.work_done[i + 1].reset();
+            pool.work_items[i + 1] = .{ .aggregate_verify = &job };
+            pool.work_ready[i + 1].set();
+        }
+
+        execAggVerify(&job, 0);
+
+        if (sig_groupcheck) sig.validate(false) catch job.err_flag.store(true, .release);
+
+        var gtsig = blst.c.blst_fp12{};
+        if (!job.err_flag.load(.acquire)) Pairing.aggregated(&gtsig, sig);
+
+        // Wait for background workers
+        for (0..n_bg) |i| {
+            pool.work_done[i + 1].wait();
+            pool.work_done[i + 1].reset();
+        }
 
         if (job.err_flag.load(.acquire)) return false;
 
@@ -762,8 +780,6 @@ const PairingPool = struct {
             }
         }
 
-        var gtsig = blst.c.blst_fp12{};
-        Pairing.aggregated(&gtsig, sig);
         return acc.finalVerify(&gtsig);
     }
 

--- a/bindings/napi/blst.zig
+++ b/bindings/napi/blst.zig
@@ -575,12 +575,20 @@ const PairingPool = struct {
         return init();
     }
 
+    /// Initializes the singleton `PairingPool`: detects CPU count, allocates all
+    /// per-worker buffers and scratch arrays, and spawns n_workers-1 background
+    /// threads (slots 1..n_workers-1). The calling thread always acts as worker 0.
+    ///
+    /// Panics on OOM or thread spawn failure — this runs once at module load time.
     fn init() *PairingPool {
         const cpu_count = std.Thread.getCpuCount() catch 1;
         const n_workers = @min(cpu_count, max_workers);
-        const n_bg = if (n_workers > 1) n_workers - 1 else 0;
+        // main thread handles slot 0
+        const background_worker_count = if (n_workers > 1) n_workers - 1 else 0;
 
         const pool = allocator.create(PairingPool) catch @panic("PairingPool: OOM");
+        // These are sized `n_workers` (not `background_worker_count`) so worker IDs map directly to array indices.
+        // Slot 0 is unused — the main thread executes directly without parking.
         const work_items = allocator.alloc(?WorkItem, n_workers) catch @panic("PairingPool: OOM");
         const work_ready = allocator.alloc(std.Thread.ResetEvent, n_workers) catch @panic("PairingPool: OOM");
         const work_done = allocator.alloc(std.Thread.ResetEvent, n_workers) catch @panic("PairingPool: OOM");
@@ -589,7 +597,7 @@ const PairingPool = struct {
         for (work_ready) |*e| e.* = .{};
         for (work_done) |*e| e.* = .{};
 
-        const threads = allocator.alloc(std.Thread, n_bg) catch @panic("PairingPool: OOM");
+        const threads = allocator.alloc(std.Thread, background_worker_count) catch @panic("PairingPool: OOM");
 
         pool.* = .{
             .n_workers = n_workers,
@@ -605,7 +613,8 @@ const PairingPool = struct {
             .scratch_rands = allocator.alloc([32]u8, SCRATCH_MAX) catch @panic("PairingPool: OOM"),
         };
 
-        for (0..n_bg) |i| {
+        // Workers get IDs 1..n; ID 0 is reserved for the calling (main) thread.
+        for (0..background_worker_count) |i| {
             threads[i] = std.Thread.spawn(.{}, workerLoop, .{ pool, i + 1 }) catch @panic("PairingPool: spawn failed");
             threads[i].detach();
         }
@@ -614,21 +623,21 @@ const PairingPool = struct {
         return pool;
     }
 
-    fn workerLoop(pool: *PairingPool, id: usize) void {
+    fn workerLoop(pool: *PairingPool, worker_index: usize) void {
         while (true) {
-            pool.work_ready[id].wait();
-            pool.work_ready[id].reset();
+            pool.work_ready[worker_index].wait();
+            pool.work_ready[worker_index].reset();
 
-            const item = pool.work_items[id] orelse {
-                pool.work_done[id].set();
+            const item = pool.work_items[worker_index] orelse {
+                pool.work_done[worker_index].set();
                 continue;
             };
             switch (item) {
-                .aggregate_verify => |job| execAggVerify(job, id),
-                .verify_multi => |job| execVerifyMulti(job, id),
+                .aggregate_verify => |job| execAggVerify(job, worker_index),
+                .verify_multi => |job| execVerifyMulti(job, worker_index),
             }
-            pool.work_items[id] = null;
-            pool.work_done[id].set();
+            pool.work_items[worker_index] = null;
+            pool.work_done[worker_index].set();
         }
     }
 
@@ -655,8 +664,8 @@ const PairingPool = struct {
         }
     }
 
-    fn execVerifyMulti(job: *VerifyMultiJob, id: usize) void {
-        var pairing = Pairing.init(@ptrCast(@alignCast(&job.pairing_bufs[id])), true, job.dst);
+    fn execVerifyMulti(job: *VerifyMultiJob, worker_index: usize) void {
+        var pairing = Pairing.init(@ptrCast(@alignCast(&job.pairing_bufs[worker_index])), true, job.dst);
         var did_work = false;
 
         while (!job.err_flag.load(.acquire)) {
@@ -695,26 +704,36 @@ const PairingPool = struct {
 
         if (did_work) {
             pairing.commit();
-            job.has_work[id] = true;
+            job.has_work[worker_index] = true;
         }
     }
 
+    /// Dispatches a work item to `n_active` slots and blocks until all complete.
+    ///
+    /// Slot 0 is executed on the calling thread;
+    /// slots 1..n_active-1 are signalled to background workers.
+    /// Workers and the main thread run concurrently.
+    ///
+    /// Ordering matters: workers are signalled BEFORE the main thread starts work,
+    /// so all threads are active in parallel (not sequentially).
     fn dispatch(pool: *PairingPool, item: WorkItem, n_active: usize) void {
         std.debug.assert(n_active <= pool.n_workers);
 
-        const n_bg = if (n_active > 1) n_active - 1 else 0;
-        for (0..n_bg) |i| {
+        const background_worker_count = if (n_active > 1) n_active - 1 else 0;
+        // Signal background workers first so they start before the main thread blocks.
+        for (0..background_worker_count) |i| {
             pool.work_done[i + 1].reset();
             pool.work_items[i + 1] = item;
             pool.work_ready[i + 1].set();
         }
 
+        // Main thread handles slot 0 while background workers run concurrently.
         switch (item) {
             .aggregate_verify => |job| execAggVerify(job, 0),
             .verify_multi => |job| execVerifyMulti(job, 0),
         }
-
-        for (0..n_bg) |i| {
+        // Collect background workers before returning.
+        for (0..background_worker_count) |i| {
             pool.work_done[i + 1].wait();
             pool.work_done[i + 1].reset();
         }
@@ -734,7 +753,7 @@ const PairingPool = struct {
         if (n_elems == 0 or msg_ptrs.len != n_elems) return false;
 
         const n_active = @min(pool.n_workers, n_elems);
-        const n_bg = if (n_active > 1) n_active - 1 else 0;
+        const background_worker_count = if (n_active > 1) n_active - 1 else 0;
         @memset(pool.has_work[0..n_active], false);
 
         var job = AggVerifyJob{
@@ -751,7 +770,7 @@ const PairingPool = struct {
             .n_elems = n_elems,
         };
 
-        for (0..n_bg) |i| {
+        for (0..background_worker_count) |i| {
             pool.work_done[i + 1].reset();
             pool.work_items[i + 1] = .{ .aggregate_verify = &job };
             pool.work_ready[i + 1].set();
@@ -765,7 +784,7 @@ const PairingPool = struct {
         if (!job.err_flag.load(.acquire)) Pairing.aggregated(&gtsig, sig);
 
         // Wait for background workers
-        for (0..n_bg) |i| {
+        for (0..background_worker_count) |i| {
             pool.work_done[i + 1].wait();
             pool.work_done[i + 1].reset();
         }
@@ -784,6 +803,8 @@ const PairingPool = struct {
     }
 
     /// Parallel batch verification using preallocated pool buffers.
+    ///
+    /// This is the multi-threaded version of `verifyMultipleAggregateSignatures`.
     fn verifyMultiAggSig(
         pool: *PairingPool,
         msg_ptrs: []const *const [32]u8,

--- a/bindings/napi/blst.zig
+++ b/bindings/napi/blst.zig
@@ -549,7 +549,7 @@ const VerifyMultiJob = struct {
 /// Persistent thread pool with preallocated buffers for parallel pairing verification.
 /// Workers park on ResetEvents between jobs. All dispatch buffers are preallocated.
 /// Scratch arrays for NAPI callers eliminate per-call allocs for n <= SCRATCH_MAX.
-const PairingPool = struct {
+pub const PairingPool = struct {
     const max_workers = 256;
 
     n_workers: u32,
@@ -557,6 +557,7 @@ const PairingPool = struct {
     work_items: []?WorkItem,
     work_ready: []std.Thread.ResetEvent,
     work_done: []std.Thread.ResetEvent,
+    shutdown: std.atomic.Value(bool),
 
     // Preallocated per-dispatch buffers (safe to reuse: dispatch is synchronous)
     pairing_bufs: [][Pairing.sizeOf()]u8,
@@ -568,7 +569,7 @@ const PairingPool = struct {
     scratch_sig_ptrs: []*const Signature,
     scratch_rands: [][32]u8,
 
-    var instance: ?*PairingPool = null;
+    pub var instance: ?*PairingPool = null;
 
     fn get() *PairingPool {
         if (@as(*const ?*PairingPool, &instance).*) |p| return p;
@@ -605,6 +606,7 @@ const PairingPool = struct {
             .work_items = work_items,
             .work_ready = work_ready,
             .work_done = work_done,
+            .shutdown = std.atomic.Value(bool).init(false),
             .pairing_bufs = allocator.alloc([Pairing.sizeOf()]u8, n_workers) catch @panic("PairingPool: OOM"),
             .has_work = allocator.alloc(bool, n_workers) catch @panic("PairingPool: OOM"),
             .scratch_msg_ptrs = allocator.alloc(*const [32]u8, SCRATCH_MAX) catch @panic("PairingPool: OOM"),
@@ -616,7 +618,6 @@ const PairingPool = struct {
         // Workers get IDs 1..n; ID 0 is reserved for the calling (main) thread.
         for (0..background_worker_count) |i| {
             threads[i] = std.Thread.spawn(.{}, workerLoop, .{ pool, i + 1 }) catch @panic("PairingPool: spawn failed");
-            threads[i].detach();
         }
 
         instance = pool;
@@ -627,6 +628,8 @@ const PairingPool = struct {
         while (true) {
             pool.work_ready[worker_index].wait();
             pool.work_ready[worker_index].reset();
+
+            if (pool.shutdown.load(.acquire)) return;
 
             const item = pool.work_items[worker_index] orelse {
                 pool.work_done[worker_index].set();
@@ -849,6 +852,29 @@ const PairingPool = struct {
         }
 
         return acc.finalVerify(null);
+    }
+
+    pub fn deinit(pool: *PairingPool) void {
+        pool.shutdown.store(true, .release);
+
+        // Wake all background workers so they observe the shutdown flag and exit.
+        for (pool.work_ready[1..pool.n_workers]) |*e| e.set();
+
+        // Join all background threads.
+        for (pool.workers) |t| t.join();
+
+        allocator.free(pool.workers);
+        allocator.free(pool.work_items);
+        allocator.free(pool.work_ready);
+        allocator.free(pool.work_done);
+        allocator.free(pool.pairing_bufs);
+        allocator.free(pool.has_work);
+        allocator.free(pool.scratch_msg_ptrs);
+        allocator.free(pool.scratch_pk_ptrs);
+        allocator.free(pool.scratch_sig_ptrs);
+        allocator.free(pool.scratch_rands);
+        allocator.destroy(pool);
+        instance = null;
     }
 };
 

--- a/bindings/napi/blst.zig
+++ b/bindings/napi/blst.zig
@@ -550,7 +550,7 @@ pub fn blst_aggregateVerify(
 
     const result = sig.aggregateVerify(
         sig_groupcheck,
-        &pairing_buf,
+        @alignCast(&pairing_buf),
         msgs,
         DST,
         pks,
@@ -598,7 +598,7 @@ pub fn blst_fastAggregateVerify(env: napi.Env, cb: napi.CallbackInfo(4)) !napi.V
 
     var pairing_buf: [Pairing.sizeOf()]u8 = undefined;
     // `pks_validate` is always false here since we assume proof of possession for public keys.
-    const result = sig.fastAggregateVerify(sigs_groupcheck, &pairing_buf, msg_info.data[0..32], DST, pks, false) catch {
+    const result = sig.fastAggregateVerify(sigs_groupcheck, @alignCast(&pairing_buf), msg_info.data[0..32], DST, pks, false) catch {
         return try env.getBoolean(false);
     };
 
@@ -632,10 +632,10 @@ pub fn blst_verifyMultipleAggregateSignatures(env: napi.Env, cb: napi.CallbackIn
     const msgs = try allocator.alloc([32]u8, n_elems);
     defer allocator.free(msgs);
 
-    const pks = try allocator.alloc(*PublicKey, n_elems);
+    const pks = try allocator.alloc(*const PublicKey, n_elems);
     defer allocator.free(pks);
 
-    const sigs = try allocator.alloc(*Signature, n_elems);
+    const sigs = try allocator.alloc(*const Signature, n_elems);
     defer allocator.free(sigs);
 
     const rands = try allocator.alloc([32]u8, n_elems);
@@ -662,10 +662,7 @@ pub fn blst_verifyMultipleAggregateSignatures(env: napi.Env, cb: napi.CallbackIn
         rand.bytes(&rands[i]);
     }
 
-    var pairing_buf: [Pairing.sizeOf()]u8 = undefined;
     const result = blst.verifyMultipleAggregateSignatures(
-        &pairing_buf,
-        n_elems,
         msgs,
         DST,
         pks,
@@ -673,6 +670,7 @@ pub fn blst_verifyMultipleAggregateSignatures(env: napi.Env, cb: napi.CallbackIn
         sigs,
         sigs_groupcheck,
         rands,
+        allocator,
     ) catch {
         return try env.getBoolean(false);
     };

--- a/bindings/napi/blst.zig
+++ b/bindings/napi/blst.zig
@@ -552,7 +552,7 @@ const VerifyMultiJob = struct {
 const PairingPool = struct {
     const max_workers = 256;
 
-    n_workers: usize,
+    n_workers: u32,
     workers: []std.Thread,
     work_items: []?WorkItem,
     work_ready: []std.Thread.ResetEvent,

--- a/bindings/napi/blst.zig
+++ b/bindings/napi/blst.zig
@@ -922,7 +922,7 @@ pub fn blst_fastAggregateVerify(env: napi.Env, cb: napi.CallbackInfo(4)) !napi.V
         pks[i] = pk.*;
     }
 
-    var pairing_buf: [Pairing.sizeOf()]u8 = undefined;
+    var pairing_buf: [Pairing.sizeOf()]u8 align(@alignOf(Pairing)) = undefined;
     // `pks_validate` is always false here since we assume proof of possession for public keys.
     const result = sig.fastAggregateVerify(sigs_groupcheck, @alignCast(&pairing_buf), msg_info.data[0..32], DST, pks, false) catch {
         return try env.getBoolean(false);

--- a/bindings/napi/root.zig
+++ b/bindings/napi/root.zig
@@ -6,6 +6,7 @@ const config = @import("./config.zig");
 const shuffle = @import("./shuffle.zig");
 const BeaconStateView = @import("./BeaconStateView.zig");
 const blst = @import("./blst.zig");
+const blst_z = @import("blst");
 const state_transition = @import("./state_transition.zig");
 
 comptime {
@@ -21,6 +22,7 @@ const EnvCleanup = struct {
     fn hook(_: *EnvCleanup) void {
         if (env_refcount.fetchSub(1, .acq_rel) == 1) {
             // Last environment — tear down shared state.
+            blst_z.thread_pool.deinitializeThreadPool();
             config.state.deinit();
             pubkeys.state.deinit();
             pool.state.deinit();
@@ -36,6 +38,7 @@ fn register(env: napi.Env, exports: napi.Value) !void {
         try pool.state.init();
         try pubkeys.state.init();
         config.state.init();
+        try blst_z.thread_pool.initializeThreadPool(null);
     }
 
     try env.addEnvCleanupHook(EnvCleanup, &env_cleanup, EnvCleanup.hook);

--- a/bindings/napi/root.zig
+++ b/bindings/napi/root.zig
@@ -24,6 +24,7 @@ const EnvCleanup = struct {
             config.state.deinit();
             pubkeys.state.deinit();
             pool.state.deinit();
+            if (blst.PairingPool.instance) |p| p.deinit();
         }
     }
 };

--- a/bindings/napi/root.zig
+++ b/bindings/napi/root.zig
@@ -22,7 +22,6 @@ const EnvCleanup = struct {
     fn hook(_: *EnvCleanup) void {
         if (env_refcount.fetchSub(1, .acq_rel) == 1) {
             // Last environment — tear down shared state.
-            blst_z.thread_pool.deinitializeThreadPool();
             config.state.deinit();
             pubkeys.state.deinit();
             pool.state.deinit();
@@ -38,7 +37,6 @@ fn register(env: napi.Env, exports: napi.Value) !void {
         try pool.state.init();
         try pubkeys.state.init();
         config.state.init();
-        try blst_z.thread_pool.initializeThreadPool(null);
     }
 
     try env.addEnvCleanupHook(EnvCleanup, &env_cleanup, EnvCleanup.hook);

--- a/bindings/napi/root.zig
+++ b/bindings/napi/root.zig
@@ -6,7 +6,6 @@ const config = @import("./config.zig");
 const shuffle = @import("./shuffle.zig");
 const BeaconStateView = @import("./BeaconStateView.zig");
 const blst = @import("./blst.zig");
-const blst_z = @import("blst");
 const state_transition = @import("./state_transition.zig");
 
 comptime {

--- a/bindings/perf/blst.test.ts
+++ b/bindings/perf/blst.test.ts
@@ -1,0 +1,66 @@
+import crypto from "node:crypto";
+import { bench, describe } from "@chainsafe/benchmark";
+import {
+  SecretKey as SecretKeyTS,
+  type Signature as SignatureTS,
+  verifyMultipleAggregateSignatures as verifyTS,
+} from "@chainsafe/blst";
+import {
+  SecretKey as SecretKeyZig,
+  type Signature as SignatureZig,
+  verifyMultipleAggregateSignatures as verifyZig,
+} from "../src/blst.js";
+
+interface SignatureSetZig {
+  msg: Uint8Array;
+  pk: InstanceType<typeof SecretKeyZig> extends { toPublicKey(): infer P } ? P : never;
+  sig: InstanceType<typeof SignatureZig>;
+}
+
+interface SignatureSetTS {
+  msg: Uint8Array;
+  pk: ReturnType<InstanceType<typeof SecretKeyTS>["toPublicKey"]>;
+  sig: InstanceType<typeof SignatureTS>;
+}
+
+function generateZigSets(count: number): SignatureSetZig[] {
+  return Array.from({ length: count }, () => {
+    const msg = crypto.randomBytes(32);
+    const sk = SecretKeyZig.fromKeygen(crypto.randomBytes(32));
+    const pk = sk.toPublicKey();
+    const sig = sk.sign(msg);
+    return { msg, pk, sig };
+  });
+}
+
+function generateTSSets(count: number): SignatureSetTS[] {
+  return Array.from({ length: count }, () => {
+    const msg = crypto.randomBytes(32);
+    const sk = SecretKeyTS.fromKeygen(crypto.randomBytes(32));
+    const pk = sk.toPublicKey();
+    const sig = sk.sign(msg);
+    return { msg, pk, sig };
+  });
+}
+
+describe("verifyMultipleAggregateSignatures", () => {
+  for (const count of [3, 8, 32, 64, 128]) {
+    bench({
+      beforeEach: () => generateZigSets(count),
+      fn: (sets) => {
+        const isValid = verifyZig(sets);
+        if (!isValid) throw Error("Invalid");
+      },
+      id: `lodestar-z  ${count} sets`,
+    });
+
+    bench({
+      beforeEach: () => generateTSSets(count),
+      fn: (sets) => {
+        const isValid = verifyTS(sets);
+        if (!isValid) throw Error("Invalid");
+      },
+      id: `@chainsafe/blst  ${count} sets`,
+    });
+  }
+});

--- a/bindings/perf/blst.test.ts
+++ b/bindings/perf/blst.test.ts
@@ -1,19 +1,23 @@
 import crypto from "node:crypto";
-import { bench, describe } from "@chainsafe/benchmark";
+import {bench, describe} from "@chainsafe/benchmark";
 import {
   SecretKey as SecretKeyTS,
   type Signature as SignatureTS,
+  aggregateSignatures as aggregateSignaturesTS,
+  aggregateVerify as aggregateVerifyTS,
   verifyMultipleAggregateSignatures as verifyTS,
 } from "@chainsafe/blst";
 import {
   SecretKey as SecretKeyZig,
   type Signature as SignatureZig,
+  aggregateSignatures as aggregateSignaturesZig,
+  aggregateVerify as aggregateVerifyZig,
   verifyMultipleAggregateSignatures as verifyZig,
 } from "../src/blst.js";
 
 interface SignatureSetZig {
   msg: Uint8Array;
-  pk: InstanceType<typeof SecretKeyZig> extends { toPublicKey(): infer P } ? P : never;
+  pk: InstanceType<typeof SecretKeyZig> extends {toPublicKey(): infer P} ? P : never;
   sig: InstanceType<typeof SignatureZig>;
 }
 
@@ -24,24 +28,60 @@ interface SignatureSetTS {
 }
 
 function generateZigSets(count: number): SignatureSetZig[] {
-  return Array.from({ length: count }, () => {
+  return Array.from({length: count}, () => {
     const msg = crypto.randomBytes(32);
     const sk = SecretKeyZig.fromKeygen(crypto.randomBytes(32));
     const pk = sk.toPublicKey();
     const sig = sk.sign(msg);
-    return { msg, pk, sig };
+    return {msg, pk, sig};
   });
 }
 
 function generateTSSets(count: number): SignatureSetTS[] {
-  return Array.from({ length: count }, () => {
+  return Array.from({length: count}, () => {
     const msg = crypto.randomBytes(32);
     const sk = SecretKeyTS.fromKeygen(crypto.randomBytes(32));
     const pk = sk.toPublicKey();
     const sig = sk.sign(msg);
-    return { msg, pk, sig };
+    return {msg, pk, sig};
   });
 }
+
+describe("aggregateVerify", () => {
+  for (const count of [3, 8, 32, 64, 128]) {
+    bench({
+      beforeEach: () => {
+        const sets = generateZigSets(count);
+        return {
+          messages: sets.map((s) => s.msg),
+          publicKeys: sets.map((s) => s.pk),
+          signature: aggregateSignaturesZig(sets.map((s) => s.sig)),
+        };
+      },
+      fn: ({messages, publicKeys, signature}) => {
+        const isValid = aggregateVerifyZig(messages, publicKeys, signature);
+        if (!isValid) throw Error("Invalid");
+      },
+      id: `aggregateVerify lodestar-z  ${count} sets`,
+    });
+
+    bench({
+      beforeEach: () => {
+        const sets = generateTSSets(count);
+        return {
+          messages: sets.map((s) => s.msg),
+          publicKeys: sets.map((s) => s.pk),
+          signature: aggregateSignaturesTS(sets.map((s) => s.sig)),
+        };
+      },
+      fn: ({messages, publicKeys, signature}) => {
+        const isValid = aggregateVerifyTS(messages, publicKeys, signature);
+        if (!isValid) throw Error("Invalid");
+      },
+      id: `aggregateVerify @chainsafe/blst  ${count} sets`,
+    });
+  }
+});
 
 describe("verifyMultipleAggregateSignatures", () => {
   for (const count of [3, 8, 32, 64, 128]) {

--- a/bindings/perf/blst.test.ts
+++ b/bindings/perf/blst.test.ts
@@ -3,6 +3,7 @@ import {bench, describe} from "@chainsafe/benchmark";
 import {
   SecretKey as SecretKeyTS,
   type Signature as SignatureTS,
+  aggregatePublicKeys as aggregatePublicKeysTS,
   aggregateSignatures as aggregateSignaturesTS,
   aggregateVerify as aggregateVerifyTS,
   verifyMultipleAggregateSignatures as verifyTS,
@@ -10,6 +11,7 @@ import {
 import {
   SecretKey as SecretKeyZig,
   type Signature as SignatureZig,
+  aggregatePublicKeys as aggregatePublicKeysZig,
   aggregateSignatures as aggregateSignaturesZig,
   aggregateVerify as aggregateVerifyZig,
   verifyMultipleAggregateSignatures as verifyZig,
@@ -46,6 +48,46 @@ function generateTSSets(count: number): SignatureSetTS[] {
     return {msg, pk, sig};
   });
 }
+
+describe("aggregatePublicKeys", () => {
+  for (const count of [1, 8, 32, 128, 256]) {
+    bench({
+      id: `aggregatePublicKeys lodestar-z  ${count} keys`,
+      beforeEach: () => generateZigSets(count).map((s) => s.pk),
+      fn: (publicKeys) => {
+        aggregatePublicKeysZig(publicKeys);
+      },
+    });
+
+    bench({
+      id: `aggregatePublicKeys @chainsafe/blst  ${count} keys`,
+      beforeEach: () => generateTSSets(count).map((s) => s.pk),
+      fn: (publicKeys) => {
+        aggregatePublicKeysTS(publicKeys);
+      },
+    });
+  }
+});
+
+describe("aggregateSignatures", () => {
+  for (const count of [1, 8, 32, 128, 256]) {
+    bench({
+      id: `aggregateSignatures lodestar-z  ${count} sigs`,
+      beforeEach: () => generateZigSets(count).map((s) => s.sig),
+      fn: (signatures) => {
+        aggregateSignaturesZig(signatures);
+      },
+    });
+
+    bench({
+      id: `aggregateSignatures @chainsafe/blst  ${count} sigs`,
+      beforeEach: () => generateTSSets(count).map((s) => s.sig),
+      fn: (signatures) => {
+        aggregateSignaturesTS(signatures);
+      },
+    });
+  }
+});
 
 describe("aggregateVerify", () => {
   for (const count of [3, 8, 32, 64, 128]) {

--- a/bindings/perf/blst.test.ts
+++ b/bindings/perf/blst.test.ts
@@ -52,19 +52,19 @@ function generateTSSets(count: number): SignatureSetTS[] {
 describe("aggregatePublicKeys", () => {
   for (const count of [1, 8, 32, 128, 256]) {
     bench({
-      id: `aggregatePublicKeys lodestar-z  ${count} keys`,
       beforeEach: () => generateZigSets(count).map((s) => s.pk),
       fn: (publicKeys) => {
         aggregatePublicKeysZig(publicKeys);
       },
+      id: `aggregatePublicKeys lodestar-z  ${count} keys`,
     });
 
     bench({
-      id: `aggregatePublicKeys @chainsafe/blst  ${count} keys`,
       beforeEach: () => generateTSSets(count).map((s) => s.pk),
       fn: (publicKeys) => {
         aggregatePublicKeysTS(publicKeys);
       },
+      id: `aggregatePublicKeys @chainsafe/blst  ${count} keys`,
     });
   }
 });
@@ -72,19 +72,19 @@ describe("aggregatePublicKeys", () => {
 describe("aggregateSignatures", () => {
   for (const count of [1, 8, 32, 128, 256]) {
     bench({
-      id: `aggregateSignatures lodestar-z  ${count} sigs`,
       beforeEach: () => generateZigSets(count).map((s) => s.sig),
       fn: (signatures) => {
         aggregateSignaturesZig(signatures);
       },
+      id: `aggregateSignatures lodestar-z  ${count} sigs`,
     });
 
     bench({
-      id: `aggregateSignatures @chainsafe/blst  ${count} sigs`,
       beforeEach: () => generateTSSets(count).map((s) => s.sig),
       fn: (signatures) => {
         aggregateSignaturesTS(signatures);
       },
+      id: `aggregateSignatures @chainsafe/blst  ${count} sigs`,
     });
   }
 });

--- a/bindings/perf/blst.test.ts
+++ b/bindings/perf/blst.test.ts
@@ -1,3 +1,5 @@
+//TODO(bing): The ts benchmarks are here really to ensure perf is up to par on the zig side.
+// Remove once we are happy
 import crypto from "node:crypto";
 import {bench, describe} from "@chainsafe/benchmark";
 import {

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -7,8 +7,8 @@
     .minimum_zig_version = "0.14.1",
     .dependencies = .{
         .blst = .{
-            .url = "git+https://github.com/chainsafe/blst-z#7c135f5049d99f603856a1c8728321cb69682788",
-            .hash = "blst_z-0.0.0-td3FNDuaAAA1nbeXzEihbQm-w9sJWrGpkrEjioonUnrV",
+            .url = "git+https://github.com/chainsafe/blst-z?ref=bing/mt-verify#d0585c52232d4586b8b3ef424a61c8299295dba4",
+            .hash = "blst_z-0.0.0-td3FNECoAAC5U1u8ZIt6WzVhEWUAiByi9S8mfeVZglyf",
         },
         .hashtree = .{
             .url = "git+https://github.com/chainsafe/hashtree-z#4ed9aebb6178662299ae799f6914499820ff0180",

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -7,8 +7,8 @@
     .minimum_zig_version = "0.14.1",
     .dependencies = .{
         .blst = .{
-            .url = "git+https://github.com/chainsafe/blst-z?ref=bing/mt-verify#2d8044a4fee9555e2b91caeb4d1282f1aadcf86e",
-            .hash = "blst_z-0.0.0-td3FNMzsAAApEwBlroOu7ooXu8S-ubHh2m8_zAgRoQ3W",
+            .url = "git+https://github.com/chainsafe/blst-z#7a3267e33848677da6b14d7207a6321f632fd434",
+            .hash = "blst_z-0.0.0-td3FNBybAAA8-g-1U89fnsbLJlE4DkmiHwe4rxBvP-0b",
         },
         .hashtree = .{
             .url = "git+https://github.com/chainsafe/hashtree-z#4ed9aebb6178662299ae799f6914499820ff0180",

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -7,8 +7,8 @@
     .minimum_zig_version = "0.14.1",
     .dependencies = .{
         .blst = .{
-            .url = "git+https://github.com/chainsafe/blst-z?ref=bing/mt-verify#d0585c52232d4586b8b3ef424a61c8299295dba4",
-            .hash = "blst_z-0.0.0-td3FNECoAAC5U1u8ZIt6WzVhEWUAiByi9S8mfeVZglyf",
+            .url = "git+https://github.com/chainsafe/blst-z?ref=bing/mt-verify#a809483ab5826bd1cddf8beccf763e764f956ee2",
+            .hash = "blst_z-0.0.0-td3FNKq4AACfABMYnm8c4h69-nvITBR91Kv2DI5kKspR",
         },
         .hashtree = .{
             .url = "git+https://github.com/chainsafe/hashtree-z#4ed9aebb6178662299ae799f6914499820ff0180",

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -7,8 +7,8 @@
     .minimum_zig_version = "0.14.1",
     .dependencies = .{
         .blst = .{
-            .url = "git+https://github.com/chainsafe/blst-z?ref=bing/mt-verify#a809483ab5826bd1cddf8beccf763e764f956ee2",
-            .hash = "blst_z-0.0.0-td3FNKq4AACfABMYnm8c4h69-nvITBR91Kv2DI5kKspR",
+            .url = "git+https://github.com/chainsafe/blst-z?ref=bing/mt-verify#2d8044a4fee9555e2b91caeb4d1282f1aadcf86e",
+            .hash = "blst_z-0.0.0-td3FNMzsAAApEwBlroOu7ooXu8S-ubHh2m8_zAgRoQ3W",
         },
         .hashtree = .{
             .url = "git+https://github.com/chainsafe/hashtree-z#4ed9aebb6178662299ae799f6914499820ff0180",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     }
   },
   "scripts": {
-    "prepare": "zig build build-lib:bindings -Doptimize=ReleaseSafe",
+    "prepare": "zig build build-lib:bindings -Doptimize=ReleaseFast",
     "lint": "biome check",
     "test": "NODE_OPTIONS='--expose-gc' vitest run bindings/test/*.test.ts"
   },

--- a/package.json
+++ b/package.json
@@ -47,7 +47,9 @@
   },
   "devDependencies": {
     "@biomejs/biome": "^2.3.11",
+    "@chainsafe/benchmark": "^2.0.1",
     "@chainsafe/biomejs-config": "^1.0.0",
+    "@chainsafe/blst": "^2.2.0",
     "@lodestar/config": "^1.39.1",
     "@lodestar/era": "^1.39.1",
     "@lodestar/state-transition": "^1.39.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,9 +15,15 @@ importers:
       '@biomejs/biome':
         specifier: ^2.3.11
         version: 2.3.11
+      '@chainsafe/benchmark':
+        specifier: ^2.0.1
+        version: 2.0.1
       '@chainsafe/biomejs-config':
         specifier: ^1.0.0
         version: 1.0.0(@biomejs/biome@2.3.11)
+      '@chainsafe/blst':
+        specifier: ^2.2.0
+        version: 2.2.0
       '@lodestar/config':
         specifier: ^1.39.1
         version: 1.39.1
@@ -35,9 +41,92 @@ importers:
         version: 25.0.9
       vitest:
         specifier: ^4.0.17
-        version: 4.0.17(@types/node@25.0.9)
+        version: 4.0.17(@types/node@25.0.9)(yaml@2.8.2)
 
 packages:
+
+  '@actions/cache@4.1.0':
+    resolution: {integrity: sha512-z3Opg+P4Y7baq+g1dODXgdtsvPLSewr3ZKpp3U0HQR1A/vWCoJFS52XSezjdngo4SIOdR5oHtyK3a3Arar+X9A==}
+
+  '@actions/core@1.11.1':
+    resolution: {integrity: sha512-hXJCSrkwfA46Vd9Z3q4cpEpHB1rL5NG04+/rbqW9d3+CSvtB1tYe8UTpAlixa1vj0m/ULglfEK2UKxMGxCxv5A==}
+
+  '@actions/exec@1.1.1':
+    resolution: {integrity: sha512-+sCcHHbVdk93a0XT19ECtO/gIXoxvdsgQLzb2fE2/5sIZmWQuluYyjPQtrtTHdU1YzTZ7bAPN4sITq2xi1679w==}
+
+  '@actions/github@6.0.1':
+    resolution: {integrity: sha512-xbZVcaqD4XnQAe35qSQqskb3SqIAfRyLBrHMd/8TuL7hJSz2QtbDwnNM8zWx4zO5l2fnGtseNE3MbEvD7BxVMw==}
+
+  '@actions/glob@0.1.2':
+    resolution: {integrity: sha512-SclLR7Ia5sEqjkJTPs7Sd86maMDw43p769YxBOxvPvEWuPEhpAnBsQfENOpXjFYMmhCqd127bmf+YdvJqVqR4A==}
+
+  '@actions/http-client@2.2.3':
+    resolution: {integrity: sha512-mx8hyJi/hjFvbPokCg4uRd4ZX78t+YyRPtnKWwIl+RzNaVuFpQHfmlGVfsKEJN8LwTCvL+DfVgAM04XaHkm6bA==}
+
+  '@actions/io@1.1.3':
+    resolution: {integrity: sha512-wi9JjgKLYS7U/z8PPbco+PvTb/nRWjeoFlJ1Qer83k/3C5PHQi28hiVdeE2kHXmIL99mQFawx8qt/JPjZilJ8Q==}
+
+  '@azure/abort-controller@1.1.0':
+    resolution: {integrity: sha512-TrRLIoSQVzfAJX9H1JeFjzAoDGcoK1IYX1UImfceTZpsyYfWr09Ss1aHW1y5TrrR3iq6RZLBwJ3E24uwPhwahw==}
+    engines: {node: '>=12.0.0'}
+
+  '@azure/abort-controller@2.1.2':
+    resolution: {integrity: sha512-nBrLsEWm4J2u5LpAPjxADTlq3trDgVZZXHNKabeXZtpq3d3AbN/KGO82R87rdDz5/lYB024rtEf10/q0urNgsA==}
+    engines: {node: '>=18.0.0'}
+
+  '@azure/core-auth@1.10.1':
+    resolution: {integrity: sha512-ykRMW8PjVAn+RS6ww5cmK9U2CyH9p4Q88YJwvUslfuMmN98w/2rdGRLPqJYObapBCdzBVeDgYWdJnFPFb7qzpg==}
+    engines: {node: '>=20.0.0'}
+
+  '@azure/core-client@1.10.1':
+    resolution: {integrity: sha512-Nh5PhEOeY6PrnxNPsEHRr9eimxLwgLlpmguQaHKBinFYA/RU9+kOYVOQqOrTsCL+KSxrLLl1gD8Dk5BFW/7l/w==}
+    engines: {node: '>=20.0.0'}
+
+  '@azure/core-http-compat@2.3.2':
+    resolution: {integrity: sha512-Tf6ltdKzOJEgxZeWLCjMxrxbodB/ZeCbzzA1A2qHbhzAjzjHoBVSUeSl/baT/oHAxhc4qdqVaDKnc2+iE932gw==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      '@azure/core-client': ^1.10.0
+      '@azure/core-rest-pipeline': ^1.22.0
+
+  '@azure/core-lro@2.7.2':
+    resolution: {integrity: sha512-0YIpccoX8m/k00O7mDDMdJpbr6mf1yWo2dfmxt5A8XVZVVMz2SSKaEbMCeJRvgQ0IaSlqhjT47p4hVIRRy90xw==}
+    engines: {node: '>=18.0.0'}
+
+  '@azure/core-paging@1.6.2':
+    resolution: {integrity: sha512-YKWi9YuCU04B55h25cnOYZHxXYtEvQEbKST5vqRga7hWY9ydd3FZHdeQF8pyh+acWZvppw13M/LMGx0LABUVMA==}
+    engines: {node: '>=18.0.0'}
+
+  '@azure/core-rest-pipeline@1.22.2':
+    resolution: {integrity: sha512-MzHym+wOi8CLUlKCQu12de0nwcq9k9Kuv43j4Wa++CsCpJwps2eeBQwD2Bu8snkxTtDKDx4GwjuR9E8yC8LNrg==}
+    engines: {node: '>=20.0.0'}
+
+  '@azure/core-tracing@1.3.1':
+    resolution: {integrity: sha512-9MWKevR7Hz8kNzzPLfX4EAtGM2b8mr50HPDBvio96bURP/9C+HjdH3sBlLSNNrvRAr5/k/svoH457gB5IKpmwQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@azure/core-util@1.13.1':
+    resolution: {integrity: sha512-XPArKLzsvl0Hf0CaGyKHUyVgF7oDnhKoP85Xv6M4StF/1AhfORhZudHtOyf2s+FcbuQ9dPRAjB8J2KvRRMUK2A==}
+    engines: {node: '>=20.0.0'}
+
+  '@azure/core-xml@1.5.0':
+    resolution: {integrity: sha512-D/sdlJBMJfx7gqoj66PKVmhDDaU6TKA49ptcolxdas29X7AfvLTmfAGLjAcIMBK7UZ2o4lygHIqVckOlQU3xWw==}
+    engines: {node: '>=20.0.0'}
+
+  '@azure/logger@1.3.0':
+    resolution: {integrity: sha512-fCqPIfOcLE+CGqGPd66c8bZpwAji98tZ4JI9i/mlTNTlsIWslCfpg48s/ypyLxZTump5sypjrKn2/kY7q8oAbA==}
+    engines: {node: '>=20.0.0'}
+
+  '@azure/ms-rest-js@2.7.0':
+    resolution: {integrity: sha512-ngbzWbqF+NmztDOpLBVDxYM+XLcUj7nKhxGbSU9WtIsXfRB//cf2ZbAG5HkOrhU9/wd/ORRB6lM/d69RKVjiyA==}
+
+  '@azure/storage-blob@12.31.0':
+    resolution: {integrity: sha512-DBgNv10aCSxopt92DkTDD0o9xScXeBqPKGmR50FPZQaEcH4JLQ+GEOGEDv19V5BMkB7kxr+m4h6il/cCDPvmHg==}
+    engines: {node: '>=20.0.0'}
+
+  '@azure/storage-common@12.3.0':
+    resolution: {integrity: sha512-/OFHhy86aG5Pe8dP5tsp+BuJ25JOAl9yaMU3WZbkeoiFMHFtJ7tu5ili7qEdBXNW9G5lDB19trwyI6V49F/8iQ==}
+    engines: {node: '>=20.0.0'}
 
   '@biomejs/biome@2.3.11':
     resolution: {integrity: sha512-/zt+6qazBWguPG6+eWmiELqO+9jRsMZ/DBU3lfuU2ngtIQYzymocHhKiZRyrbra4aCOoyTg/BmY+6WH5mv9xmQ==}
@@ -94,6 +183,10 @@ packages:
 
   '@chainsafe/as-sha256@1.2.0':
     resolution: {integrity: sha512-H2BNHQ5C3RS+H0ZvOdovK6GjFAyq5T6LClad8ivwj9Oaiy28uvdsGVS7gNJKuZmg0FGHAI+n7F0Qju6U0QkKDA==}
+
+  '@chainsafe/benchmark@2.0.1':
+    resolution: {integrity: sha512-Noecu9z6kjXWdKl9ZL/PckJxfi+Ax4/8/i4F862jo3FZcViK8LWR5Byc8pKeNC5vcDMSP73/ME3vgUovYGqwUw==}
+    hasBin: true
 
   '@chainsafe/biomejs-config@1.0.0':
     resolution: {integrity: sha512-juZ0Oivc8QeF5wIUDdgOfOvAH4II8N3hHjQBdyv2PjvbTXna+gTv0kucJ9Mp7HO+nwRH58fhFh7iOMfsrSfogg==}
@@ -312,6 +405,10 @@ packages:
     resolution: {integrity: sha512-HpjNyRaXODjXMqVTpq75jaY6TfeBk3icPWYUAbkqrQFpFfYCbPUdWPJ4FCYrejxYGUbaJGFKp8IHHEmMYp2MBw==}
     hasBin: true
 
+  '@colors/colors@1.5.0':
+    resolution: {integrity: sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==}
+    engines: {node: '>=0.1.90'}
+
   '@emnapi/core@1.8.1':
     resolution: {integrity: sha512-AvT9QFpxK0Zd8J0jopedNm+w/2fIzvtPKPjqyw9jwvBaReTTqPBk9Hixaz7KbjimP+QNz605/XnjFcDAL2pqBg==}
 
@@ -476,6 +573,14 @@ packages:
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
+
+  '@fastify/busboy@2.1.1':
+    resolution: {integrity: sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==}
+    engines: {node: '>=14'}
+
+  '@isaacs/cliui@8.0.2':
+    resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
+    engines: {node: '>=12'}
 
   '@jridgewell/sourcemap-codec@1.5.5':
     resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
@@ -770,6 +875,64 @@ packages:
     resolution: {integrity: sha512-+llXfqt+UzgoDzT9of5vPQPGqTAVCohU74I9zIBkNo5TH6s2P31DFJOGsJQKN207f0GHnYv5pV3wh3BCY/un/A==}
     engines: {node: '>= 10'}
 
+  '@octokit/auth-token@4.0.0':
+    resolution: {integrity: sha512-tY/msAuJo6ARbK6SPIxZrPBms3xPbfwBrulZe0Wtr/DIY9lje2HeV1uoebShn6mx7SjCHif6EjMvoREj+gZ+SA==}
+    engines: {node: '>= 18'}
+
+  '@octokit/core@5.2.2':
+    resolution: {integrity: sha512-/g2d4sW9nUDJOMz3mabVQvOGhVa4e/BN/Um7yca9Bb2XTzPPnfTWHWQg+IsEYO7M3Vx+EXvaM/I2pJWIMun1bg==}
+    engines: {node: '>= 18'}
+
+  '@octokit/endpoint@9.0.6':
+    resolution: {integrity: sha512-H1fNTMA57HbkFESSt3Y9+FBICv+0jFceJFPWDePYlR/iMGrwM5ph+Dd4XRQs+8X+PUFURLQgX9ChPfhJ/1uNQw==}
+    engines: {node: '>= 18'}
+
+  '@octokit/graphql@7.1.1':
+    resolution: {integrity: sha512-3mkDltSfcDUoa176nlGoA32RGjeWjl3K7F/BwHwRMJUW/IteSa4bnSV8p2ThNkcIcZU2umkZWxwETSSCJf2Q7g==}
+    engines: {node: '>= 18'}
+
+  '@octokit/openapi-types@20.0.0':
+    resolution: {integrity: sha512-EtqRBEjp1dL/15V7WiX5LJMIxxkdiGJnabzYx5Apx4FkQIFgAfKumXeYAqqJCj1s+BMX4cPFIFC4OLCR6stlnA==}
+
+  '@octokit/openapi-types@24.2.0':
+    resolution: {integrity: sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg==}
+
+  '@octokit/plugin-paginate-rest@9.2.2':
+    resolution: {integrity: sha512-u3KYkGF7GcZnSD/3UP0S7K5XUFT2FkOQdcfXZGZQPGv3lm4F2Xbf71lvjldr8c1H3nNbF+33cLEkWYbokGWqiQ==}
+    engines: {node: '>= 18'}
+    peerDependencies:
+      '@octokit/core': '5'
+
+  '@octokit/plugin-rest-endpoint-methods@10.4.1':
+    resolution: {integrity: sha512-xV1b+ceKV9KytQe3zCVqjg+8GTGfDYwaT1ATU5isiUyVtlVAO3HNdzpS4sr4GBx4hxQ46s7ITtZrAsxG22+rVg==}
+    engines: {node: '>= 18'}
+    peerDependencies:
+      '@octokit/core': '5'
+
+  '@octokit/request-error@5.1.1':
+    resolution: {integrity: sha512-v9iyEQJH6ZntoENr9/yXxjuezh4My67CBSu9r6Ve/05Iu5gNgnisNWOsoJHTP6k0Rr0+HQIpnH+kyammu90q/g==}
+    engines: {node: '>= 18'}
+
+  '@octokit/request@8.4.1':
+    resolution: {integrity: sha512-qnB2+SY3hkCmBxZsR/MPCybNmbJe4KAlfWErXq+rBKkQJlbjdJeS85VI9r8UqeLYLvnAenU8Q1okM/0MBsAGXw==}
+    engines: {node: '>= 18'}
+
+  '@octokit/types@12.6.0':
+    resolution: {integrity: sha512-1rhSOfRa6H9w4YwK0yrf5faDaDTb+yLyBUKOCV4xtCDB5VmIPqd/v9yr9o6SAzOAlRxMiRiCic6JVM1/kunVkw==}
+
+  '@octokit/types@13.10.0':
+    resolution: {integrity: sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA==}
+
+  '@pkgjs/parseargs@0.11.0':
+    resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
+    engines: {node: '>=14'}
+
+  '@protobuf-ts/runtime-rpc@2.11.1':
+    resolution: {integrity: sha512-4CqqUmNA+/uMz00+d3CYKgElXO9VrEbucjnBFEjqI4GuDrEQ32MaI3q+9qPBvIGOlL4PmHXrzM32vBPWRhQKWQ==}
+
+  '@protobuf-ts/runtime@2.11.1':
+    resolution: {integrity: sha512-KuDaT1IfHkugM2pyz+FwiY80ejWrkH1pAtOBOZFuR6SXEFTsnb/jiQWQ1rCIrcKx2BtyxnxW6BWwsVSA/Ie+WQ==}
+
   '@rollup/rollup-android-arm-eabi@4.55.1':
     resolution: {integrity: sha512-9R0DM/ykwfGIlNu6+2U09ga0WXeZ9MRC2Ter8jnz8415VbuIykVuc6bhdrbORFZANDmTDvq26mJrEVTl8TdnDg==}
     cpu: [arm]
@@ -929,6 +1092,10 @@ packages:
   '@types/retry@0.12.2':
     resolution: {integrity: sha512-XISRgDJ2Tc5q4TRqvgJtzsRkFYNJzZrhTdtMoGVBttwzzQJkPnS3WWTFc7kuDRoPtPakl+T+OfdEUjYJj7Jbow==}
 
+  '@typespec/ts-http-runtime@0.3.3':
+    resolution: {integrity: sha512-91fp6CAAJSRtH5ja95T1FHSKa8aPW9/Zw6cta81jlZTUw/+Vq8jM/AfF/14h2b71wwR84JUTW/3Y8QPhDAawFA==}
+    engines: {node: '>=20.0.0'}
+
   '@vitest/expect@4.0.17':
     resolution: {integrity: sha512-mEoqP3RqhKlbmUmntNDDCJeTDavDR+fVYkSOw8qRwJFaW/0/5zA9zFeTrHqNtcmwh6j26yMmwx2PqUDPzt5ZAQ==}
 
@@ -943,8 +1110,14 @@ packages:
       vite:
         optional: true
 
+  '@vitest/pretty-format@2.1.9':
+    resolution: {integrity: sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==}
+
   '@vitest/pretty-format@4.0.17':
     resolution: {integrity: sha512-Ah3VAYmjcEdHg6+MwFE17qyLqBHZ+ni2ScKCiW2XrlSBV4H3Z7vYfPfz7CWQ33gyu76oc0Ai36+kgLU3rfF4nw==}
+
+  '@vitest/runner@2.1.9':
+    resolution: {integrity: sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==}
 
   '@vitest/runner@4.0.17':
     resolution: {integrity: sha512-JmuQyf8aMWoo/LmNFppdpkfRVHJcsgzkbCA+/Bk7VfNH7RE6Ut2qxegeyx2j3ojtJtKIbIGy3h+KxGfYfk28YQ==}
@@ -955,11 +1128,41 @@ packages:
   '@vitest/spy@4.0.17':
     resolution: {integrity: sha512-I1bQo8QaP6tZlTomQNWKJE6ym4SHf3oLS7ceNjozxxgzavRAgZDc06T7kD8gb9bXKEgcLNt00Z+kZO6KaJ62Ew==}
 
+  '@vitest/utils@2.1.9':
+    resolution: {integrity: sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==}
+
   '@vitest/utils@4.0.17':
     resolution: {integrity: sha512-RG6iy+IzQpa9SB8HAFHJ9Y+pTzI+h8553MrciN9eC6TFBErqrQaTas4vG+MVj8S4uKk8uTT2p0vgZPnTdxd96w==}
 
+  abort-controller@3.0.0:
+    resolution: {integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==}
+    engines: {node: '>=6.5'}
+
   abort-error@1.0.1:
     resolution: {integrity: sha512-fxqCblJiIPdSXIUrxI0PL+eJG49QdP9SQ70qtB65MVAoMr2rASlOyAbJFOylfB467F/f+5BCLJJq58RYi7mGfg==}
+
+  agent-base@7.1.4:
+    resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
+    engines: {node: '>= 14'}
+
+  ajv@8.18.0:
+    resolution: {integrity: sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==}
+
+  ansi-regex@5.0.1:
+    resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
+    engines: {node: '>=8'}
+
+  ansi-regex@6.2.2:
+    resolution: {integrity: sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==}
+    engines: {node: '>=12'}
+
+  ansi-styles@4.3.0:
+    resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
+    engines: {node: '>=8'}
+
+  ansi-styles@6.2.3:
+    resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
+    engines: {node: '>=12'}
 
   any-signal@4.2.0:
     resolution: {integrity: sha512-LndMvYuAPf4rC195lk7oSFuHOYFpOszIYrNYv0gHAvz+aEhE9qPZLhmrIz5pXP2BSsPOXvsuHDXEGaiQhIh9wA==}
@@ -972,8 +1175,26 @@ packages:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
 
+  asynckit@0.4.0:
+    resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
+
+  available-typed-arrays@1.0.7:
+    resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
+    engines: {node: '>= 0.4'}
+
+  aws-sdk@2.1693.0:
+    resolution: {integrity: sha512-cJmb8xEnVLT+R6fBS5sn/EFJiX7tUnDaPtOPZ1vFbOJtd0fnZn/Ky2XGgsvvoeliWeH7mL3TWSX5zXXGSQV6gQ==}
+    engines: {node: '>= 10.0.0'}
+    deprecated: The AWS SDK for JavaScript (v2) has reached end-of-support, and no longer receives updates. Please migrate your code to use AWS SDK for JavaScript (v3). More info https://a.co/cUPnyil
+
+  balanced-match@1.0.2:
+    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
+
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
+
+  before-after-hook@2.2.3:
+    resolution: {integrity: sha512-NzUnlZexiaH/46WDhANlyR2bXRopNg4F/zuSA3OpZnllCUgRaOF2znDioDWrmbNVsuZk6l9pMquQB38cfBZwkQ==}
 
   bigint-buffer@1.1.5:
     resolution: {integrity: sha512-trfYco6AoZ+rKhKnxA0hgX0HAbVP/s808/EuDSe2JDzUnCp/xAsli35Orvk67UrTEcwuxZqYZDmfA2RXJgxVvA==}
@@ -982,8 +1203,29 @@ packages:
   bindings@1.5.0:
     resolution: {integrity: sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==}
 
+  brace-expansion@1.1.12:
+    resolution: {integrity: sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==}
+
+  brace-expansion@2.0.2:
+    resolution: {integrity: sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==}
+
+  buffer@4.9.2:
+    resolution: {integrity: sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==}
+
   buffer@6.0.3:
     resolution: {integrity: sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==}
+
+  call-bind-apply-helpers@1.0.2:
+    resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
+    engines: {node: '>= 0.4'}
+
+  call-bind@1.0.8:
+    resolution: {integrity: sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==}
+    engines: {node: '>= 0.4'}
+
+  call-bound@1.0.4:
+    resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
+    engines: {node: '>= 0.4'}
 
   case@1.6.3:
     resolution: {integrity: sha512-mzDSXIPaFwVDvZAHqZ9VlbyF4yyXRuX6IvB06WvPYkqJVO24kX1PPhv9bfpKNFZyxYFmmgo03HUiD8iklmJYRQ==}
@@ -993,24 +1235,109 @@ packages:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
     engines: {node: '>=18'}
 
+  cli-table3@0.6.5:
+    resolution: {integrity: sha512-+W/5efTR7y5HRD7gACw9yQjqMVvEMLBHmboM/kPWam+H+Hmyrgjh6YncVKK122YZkXrLudzTuAukUw9FnMf7IQ==}
+    engines: {node: 10.* || >= 12.*}
+
+  cliui@8.0.1:
+    resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
+    engines: {node: '>=12'}
+
+  color-convert@2.0.1:
+    resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
+    engines: {node: '>=7.0.0'}
+
+  color-name@1.1.4:
+    resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+
+  combined-stream@1.0.8:
+    resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
+    engines: {node: '>= 0.8'}
+
+  concat-map@0.0.1:
+    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
+
+  cross-spawn@7.0.6:
+    resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
+    engines: {node: '>= 8'}
+
+  csv-parse@5.6.0:
+    resolution: {integrity: sha512-l3nz3euub2QMg5ouu5U09Ew9Wf6/wQ8I++ch1loQ0ljmzhmfZYrH9fflS22i/PQEvsPvxCwxgz5q7UB8K1JO4Q==}
+
+  csv-stringify@6.6.0:
+    resolution: {integrity: sha512-YW32lKOmIBgbxtu3g5SaiqWNwa/9ISQt2EcgOq0+RAIFufFp9is6tqNnKahqE5kuKvrnYAzs28r+s6pXJR8Vcw==}
+
   datastore-core@10.0.4:
     resolution: {integrity: sha512-IctgCO0GA7GHG7aRm3JRruibCsfvN4EXNnNIlLCZMKIv0TPkdAL5UFV3/xTYFYrrZ1jRNrXZNZRvfcVf/R+rAw==}
+
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  define-data-property@1.1.4:
+    resolution: {integrity: sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==}
+    engines: {node: '>= 0.4'}
 
   delay@6.0.0:
     resolution: {integrity: sha512-2NJozoOHQ4NuZuVIr5CWd0iiLVIRSDepakaovIN+9eIDHEhdCAEvSy2cuf1DCrPPQLvHmbqTHODlhHg8UCy4zw==}
     engines: {node: '>=16'}
 
+  delayed-stream@1.0.0:
+    resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
+    engines: {node: '>=0.4.0'}
+
+  deprecation@2.3.1:
+    resolution: {integrity: sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ==}
+
   dns-packet@5.6.1:
     resolution: {integrity: sha512-l4gcSouhcgIKRvyy99RNVOgxXiicE+2jZoNmaNmZ6JXiGajBOJAesk1OBlJuM5k2c+eudGdLxDqXuPCKIj6kpw==}
     engines: {node: '>=6'}
 
+  dunder-proto@1.0.1:
+    resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
+    engines: {node: '>= 0.4'}
+
+  eastasianwidth@0.2.0:
+    resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
+
+  emoji-regex@8.0.0:
+    resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
+
+  emoji-regex@9.2.2:
+    resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
+
+  es-define-property@1.0.1:
+    resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
+    engines: {node: '>= 0.4'}
+
+  es-errors@1.3.0:
+    resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
+    engines: {node: '>= 0.4'}
+
   es-module-lexer@1.7.0:
     resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
+
+  es-object-atoms@1.1.1:
+    resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
+    engines: {node: '>= 0.4'}
+
+  es-set-tostringtag@2.1.0:
+    resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
+    engines: {node: '>= 0.4'}
 
   esbuild@0.27.2:
     resolution: {integrity: sha512-HyNQImnsOC7X9PMNaCIeAm4ISCQXs5a5YasTXVliKv4uuBo1dKrG0A+uQS8M5eXjVMnLg3WgXaKvprHlFJQffw==}
     engines: {node: '>=18'}
     hasBin: true
+
+  escalade@3.2.0:
+    resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
+    engines: {node: '>=6'}
 
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
@@ -1018,12 +1345,37 @@ packages:
   ethereum-cryptography@2.2.1:
     resolution: {integrity: sha512-r/W8lkHSiTLxUxW8Rf3u4HGB0xQweG2RyETjywylKZSzLWoWAijRz8WCuOtJ6wah+avllXBqZuk29HCCvhEIRg==}
 
+  event-target-shim@5.0.1:
+    resolution: {integrity: sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==}
+    engines: {node: '>=6'}
+
   eventemitter3@5.0.1:
     resolution: {integrity: sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==}
+
+  events@1.1.1:
+    resolution: {integrity: sha512-kEcvvCBByWXGnZy6JUlgAp2gBIUjfCAV6P6TgT1/aaQKcmuAEC4OZTV1I4EWQLz2gxZw76atuVyvHhTxvi0Flw==}
+    engines: {node: '>=0.4.x'}
+
+  events@3.3.0:
+    resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
+    engines: {node: '>=0.8.x'}
 
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
+
+  fast-deep-equal@3.1.3:
+    resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+
+  fast-uri@3.1.0:
+    resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
+
+  fast-xml-builder@1.0.0:
+    resolution: {integrity: sha512-fpZuDogrAgnyt9oDDz+5DBz0zgPdPZz6D4IR7iESxRXElrlGTRkHJ9eEt+SACRJwT0FNFrt71DFQIUFBJfX/uQ==}
+
+  fast-xml-parser@5.4.2:
+    resolution: {integrity: sha512-pw/6pIl4k0CSpElPEJhDppLzaixDEuWui2CUQQBH/ECDf7+y6YwA4Gf7Tyb0Rfe4DIMuZipYj4AEL0nACKglvQ==}
+    hasBin: true
 
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
@@ -1037,25 +1389,110 @@ packages:
   file-uri-to-path@1.0.0:
     resolution: {integrity: sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==}
 
+  for-each@0.3.5:
+    resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
+    engines: {node: '>= 0.4'}
+
+  foreground-child@3.3.1:
+    resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
+    engines: {node: '>=14'}
+
+  form-data@2.5.5:
+    resolution: {integrity: sha512-jqdObeR2rxZZbPSGL+3VckHMYtu+f9//KXBsVny6JSX/pa38Fy+bGjuG8eW/H6USNQWhLi8Num++cU2yOCNz4A==}
+    engines: {node: '>= 0.12'}
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
 
+  function-bind@1.1.2:
+    resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
+
+  generator-function@2.0.1:
+    resolution: {integrity: sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==}
+    engines: {node: '>= 0.4'}
+
+  get-caller-file@2.0.5:
+    resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
+    engines: {node: 6.* || 8.* || >= 10.*}
+
+  get-intrinsic@1.3.0:
+    resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
+    engines: {node: '>= 0.4'}
+
   get-iterator@2.0.1:
     resolution: {integrity: sha512-7HuY/hebu4gryTDT7O/XY/fvY9wRByEGdK6QOa4of8npTcv0+NS6frFKABcf6S9EBAsveTuKTsZQQBFMMNILIg==}
+
+  get-proto@1.0.1:
+    resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
+    engines: {node: '>= 0.4'}
+
+  glob@10.5.0:
+    resolution: {integrity: sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+    hasBin: true
+
+  gopd@1.2.0:
+    resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
+    engines: {node: '>= 0.4'}
+
+  has-property-descriptors@1.0.2:
+    resolution: {integrity: sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==}
+
+  has-symbols@1.1.0:
+    resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
+    engines: {node: '>= 0.4'}
+
+  has-tostringtag@1.0.2:
+    resolution: {integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==}
+    engines: {node: '>= 0.4'}
 
   hashlru@2.3.0:
     resolution: {integrity: sha512-0cMsjjIC8I+D3M44pOQdsy0OHXGLVz6Z0beRuufhKa0KfaD2wGwAev6jILzXsd3/vpnNQJmWyZtIILqM1N+n5A==}
 
+  hasown@2.0.2:
+    resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
+    engines: {node: '>= 0.4'}
+
+  http-proxy-agent@7.0.2:
+    resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
+    engines: {node: '>= 14'}
+
+  https-proxy-agent@7.0.6:
+    resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
+    engines: {node: '>= 14'}
+
+  ieee754@1.1.13:
+    resolution: {integrity: sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==}
+
   ieee754@1.2.1:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
+
+  inherits@2.0.4:
+    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
 
   interface-datastore@8.3.2:
     resolution: {integrity: sha512-R3NLts7pRbJKc3qFdQf+u40hK8XWc0w4Qkx3OFEstC80VoaDUABY/dXA2EJPhtNC+bsrf41Ehvqb6+pnIclyRA==}
 
   interface-store@6.0.3:
     resolution: {integrity: sha512-+WvfEZnFUhRwFxgz+QCQi7UC6o9AM0EHM9bpIe2Nhqb100NHCsTvNAn4eJgvgV2/tmLo1MP9nGxQKEcZTAueLA==}
+
+  is-arguments@1.2.0:
+    resolution: {integrity: sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==}
+    engines: {node: '>= 0.4'}
+
+  is-callable@1.2.7:
+    resolution: {integrity: sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==}
+    engines: {node: '>= 0.4'}
+
+  is-fullwidth-code-point@3.0.0:
+    resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
+    engines: {node: '>=8'}
+
+  is-generator-function@1.1.2:
+    resolution: {integrity: sha512-upqt1SkGkODW9tsGNG5mtXTXtECizwtS2kA161M+gJPc1xdb/Ax629af6YrTwcOeQHbewrPNlE5Dx7kzvXTizA==}
+    engines: {node: '>= 0.4'}
 
   is-loopback-addr@2.0.2:
     resolution: {integrity: sha512-26POf2KRCno/KTNL5Q0b/9TYnL00xEsSaLfiFRmjM7m7Lw7ZMmFybzzuX4CcsLAluZGd+niLUiMRxEooVE3aqg==}
@@ -1067,6 +1504,24 @@ packages:
   is-plain-obj@4.1.0:
     resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
     engines: {node: '>=12'}
+
+  is-regex@1.2.1:
+    resolution: {integrity: sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==}
+    engines: {node: '>= 0.4'}
+
+  is-typed-array@1.1.15:
+    resolution: {integrity: sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==}
+    engines: {node: '>= 0.4'}
+
+  is-unicode-supported@2.1.0:
+    resolution: {integrity: sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==}
+    engines: {node: '>=18'}
+
+  isarray@1.0.0:
+    resolution: {integrity: sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==}
+
+  isexe@2.0.0:
+    resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
   it-all@3.0.9:
     resolution: {integrity: sha512-fz1oJJ36ciGnu2LntAlE6SA97bFZpW7Rnt0uEc1yazzR2nKokZLr8lIRtgnpex4NsmaBcvHF+Z9krljWFy/mmg==}
@@ -1128,12 +1583,32 @@ packages:
   it-take@3.0.9:
     resolution: {integrity: sha512-XMeUbnjOcgrhFXPUqa7H0VIjYSV/BvyxxjCp76QHVAFDJw2LmR1SHxUFiqyGeobgzJr7P2ZwSRRJQGn4D2BVlA==}
 
+  jackspeak@3.4.3:
+    resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
+
+  jmespath@0.16.0:
+    resolution: {integrity: sha512-9FzQjJ7MATs1tSpnco1K6ayiYE3figslrXA72G2HQ/n76RzvYlofyi5QM+iX4YRs/pu3yzxlVQSST23+dMDknw==}
+    engines: {node: '>= 0.6.0'}
+
   js-yaml@4.1.1:
     resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
     hasBin: true
 
+  json-schema-traverse@1.0.0:
+    resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
+
   libp2p@2.9.0:
     resolution: {integrity: sha512-gzRnhLY+k9KjYifWQCYbdEfmWqCFdM0TZ5Q7qqdY13sAUKXixK0MF5+Z9LMrm5ELGDPWX7pRVLGK8BOSv5/v3Q==}
+
+  log-symbols@7.0.1:
+    resolution: {integrity: sha512-ja1E3yCr9i/0hmBVaM0bfwDjnGy8I/s6PP4DFp+yP+a+mrHO4Rm7DtmnqROTUkHIkqffC84YY7AeqX6oFk0WFg==}
+    engines: {node: '>=18'}
+
+  loupe@3.2.1:
+    resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
+
+  lru-cache@10.4.3:
+    resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
@@ -1141,8 +1616,34 @@ packages:
   main-event@1.0.1:
     resolution: {integrity: sha512-NWtdGrAca/69fm6DIVd8T9rtfDII4Q8NQbIbsKQq2VzS9eqOGYs8uaNQjcuaCq/d9H/o625aOTJX2Qoxzqw0Pw==}
 
+  math-intrinsics@1.1.0:
+    resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
+    engines: {node: '>= 0.4'}
+
+  mime-db@1.52.0:
+    resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
+    engines: {node: '>= 0.6'}
+
+  mime-types@2.1.35:
+    resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
+    engines: {node: '>= 0.6'}
+
+  minimatch@3.1.5:
+    resolution: {integrity: sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==}
+
+  minimatch@9.0.9:
+    resolution: {integrity: sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==}
+    engines: {node: '>=16 || 14 >=14.17'}
+
+  minipass@7.1.3:
+    resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
+    engines: {node: '>=16 || 14 >=14.17'}
+
   mortice@3.3.1:
     resolution: {integrity: sha512-t3oESfijIPGsmsdLEKjF+grHfrbnKSXflJtgb1wY14cjxZpS6GnhHRXTxxzCAoCCnq1YYfpEPwY3gjiCPhOufQ==}
+
+  ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
   ms@3.0.0-canary.202508261828:
     resolution: {integrity: sha512-NotsCoUCIUkojWCzQff4ttdCfIPoA1UGZsyQbi7KmqkNRfKCrvga8JJi2PknHymHOuor0cJSn/ylj52Cbt2IrQ==}
@@ -1160,8 +1661,20 @@ packages:
     resolution: {integrity: sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg==}
     engines: {node: '>= 0.4.0'}
 
+  node-fetch@2.7.0:
+    resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
+    engines: {node: 4.x || >=6.0.0}
+    peerDependencies:
+      encoding: ^0.1.0
+    peerDependenciesMeta:
+      encoding:
+        optional: true
+
   obug@2.1.1:
     resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
+
+  once@1.4.0:
+    resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
 
   p-defer@4.0.1:
     resolution: {integrity: sha512-Mr5KC5efvAK5VUptYEIopP1bakB85k2IWXaRC0rsh1uwn1L6M0LVml8OIQ4Gudg4oyZakf7FmeRLkMMtZW1i5A==}
@@ -1179,6 +1692,20 @@ packages:
     resolution: {integrity: sha512-AxTM2wDGORHGEkPCt8yqxOTMgpfbEHqF51f/5fJCmwFC3C/zNcGT63SymH2ttOAaiIws2zVg4+izQCjrakcwHg==}
     engines: {node: '>=20'}
 
+  package-json-from-dist@1.0.1:
+    resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
+
+  path-key@3.1.1:
+    resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
+    engines: {node: '>=8'}
+
+  path-scurry@1.11.1:
+    resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
+    engines: {node: '>=16 || 14 >=14.18'}
+
+  pathe@1.1.2:
+    resolution: {integrity: sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==}
+
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
 
@@ -1188,6 +1715,10 @@ packages:
   picomatch@4.0.3:
     resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
     engines: {node: '>=12'}
+
+  possible-typed-array-names@1.1.0:
+    resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
+    engines: {node: '>= 0.4'}
 
   postcss@8.5.6:
     resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
@@ -1199,6 +1730,14 @@ packages:
   protons-runtime@5.6.0:
     resolution: {integrity: sha512-/Kde+sB9DsMFrddJT/UZWe6XqvL7SL5dbag/DBCElFKhkwDj7XKt53S+mzLyaDP5OqS0wXjV5SA572uWDaT0Hg==}
 
+  punycode@1.3.2:
+    resolution: {integrity: sha512-RofWgt/7fL5wP1Y7fxE7/EmTLzQVnB0ycyibJ0OOHIlJqTNzglYFxVwETOcIoJqJmpDXJ9xImDv+Fq34F/d4Dw==}
+
+  querystring@0.2.0:
+    resolution: {integrity: sha512-X/xY82scca2tau62i9mDyU9K+I+djTMUsvwf7xnUX5GLvVzgJybOJf4Y6o9Zx3oJK/LSXg5tTZBjwzqVPaPO2g==}
+    engines: {node: '>=0.4.x'}
+    deprecated: The querystring API is considered Legacy. new code should use the URLSearchParams API instead.
+
   race-event@1.6.1:
     resolution: {integrity: sha512-vi7WH5g5KoTFpu2mme/HqZiWH14XSOtg5rfp6raBskBHl7wnmy3F/biAIyY5MsK+BHWhoPhxtZ1Y2R7OHHaWyQ==}
 
@@ -1207,6 +1746,14 @@ packages:
 
   race-signal@2.0.0:
     resolution: {integrity: sha512-P31bLhE4ByBX/70QDXMutxnqgwrF1WUXea1O8DXuviAgkdbQ1iQMQotNgzJIBC9yUSn08u/acZrMUhgw7w6GpA==}
+
+  require-directory@2.1.1:
+    resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
+    engines: {node: '>=0.10.0'}
+
+  require-from-string@2.0.2:
+    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
+    engines: {node: '>=0.10.0'}
 
   retry@0.13.1:
     resolution: {integrity: sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==}
@@ -1217,8 +1764,42 @@ packages:
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
+  safe-buffer@5.2.1:
+    resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
+
+  safe-regex-test@1.1.0:
+    resolution: {integrity: sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==}
+    engines: {node: '>= 0.4'}
+
+  sax@1.2.1:
+    resolution: {integrity: sha512-8I2a3LovHTOpm7NV5yOyO8IHqgVsfK4+UuySrXU8YXkSRX7k6hCV9b3HrkKCr3nMpgj+0bmocaJJWpvp1oc7ZA==}
+
+  sax@1.5.0:
+    resolution: {integrity: sha512-21IYA3Q5cQf089Z6tgaUTr7lDAyzoTPx5HRtbhsME8Udispad8dC/+sziTNugOEx54ilvatQ9YCzl4KQLPcRHA==}
+    engines: {node: '>=11.0.0'}
+
+  semver@6.3.1:
+    resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
+    hasBin: true
+
+  set-function-length@1.2.2:
+    resolution: {integrity: sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==}
+    engines: {node: '>= 0.4'}
+
+  shebang-command@2.0.0:
+    resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
+    engines: {node: '>=8'}
+
+  shebang-regex@3.0.0:
+    resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
+    engines: {node: '>=8'}
+
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
+  signal-exit@4.1.0:
+    resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
+    engines: {node: '>=14'}
 
   snappy@7.3.3:
     resolution: {integrity: sha512-UDJVCunvgblRpfTOjo/uT7pQzfrTsSICJ4yVS4aq7SsGBaUSpJwaVP15nF//jqinSLpN7boe/BqbUmtWMTQ5MQ==}
@@ -1237,6 +1818,25 @@ packages:
   std-env@3.10.0:
     resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
 
+  string-width@4.2.3:
+    resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
+    engines: {node: '>=8'}
+
+  string-width@5.1.2:
+    resolution: {integrity: sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==}
+    engines: {node: '>=12'}
+
+  strip-ansi@6.0.1:
+    resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
+    engines: {node: '>=8'}
+
+  strip-ansi@7.2.0:
+    resolution: {integrity: sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==}
+    engines: {node: '>=12'}
+
+  strnum@2.2.0:
+    resolution: {integrity: sha512-Y7Bj8XyJxnPAORMZj/xltsfo55uOiyHcU2tnAVzHUnSJR/KsEX+9RoDeXEnsXtl/CX4fAcrt64gZ13aGaWPeBg==}
+
   supports-color@10.2.2:
     resolution: {integrity: sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==}
     engines: {node: '>=18'}
@@ -1252,12 +1852,26 @@ packages:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
     engines: {node: '>=12.0.0'}
 
+  tinyrainbow@1.2.0:
+    resolution: {integrity: sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==}
+    engines: {node: '>=14.0.0'}
+
   tinyrainbow@3.0.3:
     resolution: {integrity: sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==}
     engines: {node: '>=14.0.0'}
 
+  tr46@0.0.3:
+    resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
+
+  tslib@1.14.1:
+    resolution: {integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==}
+
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  tunnel@0.0.6:
+    resolution: {integrity: sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==}
+    engines: {node: '>=0.6.11 <=0.7.0 || >=0.7.3'}
 
   uint8-varint@2.0.4:
     resolution: {integrity: sha512-FwpTa7ZGA/f/EssWAb5/YV6pHgVF1fViKdW8cWaEarjB8t7NyofSWBdOTyFPaGuUG4gx3v1O3PQ8etsiOs3lcw==}
@@ -1270,6 +1884,27 @@ packages:
 
   undici-types@7.16.0:
     resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
+
+  undici@5.29.0:
+    resolution: {integrity: sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==}
+    engines: {node: '>=14.0'}
+
+  universal-user-agent@6.0.1:
+    resolution: {integrity: sha512-yCzhz6FN2wU1NiiQRogkTQszlQSlpWaw8SvVegAc+bDxbzHgh1vX8uIe8OYyMH6DwH+sdTJsgMl36+mSMdRJIQ==}
+
+  url@0.10.3:
+    resolution: {integrity: sha512-hzSUW2q06EqL1gKM/a+obYHLIO6ct2hwPuviqTTOcfFVc61UbfJ2Q32+uGL/HCPxKqrdGB5QUwIe7UqlDgwsOQ==}
+
+  util@0.12.5:
+    resolution: {integrity: sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==}
+
+  uuid@8.0.0:
+    resolution: {integrity: sha512-jOXGuXZAWdsTH7eZLtyXMqUb9EcWMGZNbL9YcGBJl4MH4nrxHmZJhEHvyLFrkxo+28uLb/NYRcStH48fnD0Vzw==}
+    hasBin: true
+
+  uuid@8.3.2:
+    resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
+    hasBin: true
 
   vite@7.3.1:
     resolution: {integrity: sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==}
@@ -1348,12 +1983,249 @@ packages:
   weald@1.1.1:
     resolution: {integrity: sha512-PaEQShzMCz8J/AD2N3dJMc1hTZWkJeLKS2NMeiVkV5KDHwgZe7qXLEzyodsT/SODxWDdXJJqocuwf3kHzcXhSQ==}
 
+  webidl-conversions@3.0.1:
+    resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
+
+  whatwg-url@5.0.0:
+    resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
+
+  which-typed-array@1.1.20:
+    resolution: {integrity: sha512-LYfpUkmqwl0h9A2HL09Mms427Q1RZWuOHsukfVcKRq9q95iQxdw0ix1JQrqbcDR9PH1QDwf5Qo8OZb5lksZ8Xg==}
+    engines: {node: '>= 0.4'}
+
+  which@2.0.2:
+    resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
+    engines: {node: '>= 8'}
+    hasBin: true
+
   why-is-node-running@2.3.0:
     resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
     engines: {node: '>=8'}
     hasBin: true
 
+  wrap-ansi@7.0.0:
+    resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
+    engines: {node: '>=10'}
+
+  wrap-ansi@8.1.0:
+    resolution: {integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==}
+    engines: {node: '>=12'}
+
+  wrappy@1.0.2:
+    resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+
+  xml2js@0.5.0:
+    resolution: {integrity: sha512-drPFnkQJik/O+uPKpqSgr22mpuFHqKdbS835iAQrUC73L2F5WkboIRd63ai/2Yg6I1jzifPFKH2NTK+cfglkIA==}
+    engines: {node: '>=4.0.0'}
+
+  xml2js@0.6.2:
+    resolution: {integrity: sha512-T4rieHaC1EXcES0Kxxj4JWgaUQHDk+qwHcYOCFHfiwKz7tOVPLq7Hjq9dM1WCMhylqMEfP7hMcOIChvotiZegA==}
+    engines: {node: '>=4.0.0'}
+
+  xmlbuilder@11.0.1:
+    resolution: {integrity: sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==}
+    engines: {node: '>=4.0'}
+
+  y18n@5.0.8:
+    resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
+    engines: {node: '>=10'}
+
+  yaml@2.8.2:
+    resolution: {integrity: sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==}
+    engines: {node: '>= 14.6'}
+    hasBin: true
+
+  yargs-parser@21.1.1:
+    resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
+    engines: {node: '>=12'}
+
+  yargs@17.7.2:
+    resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==}
+    engines: {node: '>=12'}
+
+  yoctocolors@2.1.2:
+    resolution: {integrity: sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==}
+    engines: {node: '>=18'}
+
 snapshots:
+
+  '@actions/cache@4.1.0':
+    dependencies:
+      '@actions/core': 1.11.1
+      '@actions/exec': 1.1.1
+      '@actions/glob': 0.1.2
+      '@actions/http-client': 2.2.3
+      '@actions/io': 1.1.3
+      '@azure/abort-controller': 1.1.0
+      '@azure/ms-rest-js': 2.7.0
+      '@azure/storage-blob': 12.31.0
+      '@protobuf-ts/runtime-rpc': 2.11.1
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+
+  '@actions/core@1.11.1':
+    dependencies:
+      '@actions/exec': 1.1.1
+      '@actions/http-client': 2.2.3
+
+  '@actions/exec@1.1.1':
+    dependencies:
+      '@actions/io': 1.1.3
+
+  '@actions/github@6.0.1':
+    dependencies:
+      '@actions/http-client': 2.2.3
+      '@octokit/core': 5.2.2
+      '@octokit/plugin-paginate-rest': 9.2.2(@octokit/core@5.2.2)
+      '@octokit/plugin-rest-endpoint-methods': 10.4.1(@octokit/core@5.2.2)
+      '@octokit/request': 8.4.1
+      '@octokit/request-error': 5.1.1
+      undici: 5.29.0
+
+  '@actions/glob@0.1.2':
+    dependencies:
+      '@actions/core': 1.11.1
+      minimatch: 3.1.5
+
+  '@actions/http-client@2.2.3':
+    dependencies:
+      tunnel: 0.0.6
+      undici: 5.29.0
+
+  '@actions/io@1.1.3': {}
+
+  '@azure/abort-controller@1.1.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@azure/abort-controller@2.1.2':
+    dependencies:
+      tslib: 2.8.1
+
+  '@azure/core-auth@1.10.1':
+    dependencies:
+      '@azure/abort-controller': 2.1.2
+      '@azure/core-util': 1.13.1
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@azure/core-client@1.10.1':
+    dependencies:
+      '@azure/abort-controller': 2.1.2
+      '@azure/core-auth': 1.10.1
+      '@azure/core-rest-pipeline': 1.22.2
+      '@azure/core-tracing': 1.3.1
+      '@azure/core-util': 1.13.1
+      '@azure/logger': 1.3.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@azure/core-http-compat@2.3.2(@azure/core-client@1.10.1)(@azure/core-rest-pipeline@1.22.2)':
+    dependencies:
+      '@azure/abort-controller': 2.1.2
+      '@azure/core-client': 1.10.1
+      '@azure/core-rest-pipeline': 1.22.2
+
+  '@azure/core-lro@2.7.2':
+    dependencies:
+      '@azure/abort-controller': 2.1.2
+      '@azure/core-util': 1.13.1
+      '@azure/logger': 1.3.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@azure/core-paging@1.6.2':
+    dependencies:
+      tslib: 2.8.1
+
+  '@azure/core-rest-pipeline@1.22.2':
+    dependencies:
+      '@azure/abort-controller': 2.1.2
+      '@azure/core-auth': 1.10.1
+      '@azure/core-tracing': 1.3.1
+      '@azure/core-util': 1.13.1
+      '@azure/logger': 1.3.0
+      '@typespec/ts-http-runtime': 0.3.3
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@azure/core-tracing@1.3.1':
+    dependencies:
+      tslib: 2.8.1
+
+  '@azure/core-util@1.13.1':
+    dependencies:
+      '@azure/abort-controller': 2.1.2
+      '@typespec/ts-http-runtime': 0.3.3
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@azure/core-xml@1.5.0':
+    dependencies:
+      fast-xml-parser: 5.4.2
+      tslib: 2.8.1
+
+  '@azure/logger@1.3.0':
+    dependencies:
+      '@typespec/ts-http-runtime': 0.3.3
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@azure/ms-rest-js@2.7.0':
+    dependencies:
+      '@azure/core-auth': 1.10.1
+      abort-controller: 3.0.0
+      form-data: 2.5.5
+      node-fetch: 2.7.0
+      tslib: 1.14.1
+      tunnel: 0.0.6
+      uuid: 8.3.2
+      xml2js: 0.5.0
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+
+  '@azure/storage-blob@12.31.0':
+    dependencies:
+      '@azure/abort-controller': 2.1.2
+      '@azure/core-auth': 1.10.1
+      '@azure/core-client': 1.10.1
+      '@azure/core-http-compat': 2.3.2(@azure/core-client@1.10.1)(@azure/core-rest-pipeline@1.22.2)
+      '@azure/core-lro': 2.7.2
+      '@azure/core-paging': 1.6.2
+      '@azure/core-rest-pipeline': 1.22.2
+      '@azure/core-tracing': 1.3.1
+      '@azure/core-util': 1.13.1
+      '@azure/core-xml': 1.5.0
+      '@azure/logger': 1.3.0
+      '@azure/storage-common': 12.3.0(@azure/core-client@1.10.1)
+      events: 3.3.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@azure/storage-common@12.3.0(@azure/core-client@1.10.1)':
+    dependencies:
+      '@azure/abort-controller': 2.1.2
+      '@azure/core-auth': 1.10.1
+      '@azure/core-http-compat': 2.3.2(@azure/core-client@1.10.1)(@azure/core-rest-pipeline@1.22.2)
+      '@azure/core-rest-pipeline': 1.22.2
+      '@azure/core-tracing': 1.3.1
+      '@azure/core-util': 1.13.1
+      '@azure/logger': 1.3.0
+      events: 3.3.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - '@azure/core-client'
+      - supports-color
 
   '@biomejs/biome@2.3.11':
     optionalDependencies:
@@ -1391,6 +2263,25 @@ snapshots:
     optional: true
 
   '@chainsafe/as-sha256@1.2.0': {}
+
+  '@chainsafe/benchmark@2.0.1':
+    dependencies:
+      '@actions/cache': 4.1.0
+      '@actions/github': 6.0.1
+      '@vitest/runner': 2.1.9
+      ajv: 8.18.0
+      aws-sdk: 2.1693.0
+      cli-table3: 0.6.5
+      csv-parse: 5.6.0
+      csv-stringify: 6.6.0
+      debug: 4.4.3
+      glob: 10.5.0
+      log-symbols: 7.0.1
+      yaml: 2.8.2
+      yargs: 17.7.2
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
 
   '@chainsafe/biomejs-config@1.0.0(@biomejs/biome@2.3.11)':
     dependencies:
@@ -1549,6 +2440,9 @@ snapshots:
 
   '@chainsafe/zapi@0.1.1': {}
 
+  '@colors/colors@1.5.0':
+    optional: true
+
   '@emnapi/core@1.8.1':
     dependencies:
       '@emnapi/wasi-threads': 1.1.0
@@ -1642,6 +2536,17 @@ snapshots:
 
   '@esbuild/win32-x64@0.27.2':
     optional: true
+
+  '@fastify/busboy@2.1.1': {}
+
+  '@isaacs/cliui@8.0.2':
+    dependencies:
+      string-width: 5.1.2
+      string-width-cjs: string-width@4.2.3
+      strip-ansi: 7.2.0
+      strip-ansi-cjs: strip-ansi@6.0.1
+      wrap-ansi: 8.1.0
+      wrap-ansi-cjs: wrap-ansi@7.0.0
 
   '@jridgewell/sourcemap-codec@1.5.5': {}
 
@@ -2015,6 +2920,73 @@ snapshots:
       '@node-rs/crc32-win32-x64-msvc': 1.10.6
     optional: true
 
+  '@octokit/auth-token@4.0.0': {}
+
+  '@octokit/core@5.2.2':
+    dependencies:
+      '@octokit/auth-token': 4.0.0
+      '@octokit/graphql': 7.1.1
+      '@octokit/request': 8.4.1
+      '@octokit/request-error': 5.1.1
+      '@octokit/types': 13.10.0
+      before-after-hook: 2.2.3
+      universal-user-agent: 6.0.1
+
+  '@octokit/endpoint@9.0.6':
+    dependencies:
+      '@octokit/types': 13.10.0
+      universal-user-agent: 6.0.1
+
+  '@octokit/graphql@7.1.1':
+    dependencies:
+      '@octokit/request': 8.4.1
+      '@octokit/types': 13.10.0
+      universal-user-agent: 6.0.1
+
+  '@octokit/openapi-types@20.0.0': {}
+
+  '@octokit/openapi-types@24.2.0': {}
+
+  '@octokit/plugin-paginate-rest@9.2.2(@octokit/core@5.2.2)':
+    dependencies:
+      '@octokit/core': 5.2.2
+      '@octokit/types': 12.6.0
+
+  '@octokit/plugin-rest-endpoint-methods@10.4.1(@octokit/core@5.2.2)':
+    dependencies:
+      '@octokit/core': 5.2.2
+      '@octokit/types': 12.6.0
+
+  '@octokit/request-error@5.1.1':
+    dependencies:
+      '@octokit/types': 13.10.0
+      deprecation: 2.3.1
+      once: 1.4.0
+
+  '@octokit/request@8.4.1':
+    dependencies:
+      '@octokit/endpoint': 9.0.6
+      '@octokit/request-error': 5.1.1
+      '@octokit/types': 13.10.0
+      universal-user-agent: 6.0.1
+
+  '@octokit/types@12.6.0':
+    dependencies:
+      '@octokit/openapi-types': 20.0.0
+
+  '@octokit/types@13.10.0':
+    dependencies:
+      '@octokit/openapi-types': 24.2.0
+
+  '@pkgjs/parseargs@0.11.0':
+    optional: true
+
+  '@protobuf-ts/runtime-rpc@2.11.1':
+    dependencies:
+      '@protobuf-ts/runtime': 2.11.1
+
+  '@protobuf-ts/runtime@2.11.1': {}
+
   '@rollup/rollup-android-arm-eabi@4.55.1':
     optional: true
 
@@ -2127,6 +3099,14 @@ snapshots:
 
   '@types/retry@0.12.2': {}
 
+  '@typespec/ts-http-runtime@0.3.3':
+    dependencies:
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - supports-color
+
   '@vitest/expect@4.0.17':
     dependencies:
       '@standard-schema/spec': 1.1.0
@@ -2136,17 +3116,26 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.0.3
 
-  '@vitest/mocker@4.0.17(vite@7.3.1(@types/node@25.0.9))':
+  '@vitest/mocker@4.0.17(vite@7.3.1(@types/node@25.0.9)(yaml@2.8.2))':
     dependencies:
       '@vitest/spy': 4.0.17
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.1(@types/node@25.0.9)
+      vite: 7.3.1(@types/node@25.0.9)(yaml@2.8.2)
+
+  '@vitest/pretty-format@2.1.9':
+    dependencies:
+      tinyrainbow: 1.2.0
 
   '@vitest/pretty-format@4.0.17':
     dependencies:
       tinyrainbow: 3.0.3
+
+  '@vitest/runner@2.1.9':
+    dependencies:
+      '@vitest/utils': 2.1.9
+      pathe: 1.1.2
 
   '@vitest/runner@4.0.17':
     dependencies:
@@ -2161,12 +3150,41 @@ snapshots:
 
   '@vitest/spy@4.0.17': {}
 
+  '@vitest/utils@2.1.9':
+    dependencies:
+      '@vitest/pretty-format': 2.1.9
+      loupe: 3.2.1
+      tinyrainbow: 1.2.0
+
   '@vitest/utils@4.0.17':
     dependencies:
       '@vitest/pretty-format': 4.0.17
       tinyrainbow: 3.0.3
 
+  abort-controller@3.0.0:
+    dependencies:
+      event-target-shim: 5.0.1
+
   abort-error@1.0.1: {}
+
+  agent-base@7.1.4: {}
+
+  ajv@8.18.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-uri: 3.1.0
+      json-schema-traverse: 1.0.0
+      require-from-string: 2.0.2
+
+  ansi-regex@5.0.1: {}
+
+  ansi-regex@6.2.2: {}
+
+  ansi-styles@4.3.0:
+    dependencies:
+      color-convert: 2.0.1
+
+  ansi-styles@6.2.3: {}
 
   any-signal@4.2.0: {}
 
@@ -2174,7 +3192,30 @@ snapshots:
 
   assertion-error@2.0.1: {}
 
+  asynckit@0.4.0: {}
+
+  available-typed-arrays@1.0.7:
+    dependencies:
+      possible-typed-array-names: 1.1.0
+
+  aws-sdk@2.1693.0:
+    dependencies:
+      buffer: 4.9.2
+      events: 1.1.1
+      ieee754: 1.1.13
+      jmespath: 0.16.0
+      querystring: 0.2.0
+      sax: 1.2.1
+      url: 0.10.3
+      util: 0.12.5
+      uuid: 8.0.0
+      xml2js: 0.6.2
+
+  balanced-match@1.0.2: {}
+
   base64-js@1.5.1: {}
+
+  before-after-hook@2.2.3: {}
 
   bigint-buffer@1.1.5:
     dependencies:
@@ -2184,14 +3225,80 @@ snapshots:
     dependencies:
       file-uri-to-path: 1.0.0
 
+  brace-expansion@1.1.12:
+    dependencies:
+      balanced-match: 1.0.2
+      concat-map: 0.0.1
+
+  brace-expansion@2.0.2:
+    dependencies:
+      balanced-match: 1.0.2
+
+  buffer@4.9.2:
+    dependencies:
+      base64-js: 1.5.1
+      ieee754: 1.2.1
+      isarray: 1.0.0
+
   buffer@6.0.3:
     dependencies:
       base64-js: 1.5.1
       ieee754: 1.2.1
 
+  call-bind-apply-helpers@1.0.2:
+    dependencies:
+      es-errors: 1.3.0
+      function-bind: 1.1.2
+
+  call-bind@1.0.8:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-define-property: 1.0.1
+      get-intrinsic: 1.3.0
+      set-function-length: 1.2.2
+
+  call-bound@1.0.4:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      get-intrinsic: 1.3.0
+
   case@1.6.3: {}
 
   chai@6.2.2: {}
+
+  cli-table3@0.6.5:
+    dependencies:
+      string-width: 4.2.3
+    optionalDependencies:
+      '@colors/colors': 1.5.0
+
+  cliui@8.0.1:
+    dependencies:
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+      wrap-ansi: 7.0.0
+
+  color-convert@2.0.1:
+    dependencies:
+      color-name: 1.1.4
+
+  color-name@1.1.4: {}
+
+  combined-stream@1.0.8:
+    dependencies:
+      delayed-stream: 1.0.0
+
+  concat-map@0.0.1: {}
+
+  cross-spawn@7.0.6:
+    dependencies:
+      path-key: 3.1.1
+      shebang-command: 2.0.0
+      which: 2.0.2
+
+  csv-parse@5.6.0: {}
+
+  csv-stringify@6.6.0: {}
 
   datastore-core@10.0.4:
     dependencies:
@@ -2206,13 +3313,54 @@ snapshots:
       it-sort: 3.0.9
       it-take: 3.0.9
 
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
+
+  define-data-property@1.1.4:
+    dependencies:
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      gopd: 1.2.0
+
   delay@6.0.0: {}
+
+  delayed-stream@1.0.0: {}
+
+  deprecation@2.3.1: {}
 
   dns-packet@5.6.1:
     dependencies:
       '@leichtgewicht/ip-codec': 2.0.5
 
+  dunder-proto@1.0.1:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-errors: 1.3.0
+      gopd: 1.2.0
+
+  eastasianwidth@0.2.0: {}
+
+  emoji-regex@8.0.0: {}
+
+  emoji-regex@9.2.2: {}
+
+  es-define-property@1.0.1: {}
+
+  es-errors@1.3.0: {}
+
   es-module-lexer@1.7.0: {}
+
+  es-object-atoms@1.1.1:
+    dependencies:
+      es-errors: 1.3.0
+
+  es-set-tostringtag@2.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      has-tostringtag: 1.0.2
+      hasown: 2.0.2
 
   esbuild@0.27.2:
     optionalDependencies:
@@ -2243,6 +3391,8 @@ snapshots:
       '@esbuild/win32-ia32': 0.27.2
       '@esbuild/win32-x64': 0.27.2
 
+  escalade@3.2.0: {}
+
   estree-walker@3.0.3:
     dependencies:
       '@types/estree': 1.0.8
@@ -2254,9 +3404,26 @@ snapshots:
       '@scure/bip32': 1.4.0
       '@scure/bip39': 1.3.0
 
+  event-target-shim@5.0.1: {}
+
   eventemitter3@5.0.1: {}
 
+  events@1.1.1: {}
+
+  events@3.3.0: {}
+
   expect-type@1.3.0: {}
+
+  fast-deep-equal@3.1.3: {}
+
+  fast-uri@3.1.0: {}
+
+  fast-xml-builder@1.0.0: {}
+
+  fast-xml-parser@5.4.2:
+    dependencies:
+      fast-xml-builder: 1.0.0
+      strnum: 2.2.0
 
   fdir@6.5.0(picomatch@4.0.3):
     optionalDependencies:
@@ -2264,14 +3431,99 @@ snapshots:
 
   file-uri-to-path@1.0.0: {}
 
+  for-each@0.3.5:
+    dependencies:
+      is-callable: 1.2.7
+
+  foreground-child@3.3.1:
+    dependencies:
+      cross-spawn: 7.0.6
+      signal-exit: 4.1.0
+
+  form-data@2.5.5:
+    dependencies:
+      asynckit: 0.4.0
+      combined-stream: 1.0.8
+      es-set-tostringtag: 2.1.0
+      hasown: 2.0.2
+      mime-types: 2.1.35
+      safe-buffer: 5.2.1
+
   fsevents@2.3.3:
     optional: true
 
+  function-bind@1.1.2: {}
+
+  generator-function@2.0.1: {}
+
+  get-caller-file@2.0.5: {}
+
+  get-intrinsic@1.3.0:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.1
+      function-bind: 1.1.2
+      get-proto: 1.0.1
+      gopd: 1.2.0
+      has-symbols: 1.1.0
+      hasown: 2.0.2
+      math-intrinsics: 1.1.0
+
   get-iterator@2.0.1: {}
+
+  get-proto@1.0.1:
+    dependencies:
+      dunder-proto: 1.0.1
+      es-object-atoms: 1.1.1
+
+  glob@10.5.0:
+    dependencies:
+      foreground-child: 3.3.1
+      jackspeak: 3.4.3
+      minimatch: 9.0.9
+      minipass: 7.1.3
+      package-json-from-dist: 1.0.1
+      path-scurry: 1.11.1
+
+  gopd@1.2.0: {}
+
+  has-property-descriptors@1.0.2:
+    dependencies:
+      es-define-property: 1.0.1
+
+  has-symbols@1.1.0: {}
+
+  has-tostringtag@1.0.2:
+    dependencies:
+      has-symbols: 1.1.0
 
   hashlru@2.3.0: {}
 
+  hasown@2.0.2:
+    dependencies:
+      function-bind: 1.1.2
+
+  http-proxy-agent@7.0.2:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  https-proxy-agent@7.0.6:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  ieee754@1.1.13: {}
+
   ieee754@1.2.1: {}
+
+  inherits@2.0.4: {}
 
   interface-datastore@8.3.2:
     dependencies:
@@ -2280,11 +3532,45 @@ snapshots:
 
   interface-store@6.0.3: {}
 
+  is-arguments@1.2.0:
+    dependencies:
+      call-bound: 1.0.4
+      has-tostringtag: 1.0.2
+
+  is-callable@1.2.7: {}
+
+  is-fullwidth-code-point@3.0.0: {}
+
+  is-generator-function@1.1.2:
+    dependencies:
+      call-bound: 1.0.4
+      generator-function: 2.0.1
+      get-proto: 1.0.1
+      has-tostringtag: 1.0.2
+      safe-regex-test: 1.1.0
+
   is-loopback-addr@2.0.2: {}
 
   is-network-error@1.3.0: {}
 
   is-plain-obj@4.1.0: {}
+
+  is-regex@1.2.1:
+    dependencies:
+      call-bound: 1.0.4
+      gopd: 1.2.0
+      has-tostringtag: 1.0.2
+      hasown: 2.0.2
+
+  is-typed-array@1.1.15:
+    dependencies:
+      which-typed-array: 1.1.20
+
+  is-unicode-supported@2.1.0: {}
+
+  isarray@1.0.0: {}
+
+  isexe@2.0.0: {}
 
   it-all@3.0.9: {}
 
@@ -2373,9 +3659,19 @@ snapshots:
 
   it-take@3.0.9: {}
 
+  jackspeak@3.4.3:
+    dependencies:
+      '@isaacs/cliui': 8.0.2
+    optionalDependencies:
+      '@pkgjs/parseargs': 0.11.0
+
+  jmespath@0.16.0: {}
+
   js-yaml@4.1.1:
     dependencies:
       argparse: 2.0.1
+
+  json-schema-traverse@1.0.0: {}
 
   libp2p@2.9.0:
     dependencies:
@@ -2408,17 +3704,46 @@ snapshots:
       race-signal: 1.1.3
       uint8arrays: 5.1.0
 
+  log-symbols@7.0.1:
+    dependencies:
+      is-unicode-supported: 2.1.0
+      yoctocolors: 2.1.2
+
+  loupe@3.2.1: {}
+
+  lru-cache@10.4.3: {}
+
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
   main-event@1.0.1: {}
 
+  math-intrinsics@1.1.0: {}
+
+  mime-db@1.52.0: {}
+
+  mime-types@2.1.35:
+    dependencies:
+      mime-db: 1.52.0
+
+  minimatch@3.1.5:
+    dependencies:
+      brace-expansion: 1.1.12
+
+  minimatch@9.0.9:
+    dependencies:
+      brace-expansion: 2.0.2
+
+  minipass@7.1.3: {}
+
   mortice@3.3.1:
     dependencies:
       abort-error: 1.0.1
       it-queue: 1.1.1
       main-event: 1.0.1
+
+  ms@2.1.3: {}
 
   ms@3.0.0-canary.202508261828: {}
 
@@ -2428,7 +3753,15 @@ snapshots:
 
   netmask@2.0.2: {}
 
+  node-fetch@2.7.0:
+    dependencies:
+      whatwg-url: 5.0.0
+
   obug@2.1.1: {}
+
+  once@1.4.0:
+    dependencies:
+      wrappy: 1.0.2
 
   p-defer@4.0.1: {}
 
@@ -2445,11 +3778,24 @@ snapshots:
 
   p-timeout@7.0.1: {}
 
+  package-json-from-dist@1.0.1: {}
+
+  path-key@3.1.1: {}
+
+  path-scurry@1.11.1:
+    dependencies:
+      lru-cache: 10.4.3
+      minipass: 7.1.3
+
+  pathe@1.1.2: {}
+
   pathe@2.0.3: {}
 
   picocolors@1.1.1: {}
 
   picomatch@4.0.3: {}
+
+  possible-typed-array-names@1.1.0: {}
 
   postcss@8.5.6:
     dependencies:
@@ -2465,6 +3811,10 @@ snapshots:
       uint8arraylist: 2.4.8
       uint8arrays: 5.1.0
 
+  punycode@1.3.2: {}
+
+  querystring@0.2.0: {}
+
   race-event@1.6.1:
     dependencies:
       abort-error: 1.0.1
@@ -2472,6 +3822,10 @@ snapshots:
   race-signal@1.1.3: {}
 
   race-signal@2.0.0: {}
+
+  require-directory@2.1.1: {}
+
+  require-from-string@2.0.2: {}
 
   retry@0.13.1: {}
 
@@ -2506,7 +3860,38 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.55.1
       fsevents: 2.3.3
 
+  safe-buffer@5.2.1: {}
+
+  safe-regex-test@1.1.0:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      is-regex: 1.2.1
+
+  sax@1.2.1: {}
+
+  sax@1.5.0: {}
+
+  semver@6.3.1: {}
+
+  set-function-length@1.2.2:
+    dependencies:
+      define-data-property: 1.1.4
+      es-errors: 1.3.0
+      function-bind: 1.1.2
+      get-intrinsic: 1.3.0
+      gopd: 1.2.0
+      has-property-descriptors: 1.0.2
+
+  shebang-command@2.0.0:
+    dependencies:
+      shebang-regex: 3.0.0
+
+  shebang-regex@3.0.0: {}
+
   siginfo@2.0.0: {}
+
+  signal-exit@4.1.0: {}
 
   snappy@7.3.3:
     optionalDependencies:
@@ -2537,6 +3922,28 @@ snapshots:
 
   std-env@3.10.0: {}
 
+  string-width@4.2.3:
+    dependencies:
+      emoji-regex: 8.0.0
+      is-fullwidth-code-point: 3.0.0
+      strip-ansi: 6.0.1
+
+  string-width@5.1.2:
+    dependencies:
+      eastasianwidth: 0.2.0
+      emoji-regex: 9.2.2
+      strip-ansi: 7.2.0
+
+  strip-ansi@6.0.1:
+    dependencies:
+      ansi-regex: 5.0.1
+
+  strip-ansi@7.2.0:
+    dependencies:
+      ansi-regex: 6.2.2
+
+  strnum@2.2.0: {}
+
   supports-color@10.2.2: {}
 
   tinybench@2.9.0: {}
@@ -2548,10 +3955,17 @@ snapshots:
       fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
 
+  tinyrainbow@1.2.0: {}
+
   tinyrainbow@3.0.3: {}
 
-  tslib@2.8.1:
-    optional: true
+  tr46@0.0.3: {}
+
+  tslib@1.14.1: {}
+
+  tslib@2.8.1: {}
+
+  tunnel@0.0.6: {}
 
   uint8-varint@2.0.4:
     dependencies:
@@ -2568,7 +3982,30 @@ snapshots:
 
   undici-types@7.16.0: {}
 
-  vite@7.3.1(@types/node@25.0.9):
+  undici@5.29.0:
+    dependencies:
+      '@fastify/busboy': 2.1.1
+
+  universal-user-agent@6.0.1: {}
+
+  url@0.10.3:
+    dependencies:
+      punycode: 1.3.2
+      querystring: 0.2.0
+
+  util@0.12.5:
+    dependencies:
+      inherits: 2.0.4
+      is-arguments: 1.2.0
+      is-generator-function: 1.1.2
+      is-typed-array: 1.1.15
+      which-typed-array: 1.1.20
+
+  uuid@8.0.0: {}
+
+  uuid@8.3.2: {}
+
+  vite@7.3.1(@types/node@25.0.9)(yaml@2.8.2):
     dependencies:
       esbuild: 0.27.2
       fdir: 6.5.0(picomatch@4.0.3)
@@ -2579,11 +4016,12 @@ snapshots:
     optionalDependencies:
       '@types/node': 25.0.9
       fsevents: 2.3.3
+      yaml: 2.8.2
 
-  vitest@4.0.17(@types/node@25.0.9):
+  vitest@4.0.17(@types/node@25.0.9)(yaml@2.8.2):
     dependencies:
       '@vitest/expect': 4.0.17
-      '@vitest/mocker': 4.0.17(vite@7.3.1(@types/node@25.0.9))
+      '@vitest/mocker': 4.0.17(vite@7.3.1(@types/node@25.0.9)(yaml@2.8.2))
       '@vitest/pretty-format': 4.0.17
       '@vitest/runner': 4.0.17
       '@vitest/snapshot': 4.0.17
@@ -2600,7 +4038,7 @@ snapshots:
       tinyexec: 1.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.0.3
-      vite: 7.3.1(@types/node@25.0.9)
+      vite: 7.3.1(@types/node@25.0.9)(yaml@2.8.2)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 25.0.9
@@ -2622,7 +4060,72 @@ snapshots:
       ms: 3.0.0-canary.202508261828
       supports-color: 10.2.2
 
+  webidl-conversions@3.0.1: {}
+
+  whatwg-url@5.0.0:
+    dependencies:
+      tr46: 0.0.3
+      webidl-conversions: 3.0.1
+
+  which-typed-array@1.1.20:
+    dependencies:
+      available-typed-arrays: 1.0.7
+      call-bind: 1.0.8
+      call-bound: 1.0.4
+      for-each: 0.3.5
+      get-proto: 1.0.1
+      gopd: 1.2.0
+      has-tostringtag: 1.0.2
+
+  which@2.0.2:
+    dependencies:
+      isexe: 2.0.0
+
   why-is-node-running@2.3.0:
     dependencies:
       siginfo: 2.0.0
       stackback: 0.0.2
+
+  wrap-ansi@7.0.0:
+    dependencies:
+      ansi-styles: 4.3.0
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+
+  wrap-ansi@8.1.0:
+    dependencies:
+      ansi-styles: 6.2.3
+      string-width: 5.1.2
+      strip-ansi: 7.2.0
+
+  wrappy@1.0.2: {}
+
+  xml2js@0.5.0:
+    dependencies:
+      sax: 1.5.0
+      xmlbuilder: 11.0.1
+
+  xml2js@0.6.2:
+    dependencies:
+      sax: 1.2.1
+      xmlbuilder: 11.0.1
+
+  xmlbuilder@11.0.1: {}
+
+  y18n@5.0.8: {}
+
+  yaml@2.8.2: {}
+
+  yargs-parser@21.1.1: {}
+
+  yargs@17.7.2:
+    dependencies:
+      cliui: 8.0.1
+      escalade: 3.2.0
+      get-caller-file: 2.0.5
+      require-directory: 2.1.1
+      string-width: 4.2.3
+      y18n: 5.0.8
+      yargs-parser: 21.1.1
+
+  yoctocolors@2.1.2: {}

--- a/src/state_transition/utils/bls.zig
+++ b/src/state_transition/utils/bls.zig
@@ -23,7 +23,7 @@ pub fn verify(msg: []const u8, pk: *const PublicKey, sig: *const Signature, in_p
 }
 
 pub fn fastAggregateVerify(msg: []const u8, pks: []const PublicKey, sig: *const Signature, in_pk_validate: ?bool, in_sigs_group_check: ?bool) !bool {
-    var pairing_buf: [blst.Pairing.sizeOf()]u8 = undefined;
+    var pairing_buf: [blst.Pairing.sizeOf()]u8 align(@alignOf(blst.Pairing)) = undefined;
 
     const sigs_groupcheck = in_sigs_group_check orelse false;
     const pks_validate = in_pk_validate orelse false;

--- a/src/state_transition/utils/bls.zig
+++ b/src/state_transition/utils/bls.zig
@@ -27,7 +27,7 @@ pub fn fastAggregateVerify(msg: []const u8, pks: []const PublicKey, sig: *const 
 
     const sigs_groupcheck = in_sigs_group_check orelse false;
     const pks_validate = in_pk_validate orelse false;
-    return sig.fastAggregateVerify(sigs_groupcheck, &pairing_buf, msg[0..32], DST, pks, pks_validate) catch return false;
+    return sig.fastAggregateVerify(sigs_groupcheck, @alignCast(&pairing_buf), msg[0..32], DST, pks, pks_validate) catch return false;
 }
 
 // TODO: unit tests

--- a/zbuild.zon
+++ b/zbuild.zon
@@ -10,7 +10,7 @@
     },
     .dependencies = .{
         .blst = .{
-            .url = "git+https://github.com/chainsafe/blst-z#7c135f5049d99f603856a1c8728321cb69682788",
+            .url = "git+https://github.com/chainsafe/blst-z#bing/mt-verify",
         },
         .hashtree = .{
             .url = "git+https://github.com/chainsafe/hashtree-z#4ed9aebb6178662299ae799f6914499820ff0180",

--- a/zbuild.zon
+++ b/zbuild.zon
@@ -10,7 +10,7 @@
     },
     .dependencies = .{
         .blst = .{
-            .url = "git+https://github.com/chainsafe/blst-z#bing/mt-verify",
+            .url = "git+https://github.com/chainsafe/blst-z#7a3267e33848677da6b14d7207a6321f632fd434",
         },
         .hashtree = .{
             .url = "git+https://github.com/chainsafe/hashtree-z#4ed9aebb6178662299ae799f6914499820ff0180",


### PR DESCRIPTION
pre-requisite for chainsafe/lodestar#8900

Integrated the changes from [cayman/blst-mt](https://github.com/ChainSafe/lodestar-z/tree/cayman/blst-mt) here, and numbers are a lot more reasonable for `verifyMultipleAggregateSignatures`.

Turns out the pooling done on the binding layer instead of natively in zig was the difference. The previous attempts were targeted at doing multi-threaded verification on the native layer (see https://github.com/ChainSafe/blst-z/pull/60), but that turned out to be pretty bad - see [upstream PR](https://github.com/ChainSafe/lodestar/pull/8900#issuecomment-3981821593)). This PR instead uses `blst-z` as is without any changes and does pooling/multi-threading on the napi layer instead.

I ran this a few times, mostly got consistently ~= `@chainsafe/blst` results.

To run:

```
pnpm i && pnpm benchmark
```

On an M2 Pro:

```
bindings/perf/blst.test.ts
  aggregatePublicKeys
    ✔ aggregatePublicKeys lodestar-z  1 keys                              748503.0 ops/s    1.336000 us/op        -       6203 runs   3.00 s
    ✔ aggregatePublicKeys @chainsafe/blst  1 keys                         703729.8 ops/s    1.421000 us/op        -       6193 runs   3.00 s
    ✔ aggregatePublicKeys lodestar-z  8 keys                              121951.2 ops/s    8.200000 us/op        -        462 runs   3.00 s
    ✔ aggregatePublicKeys @chainsafe/blst  8 keys                         127713.9 ops/s    7.830000 us/op        -        469 runs   3.00 s
    ✔ aggregatePublicKeys lodestar-z  32 keys                             39339.10 ops/s    25.42000 us/op        -        111 runs   3.01 s
    ✔ aggregatePublicKeys @chainsafe/blst  32 keys                        38330.33 ops/s    26.08900 us/op        -        109 runs   3.01 s
    ✔ aggregatePublicKeys lodestar-z  128 keys                            13414.72 ops/s    74.54500 us/op        -         30 runs   3.04 s
    ✔ aggregatePublicKeys @chainsafe/blst  128 keys                       11803.59 ops/s    84.72000 us/op        -         23 runs   2.78 s
    ✔ aggregatePublicKeys lodestar-z  256 keys                            6699.898 ops/s    149.2560 us/op        -         13 runs   3.00 s
    ✔ aggregatePublicKeys @chainsafe/blst  256 keys                       6145.262 ops/s    162.7270 us/op        -         13 runs   3.08 s

  aggregateSignatures
    ✔ aggregateSignatures lodestar-z  1 sigs                              780031.2 ops/s    1.282000 us/op        -       5250 runs   2.55 s
    ✔ aggregateSignatures @chainsafe/blst  1 sigs                         836820.1 ops/s    1.195000 us/op        -       4337 runs   2.13 s
    ✔ aggregateSignatures lodestar-z  8 sigs                              75244.54 ops/s    13.29000 us/op        -        165 runs   2.05 s
    ✔ aggregateSignatures @chainsafe/blst  8 sigs                         53769.22 ops/s    18.59800 us/op        -        467 runs   3.01 s
    ✔ aggregateSignatures lodestar-z  32 sigs                             23397.83 ops/s    42.73900 us/op        -        117 runs   3.00 s
    ✔ aggregateSignatures @chainsafe/blst  32 sigs                        23404.95 ops/s    42.72600 us/op        -         53 runs   2.21 s
    ✔ aggregateSignatures lodestar-z  128 sigs                            6479.160 ops/s    154.3410 us/op        -         20 runs   2.57 s
    ✔ aggregateSignatures @chainsafe/blst  128 sigs                       6047.741 ops/s    165.3510 us/op        -         28 runs   3.02 s
    ✔ aggregateSignatures lodestar-z  256 sigs                            3220.695 ops/s    310.4920 us/op        -         11 runs   2.83 s
    ✔ aggregateSignatures @chainsafe/blst  256 sigs                       3083.993 ops/s    324.2550 us/op        -          8 runs   2.44 s

  aggregateVerify
    ✔ aggregateVerify lodestar-z  3 sets                                  1218.814 ops/s    820.4700 us/op        -        103 runs   1.40 s
    ✔ aggregateVerify @chainsafe/blst  3 sets                             1435.247 ops/s    696.7440 us/op        -        862 runs   3.00 s
    ✔ aggregateVerify lodestar-z  8 sets                                  1147.692 ops/s    871.3140 us/op        -        232 runs   2.44 s
    ✔ aggregateVerify @chainsafe/blst  8 sets                             1216.712 ops/s    821.8870 us/op        -         80 runs   1.82 s
    ✔ aggregateVerify lodestar-z  32 sets                                 571.2556 ops/s    1.750530 ms/op        -        100 runs   2.97 s
    ✔ aggregateVerify @chainsafe/blst  32 sets                            560.1074 ops/s    1.785372 ms/op        -        103 runs   3.01 s
    ✔ aggregateVerify lodestar-z  64 sets                                 360.0484 ops/s    2.777404 ms/op        -         28 runs   2.35 s
    ✔ aggregateVerify @chainsafe/blst  64 sets                            296.5946 ops/s    3.371606 ms/op        -         49 runs   3.00 s
    ✔ aggregateVerify lodestar-z  128 sets                                119.1942 ops/s    8.389672 ms/op        -         22 runs   3.05 s
    ✔ aggregateVerify @chainsafe/blst  128 sets                           171.3569 ops/s    5.835774 ms/op        -         24 runs   3.00 s

  verifyMultipleAggregateSignatures
    ✔ lodestar-z  3 sets                                                  1049.442 ops/s    952.8870 us/op        -        334 runs   1.83 s
    ✔ @chainsafe/blst  3 sets                                             1046.280 ops/s    955.7670 us/op        -        241 runs   1.62 s
    ✔ lodestar-z  8 sets                                                  970.8540 ops/s    1.030021 ms/op        -        125 runs   2.03 s
    ✔ @chainsafe/blst  8 sets                                             884.7420 ops/s    1.130273 ms/op        -        353 runs   3.00 s
    ✔ lodestar-z  32 sets                                                 443.7648 ops/s    2.253446 ms/op        -         43 runs   2.15 s
    ✔ @chainsafe/blst  32 sets                                            449.9561 ops/s    2.222439 ms/op        -         29 runs   1.94 s
    ✔ lodestar-z  64 sets                                                 262.7697 ops/s    3.805614 ms/op        -         40 runs   2.72 s
    ✔ @chainsafe/blst  64 sets                                            271.0820 ops/s    3.688921 ms/op        -         33 runs   2.54 s
    ✔ lodestar-z  128 sets                                                124.6683 ops/s    8.021286 ms/op        -         24 runs   3.00 s
    ✔ @chainsafe/blst  128 sets                                           133.3907 ops/s    7.496774 ms/op        -         26 runs   3.07 s
```

With @wemeetagain 's branch, it was about similar:

```console
bindings/perf/functions.test.ts
  sanity
    ✔ sanitytest - blstZ                                                  792393.0 ops/s    1.262000 us/op        -    1454903 runs   2.38 s
    ✔ sanitytest - blstTS                                                 630119.7 ops/s    1.587000 us/op        -    1040106 runs   2.02 s

  aggregatePublicKeys
    ✔ aggregatePublicKeys blstZ - 1 keys                                   1221001 ops/s    819.0000 ns/op        -    1194944 runs   1.76 s
    ✔ aggregatePublicKeys blstTS - 1 keys                                 815660.7 ops/s    1.226000 us/op        -     249565 runs   3.65 s
    ✔ aggregatePublicKeys blstZ - 8 keys                                  141043.7 ops/s    7.090000 us/op        -     114893 runs  0.909 s
    ✔ aggregatePublicKeys blstTS - 8 keys                                 139353.4 ops/s    7.176000 us/op        -       6169 runs  0.826 s
    ✔ aggregatePublicKeys blstZ - 32 keys                                 53850.30 ops/s    18.57000 us/op        -      24708 runs  0.505 s
    ✔ aggregatePublicKeys blstTS - 32 keys                                53413.10 ops/s    18.72200 us/op        -       1167 runs  0.992 s
    ✔ aggregatePublicKeys blstZ - 128 keys                                14944.78 ops/s    66.91300 us/op        -      13336 runs   1.17 s
    ✔ aggregatePublicKeys blstTS - 128 keys                               14663.40 ops/s    68.19700 us/op        -        930 runs   3.36 s
    ✔ aggregatePublicKeys blstZ - 256 keys                                7594.283 ops/s    131.6780 us/op        -       6564 runs   1.15 s
    ✔ aggregatePublicKeys blstTS - 256 keys                               7812.927 ops/s    127.9930 us/op        -        545 runs   5.28 s

  aggregateSignatures
    ✔ aggregateSignatures blstZ - 1 sigs                                   1377410 ops/s    726.0000 ns/op        -    1807262 runs   2.73 s
    ✔ aggregateSignatures blstTS - 1 sigs                                 838926.2 ops/s    1.192000 us/op        -      89767 runs   2.42 s
    ✔ aggregateSignatures blstZ - 8 sigs                                  89055.13 ops/s    11.22900 us/op        -      32404 runs  0.404 s
    ✔ aggregateSignatures blstTS - 8 sigs                                 86933.84 ops/s    11.50300 us/op        -       1456 runs  0.512 s
    ✔ aggregateSignatures blstZ - 32 sigs                                 26053.20 ops/s    38.38300 us/op        -       6585 runs  0.303 s
    ✔ aggregateSignatures blstTS - 32 sigs                                25441.41 ops/s    39.30600 us/op        -       1307 runs   1.95 s
    ✔ aggregateSignatures blstZ - 128 sigs                                6847.205 ops/s    146.0450 us/op        -       2050 runs  0.483 s
    ✔ aggregateSignatures blstTS - 128 sigs                               7023.606 ops/s    142.3770 us/op        -        188 runs   3.98 s
    ✔ aggregateSignatures blstZ - 256 sigs                                3373.159 ops/s    296.4580 us/op        -       2021 runs  0.903 s
    ✔ aggregateSignatures blstTS - 256 sigs                               3443.799 ops/s    290.3770 us/op        -         92 runs   7.47 s

  aggregateVerify
    ✔ aggregateVerify blstZ - 1 sets                                      1268.525 ops/s    788.3170 us/op        -        257 runs  0.705 s
    ✔ aggregateVerify blstTS - 1 sets                                     1598.210 ops/s    625.7000 us/op        -        909 runs   1.14 s
    ✔ aggregateVerify blstZ - 8 sets                                      1030.282 ops/s    970.6080 us/op        -       1228 runs   1.72 s
    ✔ aggregateVerify blstTS - 8 sets                                     1210.268 ops/s    826.2630 us/op        -        438 runs   1.21 s
    ✔ aggregateVerify blstZ - 32 sets                                     550.8027 ops/s    1.815532 ms/op        -        602 runs   1.63 s
    ✔ aggregateVerify blstTS - 32 sets                                    634.7373 ops/s    1.575455 ms/op        -        141 runs   1.31 s
    ✔ aggregateVerify blstZ - 128 sets                                    176.6969 ops/s    5.659408 ms/op        -        319 runs   2.38 s
    ✔ aggregateVerify blstTS - 128 sets                                   195.7491 ops/s    5.108580 ms/op        -         82 runs   1.92 s
    ✔ aggregateVerify blstZ - 256 sets                                    109.5515 ops/s    9.128127 ms/op        -         99 runs   1.46 s
    ✔ aggregateVerify blstTS - 256 sets                                   106.8037 ops/s    9.362972 ms/op        -        124 runs   3.53 s

  verifyMultipleAggregateSignatures
    ✔ verifyMultiAggSig blstZ - 1 sets                                    1115.641 ops/s    896.3460 us/op        -        451 runs  0.906 s
    ✔ verifyMultiAggSig blstTS - 1 sets                                   1096.657 ops/s    911.8620 us/op        -        319 runs  0.826 s
    ✔ verifyMultiAggSig blstZ - 8 sets                                    996.2313 ops/s    1.003783 ms/op        -        403 runs  0.906 s
    ✔ verifyMultiAggSig blstTS - 8 sets                                   993.5420 ops/s    1.006500 ms/op        -        304 runs   1.06 s
    ✔ verifyMultiAggSig blstZ - 32 sets                                   467.8973 ops/s    2.137221 ms/op        -        143 runs  0.808 s
    ✔ verifyMultiAggSig blstTS - 32 sets                                  464.9837 ops/s    2.150613 ms/op        -        120 runs   1.21 s
    ✔ verifyMultiAggSig blstZ - 128 sets                                  153.7131 ops/s    6.505627 ms/op        -         49 runs  0.822 s
    ✔ verifyMultiAggSig blstTS - 128 sets                                 156.4704 ops/s    6.390986 ms/op        -         28 runs   1.22 s
    ✔ verifyMultiAggSig blstZ - 256 sets                                  86.04139 ops/s    11.62231 ms/op        -         37 runs  0.943 s
    ✔ verifyMultiAggSig blstTS - 256 sets                                 69.99464 ops/s    14.28681 ms/op        -         49 runs   2.13 s
```