### PR TITLE
fix: native metrics example

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -265,8 +265,7 @@ jobs:
           pnpm test
 
   build-examples:
-    name: spec tests - mainnet
-    # It takes time to download and run spec tests, so we only run them on ubuntu-latest
+    name: build examples
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -263,3 +263,19 @@ jobs:
       - name: Test bindings
         run: |
           pnpm test
+
+  build-examples:
+    name: spec tests - mainnet
+    # It takes time to download and run spec tests, so we only run them on ubuntu-latest
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+      - name: Install Zig
+        uses: mlugg/setup-zig@v2
+        with:
+          version: ${{ env.ZIG_VERSION }}
+          cache-key: ubuntu-latest-${{ env.ZIG_VERSION }}
+      - name: Build metrics example
+        run: |
+          zig build build-exe:metrics_stf

--- a/build.zig
+++ b/build.zig
@@ -171,28 +171,28 @@ pub fn build(b: *std.Build) void {
     const tls_run_exe_download_era_files = b.step("run:download_era_files", "Run the download_era_files executable");
     tls_run_exe_download_era_files.dependOn(&run_exe_download_era_files.step);
 
-    const module_metrics_era = b.createModule(.{
-        .root_source_file = b.path("examples/metrics_era.zig"),
+    const module_metrics_stf = b.createModule(.{
+        .root_source_file = b.path("examples/metrics.zig"),
         .target = target,
         .optimize = optimize,
     });
-    b.modules.put(b.dupe("metrics_era"), module_metrics_era) catch @panic("OOM");
+    b.modules.put(b.dupe("metrics_stf"), module_metrics_stf) catch @panic("OOM");
 
-    const exe_metrics_era = b.addExecutable(.{
-        .name = "metrics_era",
-        .root_module = module_metrics_era,
+    const exe_metrics_stf = b.addExecutable(.{
+        .name = "metrics_stf",
+        .root_module = module_metrics_stf,
     });
 
-    const install_exe_metrics_era = b.addInstallArtifact(exe_metrics_era, .{});
+    const install_exe_metrics_stf = b.addInstallArtifact(exe_metrics_stf, .{});
 
-    const tls_install_exe_metrics_era = b.step("build-exe:metrics_era", "Install the metrics_era executable");
-    tls_install_exe_metrics_era.dependOn(&install_exe_metrics_era.step);
-    b.getInstallStep().dependOn(&install_exe_metrics_era.step);
+    const tls_install_exe_metrics_stf = b.step("build-exe:metrics_stf", "Install the metrics_stf executable");
+    tls_install_exe_metrics_stf.dependOn(&install_exe_metrics_stf.step);
+    b.getInstallStep().dependOn(&install_exe_metrics_stf.step);
 
-    const run_exe_metrics_era = b.addRunArtifact(exe_metrics_era);
-    if (b.args) |args| run_exe_metrics_era.addArgs(args);
-    const tls_run_exe_metrics_era = b.step("run:metrics_era", "Run the metrics_era executable");
-    tls_run_exe_metrics_era.dependOn(&run_exe_metrics_era.step);
+    const run_exe_metrics_stf = b.addRunArtifact(exe_metrics_stf);
+    if (b.args) |args| run_exe_metrics_stf.addArgs(args);
+    const tls_run_exe_metrics_stf = b.step("run:metrics_stf", "Run the metrics_stf executable");
+    tls_run_exe_metrics_stf.dependOn(&run_exe_metrics_stf.step);
 
     const module_download_spec_tests = b.createModule(.{
         .root_source_file = b.path("test/spec/download_spec_tests.zig"),
@@ -664,19 +664,19 @@ pub fn build(b: *std.Build) void {
     tls_run_test_download_era_files.dependOn(&run_test_download_era_files.step);
     tls_run_test.dependOn(&run_test_download_era_files.step);
 
-    const test_metrics_era = b.addTest(.{
-        .name = "metrics_era",
-        .root_module = module_metrics_era,
-        .filters = b.option([][]const u8, "metrics_era.filters", "metrics_era test filters") orelse &[_][]const u8{},
+    const test_metrics_stf = b.addTest(.{
+        .name = "metrics_stf",
+        .root_module = module_metrics_stf,
+        .filters = b.option([][]const u8, "metrics_stf.filters", "metrics_stf test filters") orelse &[_][]const u8{},
     });
-    const install_test_metrics_era = b.addInstallArtifact(test_metrics_era, .{});
-    const tls_install_test_metrics_era = b.step("build-test:metrics_era", "Install the metrics_era test");
-    tls_install_test_metrics_era.dependOn(&install_test_metrics_era.step);
+    const install_test_metrics_stf = b.addInstallArtifact(test_metrics_stf, .{});
+    const tls_install_test_metrics_stf = b.step("build-test:metrics_stf", "Install the metrics_stf test");
+    tls_install_test_metrics_stf.dependOn(&install_test_metrics_stf.step);
 
-    const run_test_metrics_era = b.addRunArtifact(test_metrics_era);
-    const tls_run_test_metrics_era = b.step("test:metrics_era", "Run the metrics_era test");
-    tls_run_test_metrics_era.dependOn(&run_test_metrics_era.step);
-    tls_run_test.dependOn(&run_test_metrics_era.step);
+    const run_test_metrics_stf = b.addRunArtifact(test_metrics_stf);
+    const tls_run_test_metrics_stf = b.step("test:metrics_stf", "Run the metrics_stf test");
+    tls_run_test_metrics_stf.dependOn(&run_test_metrics_stf.step);
+    tls_run_test.dependOn(&run_test_metrics_stf.step);
 
     const test_download_spec_tests = b.addTest(.{
         .name = "download_spec_tests",
@@ -1000,13 +1000,14 @@ pub fn build(b: *std.Build) void {
 
     module_download_era_files.addImport("download_era_options", options_module_download_era_options);
 
-    module_metrics_era.addImport("consensus_types", module_consensus_types);
-    module_metrics_era.addImport("state_transition", module_state_transition);
-    module_metrics_era.addImport("download_era_options", options_module_download_era_options);
-    module_metrics_era.addImport("era", module_era);
-    module_metrics_era.addImport("config", module_config);
-    module_metrics_era.addImport("preset", module_preset);
-    module_metrics_era.addImport("httpz", dep_httpz.module("httpz"));
+    module_metrics_stf.addImport("consensus_types", module_consensus_types);
+    module_metrics_stf.addImport("fork_types", module_fork_types);
+    module_metrics_stf.addImport("state_transition", module_state_transition);
+    module_metrics_stf.addImport("download_era_options", options_module_download_era_options);
+    module_metrics_stf.addImport("era", module_era);
+    module_metrics_stf.addImport("config", module_config);
+    module_metrics_stf.addImport("preset", module_preset);
+    module_metrics_stf.addImport("httpz", dep_httpz.module("httpz"));
 
     module_download_spec_tests.addImport("spec_test_options", options_module_spec_test_options);
 

--- a/examples/metrics.zig
+++ b/examples/metrics.zig
@@ -132,6 +132,7 @@ pub fn main() !void {
     std.debug.print("Running state transition.\nYou may open up a local prometheus instance to check out metrics in action.\n", .{});
     for (blocks_index.start_slot + 1..blocks_index.start_slot + blocks_index.offsets.len) |slot| {
         const block = try reader_blocks.readBlock(allocator, slot) orelse continue;
+        defer block.deinit(allocator);
 
         const block_num = switch (block.blockType()) {
             .full => (try block.beaconBlock().beaconBlockBody().executionPayload()).blockNumber(),

--- a/examples/metrics.zig
+++ b/examples/metrics.zig
@@ -1,5 +1,5 @@
 //! Simple example to show collection of metrics using metrics.zig, with mainnet era files.
-//!ny
+//!
 //! Metrics are served on `port` on a separate thread, which is visualized through Prometheus,
 //! while we continuously run the state transition function using data from 2 consecutive era files.
 //! Run a Prometheus instance to see the data visually.

--- a/examples/metrics.zig
+++ b/examples/metrics.zig
@@ -1,12 +1,12 @@
 //! Simple example to show collection of metrics using metrics.zig, with mainnet era files.
-//!
+//!ny
 //! Metrics are served on `port` on a separate thread, which is visualized through Prometheus,
 //! while we continuously run the state transition function using data from 2 consecutive era files.
 //! Run a Prometheus instance to see the data visually.
 //!
 //! To run this example, we first require era files: `zig build run:download_era_files`.
 //!
-//! Then, run `zig build run:metrics_era`.
+//! Then, run `zig build run:metrics_stf`.
 //!
 //! Note: this example is mainly meant to test that our metrics is working; realistically we do not need
 //! such an example. The bulk of this code should be moved to our beacon node implementation once it's ready.
@@ -20,14 +20,14 @@ const state_transition = @import("state_transition");
 const types = @import("consensus_types");
 
 const CachedBeaconState = state_transition.CachedBeaconState;
-const SignedBlock = state_transition.SignedBlock;
+const AnySignedBeaconBlock = @import("fork_types").AnySignedBeaconBlock;
 const active_preset = @import("preset").active_preset;
 const mainnet_chain_config = @import("config").mainnet.chain_config;
 const minimal_chain_config = @import("config").minimal.chain_config;
 const BeaconConfig = @import("config").BeaconConfig;
 const ValidatorIndex = @import("consensus_types").primitive.ValidatorIndex.Type;
 const Index2PubkeyCache = state_transition.Index2PubkeyCache;
-const PubkeyIndexMap = state_transition.PubkeyIndexMap(ValidatorIndex);
+const PubkeyIndexMap = state_transition.PubkeyIndexMap;
 const chain_config = if (active_preset == .mainnet) mainnet_chain_config else minimal_chain_config;
 
 const MetricsHandler = struct {
@@ -96,7 +96,7 @@ pub fn main() !void {
     defer reader_blocks.close(allocator);
 
     std.debug.print("Reading state\n", .{});
-    var state_ptr = try allocator.create(state_transition.BeaconState);
+    var state_ptr = try allocator.create(@import("fork_types").AnyBeaconState);
     errdefer allocator.destroy(state_ptr);
     state_ptr.* = try reader_state.readState(allocator, null);
     const blocks_index = reader_blocks.group_indices[0].blocks_index orelse return error.NoBlockIndex;
@@ -106,7 +106,7 @@ pub fn main() !void {
         allocator.destroy(index_pubkey_cache);
     }
     index_pubkey_cache.* = Index2PubkeyCache.init(allocator);
-    const pubkey_index_map = try PubkeyIndexMap.init(allocator);
+    var pubkey_index_map = PubkeyIndexMap.init(allocator);
     errdefer pubkey_index_map.deinit();
 
     const config = try allocator.create(BeaconConfig);
@@ -116,7 +116,7 @@ pub fn main() !void {
     const immutable_data = state_transition.EpochCacheImmutableData{
         .config = config,
         .index_to_pubkey = index_pubkey_cache,
-        .pubkey_to_index = pubkey_index_map,
+        .pubkey_to_index = &pubkey_index_map,
     };
 
     std.debug.print("Creating cached beacon state\n", .{});
@@ -131,14 +131,11 @@ pub fn main() !void {
     );
     std.debug.print("Running state transition.\nYou may open up a local prometheus instance to check out metrics in action.\n", .{});
     for (blocks_index.start_slot + 1..blocks_index.start_slot + blocks_index.offsets.len) |slot| {
-        const raw_block = try reader_blocks.readBlock(allocator, slot) orelse continue;
-        defer raw_block.deinit(allocator);
+        const block = try reader_blocks.readBlock(allocator, slot) orelse continue;
 
-        const block: SignedBlock = .{ .regular = raw_block };
-
-        const block_num = switch (block.message().beaconBlockBody()) {
-            .regular => |b| b.executionPayload().getBlockNumber(),
-            .blinded => |b| b.executionPayloadHeader().getBlockNumber(),
+        const block_num = switch (block.blockType()) {
+            .full => (try block.beaconBlock().beaconBlockBody().executionPayload()).blockNumber(),
+            .blinded => (try block.beaconBlock().beaconBlockBody().executionPayloadHeader()).blockNumber(),
         };
         std.debug.print("state slot = {}, block number = {}\n", .{ try cached_state.state.slot(), block_num });
 

--- a/zbuild.zon
+++ b/zbuild.zon
@@ -139,11 +139,12 @@
                 .imports = .{.download_era_options},
             },
         },
-        .metrics_era = .{
+        .metrics_stf = .{
             .root_module = .{
-                .root_source_file = "examples/metrics_era.zig",
+                .root_source_file = "examples/metrics.zig",
                 .imports = .{
                     .consensus_types,
+                    .fork_types,
                     .state_transition,
                     .download_era_options,
                     .era,


### PR DESCRIPTION
- rename: metrics_era.zig -> metrics.zig (we're about to have metrics.ts)
- update api usage to match new `fork_types`