### PR TITLE
fix(bench): fix compilation errors in SSZ and state transition benchmarks

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -104,6 +104,10 @@ jobs:
         run: |
           zig build test:state_transition
 
+      - name: Build benchmarks
+        run: |
+          zig build build-exe:bench_hashing build-exe:bench_merkle_gindex build-exe:bench_merkle_node build-exe:bench_ssz_attestation build-exe:bench_ssz_block build-exe:bench_ssz_state build-exe:bench_process_block build-exe:bench_process_epoch
+
   build-test-slow:
     name: slow tests 
     # It takes time to download and run these tests, so we only run them on ubuntu-latest

--- a/bench/ssz/attestation.zig
+++ b/bench/ssz/attestation.zig
@@ -134,9 +134,9 @@ pub fn main() !void {
     const block_bytes: []u8 = @constCast(try era_reader.readSerializedBlock(allocator, block_slot) orelse return error.InvalidEraFile);
     defer allocator.free(block_bytes);
 
-    var block = SignedBeaconBlock.default_value;
-    defer block.deinit();
-    try SignedBeaconBlock.deserializeFromBytes(allocator, block_bytes, &block);
+    const block = allocator.create(SignedBeaconBlock.Type) catch unreachable;
+    block.* = SignedBeaconBlock.default_value;
+    try SignedBeaconBlock.deserializeFromBytes(allocator, block_bytes, block);
 
     const attestation = &block.message.body.attestations.items[0];
     const attestation_bytes = try allocator.alloc(u8, Attestation.serializedSize(attestation));

--- a/bench/state_transition/process_block.zig
+++ b/bench/state_transition/process_block.zig
@@ -525,11 +525,11 @@ fn runBenchmark(
     const validators = try beacon_state.?.validatorsSlice(allocator);
     defer allocator.free(validators);
 
-    try state_transition.syncPubkeys(validators, &pubkey_index_map, &index_pubkey_cache);
+    try state_transition.syncPubkeys(validators, &pubkey_index_map, index_pubkey_cache);
 
     const cached_state = try CachedBeaconState.createCachedBeaconState(allocator, beacon_state.?, .{
         .config = &beacon_config,
-        .index_to_pubkey = &index_pubkey_cache,
+        .index_to_pubkey = index_pubkey_cache,
         .pubkey_to_index = &pubkey_index_map,
     }, .{ .skip_sync_committee_cache = !comptime fork.gte(.altair), .skip_sync_pubkeys = false });
     beacon_state = null;

--- a/bench/state_transition/process_epoch.zig
+++ b/bench/state_transition/process_epoch.zig
@@ -698,11 +698,11 @@ fn runBenchmark(
     const validators = try beacon_state.?.validatorsSlice(allocator);
     defer allocator.free(validators);
 
-    try state_transition.syncPubkeys(validators, &pubkey_index_map, &index_pubkey_cache);
+    try state_transition.syncPubkeys(validators, &pubkey_index_map, index_pubkey_cache);
 
     const immutable_data = state_transition.EpochCacheImmutableData{
         .config = &beacon_config,
-        .index_to_pubkey = &index_pubkey_cache,
+        .index_to_pubkey = index_pubkey_cache,
         .pubkey_to_index = &pubkey_index_map,
     };
 


### PR DESCRIPTION
Fix three compilation issues caused by API drift:
- attestation.zig: heap-allocate SignedBeaconBlock (no deinit on container type)
- process_block.zig, process_epoch.zig: remove extra indirection on index_pubkey_cache
- Adds a step to the build-test job that compiles all 8 benchmark
executables without running them, preventing API drift from silently
breaking benchmarks.