### PR TITLE
chore: improve process_epoch benchmarks

### DIFF
--- a/bench/state_transition/process_epoch.zig
+++ b/bench/state_transition/process_epoch.zig
@@ -326,7 +326,6 @@ fn ProcessHistoricalSummariesUpdateBench(comptime fork: ForkSeq) type {
 fn ProcessParticipationFlagUpdatesBench(comptime fork: ForkSeq) type {
     return struct {
         cached_state: *CachedBeaconState,
-        epoch_transition_cache: *EpochTransitionCache,
 
         pub fn run(self: @This(), allocator: std.mem.Allocator) void {
             const cloned = self.cached_state.clone(allocator, .{}) catch unreachable;
@@ -860,7 +859,6 @@ fn runBenchmark(
     if (comptime fork.gte(.altair)) {
         try bench.addParam("participation_flags", &ProcessParticipationFlagUpdatesBench(fork){
             .cached_state = cached_state,
-            .epoch_transition_cache = &epoch_transition_cache,
         }, .{});
 
         try bench.addParam("sync_committee_updates", &ProcessSyncCommitteeUpdatesBench(fork){

--- a/bench/state_transition/process_epoch.zig
+++ b/bench/state_transition/process_epoch.zig
@@ -22,19 +22,16 @@ const loadState = @import("utils.zig").loadState;
 fn ProcessJustificationAndFinalizationBench(comptime fork: ForkSeq) type {
     return struct {
         cached_state: *CachedBeaconState,
+        epoch_transition_cache: *EpochTransitionCache,
 
         pub fn run(self: @This(), allocator: std.mem.Allocator) void {
-            const cloned = self.cached_state.clone(allocator, .{}) catch unreachable;
-            defer {
-                cloned.deinit();
-                allocator.destroy(cloned);
-            }
-            var cache = EpochTransitionCache.init(allocator, cloned.config, cloned.epoch_cache, cloned.state) catch unreachable;
-            defer cache.deinit();
+            _ = allocator;
+            const cloned = self.cached_state;
+            const cache = self.epoch_transition_cache;
             state_transition.processJustificationAndFinalization(
                 fork,
                 cloned.state.castToFork(fork),
-                &cache,
+                cache,
             ) catch unreachable;
         }
     };
@@ -43,22 +40,18 @@ fn ProcessJustificationAndFinalizationBench(comptime fork: ForkSeq) type {
 fn ProcessInactivityUpdatesBench(comptime fork: ForkSeq) type {
     return struct {
         cached_state: *CachedBeaconState,
+        epoch_transition_cache: *EpochTransitionCache,
 
         pub fn run(self: @This(), allocator: std.mem.Allocator) void {
-            const cloned = self.cached_state.clone(allocator, .{}) catch unreachable;
-            defer {
-                cloned.deinit();
-                allocator.destroy(cloned);
-            }
-            var cache = EpochTransitionCache.init(allocator, cloned.config, cloned.epoch_cache, cloned.state) catch unreachable;
-            defer cache.deinit();
+            const cloned = self.cached_state;
+            const cache = self.epoch_transition_cache;
             state_transition.processInactivityUpdates(
                 fork,
                 allocator,
                 cloned.config,
                 cloned.epoch_cache,
                 cloned.state.castToFork(fork),
-                &cache,
+                cache,
             ) catch unreachable;
         }
     };
@@ -67,22 +60,20 @@ fn ProcessInactivityUpdatesBench(comptime fork: ForkSeq) type {
 fn ProcessRewardsAndPenaltiesBench(comptime fork: ForkSeq) type {
     return struct {
         cached_state: *CachedBeaconState,
+        epoch_transition_cache: *EpochTransitionCache,
 
         pub fn run(self: @This(), allocator: std.mem.Allocator) void {
-            const cloned = self.cached_state.clone(allocator, .{}) catch unreachable;
-            defer {
-                cloned.deinit();
-                allocator.destroy(cloned);
-            }
-            var cache = EpochTransitionCache.init(allocator, cloned.config, cloned.epoch_cache, cloned.state) catch unreachable;
-            defer cache.deinit();
+            const cloned = self.cached_state;
+            const cache = self.epoch_transition_cache;
+            const validator_count = cloned.state.validatorsCount() catch unreachable;
+            cache.syncRewardPenaltyLengths(validator_count) catch unreachable;
             state_transition.processRewardsAndPenalties(
                 fork,
                 allocator,
                 cloned.config,
                 cloned.epoch_cache,
                 cloned.state.castToFork(fork),
-                &cache,
+                cache,
                 null,
             ) catch unreachable;
         }
@@ -92,21 +83,18 @@ fn ProcessRewardsAndPenaltiesBench(comptime fork: ForkSeq) type {
 fn ProcessRegistryUpdatesBench(comptime fork: ForkSeq) type {
     return struct {
         cached_state: *CachedBeaconState,
+        epoch_transition_cache: *EpochTransitionCache,
 
         pub fn run(self: @This(), allocator: std.mem.Allocator) void {
-            const cloned = self.cached_state.clone(allocator, .{}) catch unreachable;
-            defer {
-                cloned.deinit();
-                allocator.destroy(cloned);
-            }
-            var cache = EpochTransitionCache.init(allocator, cloned.config, cloned.epoch_cache, cloned.state) catch unreachable;
-            defer cache.deinit();
+            _ = allocator;
+            const cloned = self.cached_state;
+            const cache = self.epoch_transition_cache;
             state_transition.processRegistryUpdates(
                 fork,
                 cloned.config,
                 cloned.epoch_cache,
                 cloned.state.castToFork(fork),
-                &cache,
+                cache,
             ) catch unreachable;
         }
     };
@@ -115,21 +103,17 @@ fn ProcessRegistryUpdatesBench(comptime fork: ForkSeq) type {
 fn ProcessSlashingsBench(comptime fork: ForkSeq) type {
     return struct {
         cached_state: *CachedBeaconState,
+        epoch_transition_cache: *EpochTransitionCache,
 
         pub fn run(self: @This(), allocator: std.mem.Allocator) void {
-            const cloned = self.cached_state.clone(allocator, .{}) catch unreachable;
-            defer {
-                cloned.deinit();
-                allocator.destroy(cloned);
-            }
-            var cache = EpochTransitionCache.init(allocator, cloned.config, cloned.epoch_cache, cloned.state) catch unreachable;
-            defer cache.deinit();
+            const cloned = self.cached_state;
+            const cache = self.epoch_transition_cache;
             _ = state_transition.processSlashings(
                 fork,
                 allocator,
                 cloned.epoch_cache,
                 cloned.state.castToFork(fork),
-                &cache,
+                cache,
                 true,
             ) catch unreachable;
         }
@@ -139,21 +123,17 @@ fn ProcessSlashingsBench(comptime fork: ForkSeq) type {
 fn ProcessEth1DataResetBench(comptime fork: ForkSeq) type {
     return struct {
         cached_state: *CachedBeaconState,
+        epoch_transition_cache: *EpochTransitionCache,
 
         pub fn run(self: @This(), allocator: std.mem.Allocator) void {
-            const cloned = self.cached_state.clone(allocator, .{}) catch unreachable;
-            defer {
-                cloned.deinit();
-                allocator.destroy(cloned);
-            }
-
-            var cache = EpochTransitionCache.init(allocator, cloned.config, cloned.epoch_cache, cloned.state) catch unreachable;
-            defer cache.deinit();
+            _ = allocator;
+            const cloned = self.cached_state;
+            const cache = self.epoch_transition_cache;
 
             state_transition.processEth1DataReset(
                 fork,
                 cloned.state.castToFork(fork),
-                &cache,
+                cache,
             ) catch unreachable;
         }
     };
@@ -162,16 +142,11 @@ fn ProcessEth1DataResetBench(comptime fork: ForkSeq) type {
 fn ProcessPendingDepositsBench(comptime fork: ForkSeq) type {
     return struct {
         cached_state: *CachedBeaconState,
+        epoch_transition_cache: *EpochTransitionCache,
 
         pub fn run(self: @This(), allocator: std.mem.Allocator) void {
-            const cloned = self.cached_state.clone(allocator, .{}) catch unreachable;
-            defer {
-                cloned.deinit();
-                allocator.destroy(cloned);
-            }
-
-            var cache = EpochTransitionCache.init(allocator, cloned.config, cloned.epoch_cache, cloned.state) catch unreachable;
-            defer cache.deinit();
+            const cloned = self.cached_state;
+            const cache = self.epoch_transition_cache;
 
             state_transition.processPendingDeposits(
                 fork,
@@ -179,7 +154,7 @@ fn ProcessPendingDepositsBench(comptime fork: ForkSeq) type {
                 cloned.config,
                 cloned.epoch_cache,
                 cloned.state.castToFork(fork),
-                &cache,
+                cache,
             ) catch unreachable;
         }
     };
@@ -188,22 +163,18 @@ fn ProcessPendingDepositsBench(comptime fork: ForkSeq) type {
 fn ProcessPendingConsolidationsBench(comptime fork: ForkSeq) type {
     return struct {
         cached_state: *CachedBeaconState,
+        epoch_transition_cache: *EpochTransitionCache,
 
         pub fn run(self: @This(), allocator: std.mem.Allocator) void {
-            const cloned = self.cached_state.clone(allocator, .{}) catch unreachable;
-            defer {
-                cloned.deinit();
-                allocator.destroy(cloned);
-            }
-
-            var cache = EpochTransitionCache.init(allocator, cloned.config, cloned.epoch_cache, cloned.state) catch unreachable;
-            defer cache.deinit();
+            _ = allocator;
+            const cloned = self.cached_state;
+            const cache = self.epoch_transition_cache;
 
             state_transition.processPendingConsolidations(
                 fork,
                 cloned.epoch_cache,
                 cloned.state.castToFork(fork),
-                &cache,
+                cache,
             ) catch unreachable;
         }
     };
@@ -212,23 +183,18 @@ fn ProcessPendingConsolidationsBench(comptime fork: ForkSeq) type {
 fn ProcessEffectiveBalanceUpdatesBench(comptime fork: ForkSeq) type {
     return struct {
         cached_state: *CachedBeaconState,
+        epoch_transition_cache: *EpochTransitionCache,
 
         pub fn run(self: @This(), allocator: std.mem.Allocator) void {
-            const cloned = self.cached_state.clone(allocator, .{}) catch unreachable;
-            defer {
-                cloned.deinit();
-                allocator.destroy(cloned);
-            }
-
-            var cache = EpochTransitionCache.init(allocator, cloned.config, cloned.epoch_cache, cloned.state) catch unreachable;
-            defer cache.deinit();
+            const cloned = self.cached_state;
+            const cache = self.epoch_transition_cache;
 
             _ = state_transition.processEffectiveBalanceUpdates(
                 fork,
                 allocator,
                 cloned.epoch_cache,
                 cloned.state.castToFork(fork),
-                &cache,
+                cache,
             ) catch unreachable;
         }
     };
@@ -237,22 +203,18 @@ fn ProcessEffectiveBalanceUpdatesBench(comptime fork: ForkSeq) type {
 fn ProcessSlashingsResetBench(comptime fork: ForkSeq) type {
     return struct {
         cached_state: *CachedBeaconState,
+        epoch_transition_cache: *EpochTransitionCache,
 
         pub fn run(self: @This(), allocator: std.mem.Allocator) void {
-            const cloned = self.cached_state.clone(allocator, .{}) catch unreachable;
-            defer {
-                cloned.deinit();
-                allocator.destroy(cloned);
-            }
-
-            var cache = EpochTransitionCache.init(allocator, cloned.config, cloned.epoch_cache, cloned.state) catch unreachable;
-            defer cache.deinit();
+            _ = allocator;
+            const cloned = self.cached_state;
+            const cache = self.epoch_transition_cache;
 
             state_transition.processSlashingsReset(
                 fork,
                 cloned.epoch_cache,
                 cloned.state.castToFork(fork),
-                &cache,
+                cache,
             ) catch unreachable;
         }
     };
@@ -261,21 +223,17 @@ fn ProcessSlashingsResetBench(comptime fork: ForkSeq) type {
 fn ProcessRandaoMixesResetBench(comptime fork: ForkSeq) type {
     return struct {
         cached_state: *CachedBeaconState,
+        epoch_transition_cache: *EpochTransitionCache,
 
         pub fn run(self: @This(), allocator: std.mem.Allocator) void {
-            const cloned = self.cached_state.clone(allocator, .{}) catch unreachable;
-            defer {
-                cloned.deinit();
-                allocator.destroy(cloned);
-            }
-
-            var cache = EpochTransitionCache.init(allocator, cloned.config, cloned.epoch_cache, cloned.state) catch unreachable;
-            defer cache.deinit();
+            _ = allocator;
+            const cloned = self.cached_state;
+            const cache = self.epoch_transition_cache;
 
             state_transition.processRandaoMixesReset(
                 fork,
                 cloned.state.castToFork(fork),
-                &cache,
+                cache,
             ) catch unreachable;
         }
     };
@@ -284,21 +242,17 @@ fn ProcessRandaoMixesResetBench(comptime fork: ForkSeq) type {
 fn ProcessHistoricalSummariesUpdateBench(comptime fork: ForkSeq) type {
     return struct {
         cached_state: *CachedBeaconState,
+        epoch_transition_cache: *EpochTransitionCache,
 
         pub fn run(self: @This(), allocator: std.mem.Allocator) void {
-            const cloned = self.cached_state.clone(allocator, .{}) catch unreachable;
-            defer {
-                cloned.deinit();
-                allocator.destroy(cloned);
-            }
-
-            var cache = EpochTransitionCache.init(allocator, cloned.config, cloned.epoch_cache, cloned.state) catch unreachable;
-            defer cache.deinit();
+            _ = allocator;
+            const cloned = self.cached_state;
+            const cache = self.epoch_transition_cache;
 
             state_transition.processHistoricalSummariesUpdate(
                 fork,
                 cloned.state.castToFork(fork),
-                &cache,
+                cache,
             ) catch unreachable;
         }
     };
@@ -307,6 +261,7 @@ fn ProcessHistoricalSummariesUpdateBench(comptime fork: ForkSeq) type {
 fn ProcessParticipationFlagUpdatesBench(comptime fork: ForkSeq) type {
     return struct {
         cached_state: *CachedBeaconState,
+        epoch_transition_cache: *EpochTransitionCache,
 
         pub fn run(self: @This(), allocator: std.mem.Allocator) void {
             const cloned = self.cached_state.clone(allocator, .{}) catch unreachable;
@@ -326,6 +281,7 @@ fn ProcessParticipationFlagUpdatesBench(comptime fork: ForkSeq) type {
 fn ProcessSyncCommitteeUpdatesBench(comptime fork: ForkSeq) type {
     return struct {
         cached_state: *CachedBeaconState,
+        epoch_transition_cache: *EpochTransitionCache,
 
         pub fn run(self: @This(), allocator: std.mem.Allocator) void {
             const cloned = self.cached_state.clone(allocator, .{}) catch unreachable;
@@ -347,23 +303,18 @@ fn ProcessSyncCommitteeUpdatesBench(comptime fork: ForkSeq) type {
 fn ProcessProposerLookaheadBench(comptime fork: ForkSeq) type {
     return struct {
         cached_state: *CachedBeaconState,
+        epoch_transition_cache: *EpochTransitionCache,
 
         pub fn run(self: @This(), allocator: std.mem.Allocator) void {
-            const cloned = self.cached_state.clone(allocator, .{}) catch unreachable;
-            defer {
-                cloned.deinit();
-                allocator.destroy(cloned);
-            }
-
-            var cache = EpochTransitionCache.init(allocator, cloned.config, cloned.epoch_cache, cloned.state) catch unreachable;
-            defer cache.deinit();
+            const cloned = self.cached_state;
+            const cache = self.epoch_transition_cache;
 
             state_transition.processProposerLookahead(
                 fork,
                 allocator,
                 cloned.epoch_cache,
                 cloned.state.castToFork(fork),
-                &cache,
+                cache,
             ) catch unreachable;
         }
     };
@@ -434,16 +385,13 @@ fn printSegmentStats(stdout: anytype) !void {
 fn ProcessEpochBench(comptime fork: ForkSeq) type {
     return struct {
         cached_state: *CachedBeaconState,
+        epoch_transition_cache: *EpochTransitionCache,
 
         pub fn run(self: @This(), allocator: std.mem.Allocator) void {
-            const cloned = self.cached_state.clone(allocator, .{}) catch unreachable;
-            defer {
-                cloned.deinit();
-                allocator.destroy(cloned);
-            }
-
-            var cache = EpochTransitionCache.init(allocator, cloned.config, cloned.epoch_cache, cloned.state) catch unreachable;
-            defer cache.deinit();
+            const cloned = self.cached_state;
+            const cache = self.epoch_transition_cache;
+            const validator_count = cloned.state.validatorsCount() catch unreachable;
+            cache.syncRewardPenaltyLengths(validator_count) catch unreachable;
 
             state_transition.processEpoch(
                 fork,
@@ -451,7 +399,7 @@ fn ProcessEpochBench(comptime fork: ForkSeq) type {
                 cloned.config,
                 cloned.epoch_cache,
                 cloned.state.castToFork(fork),
-                &cache,
+                cache,
             ) catch unreachable;
         }
     };
@@ -460,16 +408,11 @@ fn ProcessEpochBench(comptime fork: ForkSeq) type {
 fn ProcessEpochSegmentedBench(comptime fork: ForkSeq) type {
     return struct {
         cached_state: *CachedBeaconState,
+        epoch_transition_cache: *EpochTransitionCache,
 
         pub fn run(self: @This(), allocator: std.mem.Allocator) void {
-            const cloned = self.cached_state.clone(allocator, .{}) catch unreachable;
-            defer {
-                cloned.deinit();
-                allocator.destroy(cloned);
-            }
-
-            var cache = EpochTransitionCache.init(allocator, cloned.config, cloned.epoch_cache, cloned.state) catch unreachable;
-            defer cache.deinit();
+            const cloned = self.cached_state;
+            const cache = self.epoch_transition_cache;
 
             const fork_state = cloned.state.castToFork(fork);
             const epoch_cache = cloned.epoch_cache;
@@ -477,7 +420,7 @@ fn ProcessEpochSegmentedBench(comptime fork: ForkSeq) type {
             const epoch_start = std.time.nanoTimestamp();
 
             const jf_start = std.time.nanoTimestamp();
-            state_transition.processJustificationAndFinalization(fork, fork_state, &cache) catch unreachable;
+            state_transition.processJustificationAndFinalization(fork, fork_state, cache) catch unreachable;
             recordSegment(.justification_finalization, elapsedSince(jf_start));
 
             if (comptime fork.gte(.altair)) {
@@ -488,7 +431,7 @@ fn ProcessEpochSegmentedBench(comptime fork: ForkSeq) type {
                     cloned.config,
                     epoch_cache,
                     fork_state,
-                    &cache,
+                    cache,
                 ) catch unreachable;
                 recordSegment(.inactivity_updates, elapsedSince(inactivity_start));
             }
@@ -499,7 +442,7 @@ fn ProcessEpochSegmentedBench(comptime fork: ForkSeq) type {
                 cloned.config,
                 epoch_cache,
                 fork_state,
-                &cache,
+                cache,
             ) catch unreachable;
             recordSegment(.registry_updates, elapsedSince(registry_start));
 
@@ -509,7 +452,7 @@ fn ProcessEpochSegmentedBench(comptime fork: ForkSeq) type {
                 allocator,
                 epoch_cache,
                 fork_state,
-                &cache,
+                cache,
                 false,
             ) catch unreachable;
             recordSegment(.slashings, elapsedSince(slashings_start));
@@ -521,13 +464,13 @@ fn ProcessEpochSegmentedBench(comptime fork: ForkSeq) type {
                 cloned.config,
                 epoch_cache,
                 fork_state,
-                &cache,
+                cache,
                 slashing_penalties,
             ) catch unreachable;
             recordSegment(.rewards_and_penalties, elapsedSince(rewards_start));
 
             const eth1_start = std.time.nanoTimestamp();
-            state_transition.processEth1DataReset(fork, fork_state, &cache) catch unreachable;
+            state_transition.processEth1DataReset(fork, fork_state, cache) catch unreachable;
             recordSegment(.eth1_data_reset, elapsedSince(eth1_start));
 
             if (comptime fork.gte(.electra)) {
@@ -538,7 +481,7 @@ fn ProcessEpochSegmentedBench(comptime fork: ForkSeq) type {
                     cloned.config,
                     epoch_cache,
                     fork_state,
-                    &cache,
+                    cache,
                 ) catch unreachable;
                 recordSegment(.pending_deposits, elapsedSince(pending_deposits_start));
 
@@ -547,7 +490,7 @@ fn ProcessEpochSegmentedBench(comptime fork: ForkSeq) type {
                     fork,
                     epoch_cache,
                     fork_state,
-                    &cache,
+                    cache,
                 ) catch unreachable;
                 recordSegment(.pending_consolidations, elapsedSince(pending_consolidations_start));
             }
@@ -558,7 +501,7 @@ fn ProcessEpochSegmentedBench(comptime fork: ForkSeq) type {
                 allocator,
                 epoch_cache,
                 fork_state,
-                &cache,
+                cache,
             ) catch unreachable;
             recordSegment(.effective_balance_updates, elapsedSince(eb_start));
 
@@ -567,21 +510,21 @@ fn ProcessEpochSegmentedBench(comptime fork: ForkSeq) type {
                 fork,
                 epoch_cache,
                 fork_state,
-                &cache,
+                cache,
             ) catch unreachable;
             recordSegment(.slashings_reset, elapsedSince(slashings_reset_start));
 
             const randao_reset_start = std.time.nanoTimestamp();
-            state_transition.processRandaoMixesReset(fork, fork_state, &cache) catch unreachable;
+            state_transition.processRandaoMixesReset(fork, fork_state, cache) catch unreachable;
             recordSegment(.randao_mixes_reset, elapsedSince(randao_reset_start));
 
             if (comptime fork.gte(.capella)) {
                 const historical_summaries_start = std.time.nanoTimestamp();
-                state_transition.processHistoricalSummariesUpdate(fork, fork_state, &cache) catch unreachable;
+                state_transition.processHistoricalSummariesUpdate(fork, fork_state, cache) catch unreachable;
                 recordSegment(.historical_summaries, elapsedSince(historical_summaries_start));
             } else {
                 const historical_roots_start = std.time.nanoTimestamp();
-                state_transition.processHistoricalRootsUpdate(fork, fork_state, &cache) catch unreachable;
+                state_transition.processHistoricalRootsUpdate(fork, fork_state, cache) catch unreachable;
                 recordSegment(.historical_roots, elapsedSince(historical_roots_start));
             }
 
@@ -613,7 +556,7 @@ fn ProcessEpochSegmentedBench(comptime fork: ForkSeq) type {
                     allocator,
                     epoch_cache,
                     fork_state,
-                    &cache,
+                    cache,
                 ) catch unreachable;
                 recordSegment(.proposer_lookahead, elapsedSince(lookahead_start));
             }
@@ -621,6 +564,39 @@ fn ProcessEpochSegmentedBench(comptime fork: ForkSeq) type {
             recordSegment(.epoch_total, elapsedSince(epoch_start));
         }
     };
+}
+
+fn loadStateBytesFromConfiguredEraFiles(allocator: std.mem.Allocator, stdout: anytype) ![]const u8 {
+    if (download_era_options.era_files.len == 0) return error.NoEraFilesConfigured;
+
+    var last_err: ?anyerror = null;
+
+    for (download_era_options.era_files) |era_file| {
+        const era_path = try std.fs.path.join(
+            allocator,
+            &[_][]const u8{ download_era_options.era_out_dir, era_file },
+        );
+        defer allocator.free(era_path);
+
+        var era_reader = era.Reader.open(allocator, config.mainnet.config, era_path) catch |err| {
+            last_err = err;
+            try stdout.print("Skipping ERA file {s}: {s}\n", .{ era_path, @errorName(err) });
+            continue;
+        };
+        defer era_reader.close(allocator);
+
+        const state_bytes = era_reader.readSerializedState(allocator, null) catch |err| {
+            last_err = err;
+            try stdout.print("Skipping ERA file {s}: {s}\n", .{ era_path, @errorName(err) });
+            continue;
+        };
+
+        try stdout.print("State file loaded from {s}: {} bytes\n", .{ era_path, state_bytes.len });
+        return state_bytes;
+    }
+
+    if (last_err) |err| return err;
+    return error.NoUsableEraStateFound;
 }
 
 pub fn main() !void {
@@ -632,20 +608,8 @@ pub fn main() !void {
     var pool = try Node.Pool.init(allocator, 10_000_000);
     defer pool.deinit();
 
-    // Use download_era_options.era_files[0] for state
-    const era_path = try std.fs.path.join(
-        allocator,
-        &[_][]const u8{ download_era_options.era_out_dir, download_era_options.era_files[0] },
-    );
-    defer allocator.free(era_path);
-
-    var era_reader = try era.Reader.open(allocator, config.mainnet.config, era_path);
-    defer era_reader.close(allocator);
-
-    const state_bytes = try era_reader.readSerializedState(allocator, null);
+    const state_bytes = try loadStateBytesFromConfiguredEraFiles(allocator, stdout);
     defer allocator.free(state_bytes);
-
-    try stdout.print("State file loaded: {} bytes\n", .{state_bytes.len});
 
     // Detect fork from state SSZ bytes
     const chain_config = config.mainnet.chain_config;
@@ -716,6 +680,14 @@ fn runBenchmark(
         allocator.destroy(cached_state);
     }
 
+    var epoch_transition_cache = try EpochTransitionCache.init(
+        allocator,
+        cached_state.config,
+        cached_state.epoch_cache,
+        cached_state.state,
+    );
+    defer epoch_transition_cache.deinit();
+
     try stdout.print("Cached state created at slot {}\n", .{try cached_state.state.slot()});
     try stdout.print("\nStarting process_epoch benchmarks for {s} fork...\n\n", .{@tagName(fork)});
 
@@ -724,80 +696,101 @@ fn runBenchmark(
 
     try bench.addParam("justification_finalization", &ProcessJustificationAndFinalizationBench(fork){
         .cached_state = cached_state,
+        .epoch_transition_cache = &epoch_transition_cache,
     }, .{});
 
     if (comptime fork.gte(.altair)) {
         try bench.addParam("inactivity_updates", &ProcessInactivityUpdatesBench(fork){
             .cached_state = cached_state,
+            .epoch_transition_cache = &epoch_transition_cache,
         }, .{});
     }
 
     try bench.addParam("rewards_and_penalties", &ProcessRewardsAndPenaltiesBench(fork){
         .cached_state = cached_state,
+        .epoch_transition_cache = &epoch_transition_cache,
     }, .{});
 
     try bench.addParam("registry_updates", &ProcessRegistryUpdatesBench(fork){
         .cached_state = cached_state,
+        .epoch_transition_cache = &epoch_transition_cache,
     }, .{});
 
     try bench.addParam("slashings", &ProcessSlashingsBench(fork){
         .cached_state = cached_state,
+        .epoch_transition_cache = &epoch_transition_cache,
     }, .{});
 
     try bench.addParam("eth1_data_reset", &ProcessEth1DataResetBench(fork){
         .cached_state = cached_state,
+        .epoch_transition_cache = &epoch_transition_cache,
     }, .{});
 
     if (comptime fork.gte(.electra)) {
         try bench.addParam("pending_deposits", &ProcessPendingDepositsBench(fork){
             .cached_state = cached_state,
+            .epoch_transition_cache = &epoch_transition_cache,
         }, .{});
 
         try bench.addParam("pending_consolidations", &ProcessPendingConsolidationsBench(fork){
             .cached_state = cached_state,
+            .epoch_transition_cache = &epoch_transition_cache,
         }, .{});
     }
 
     try bench.addParam("effective_balance_updates", &ProcessEffectiveBalanceUpdatesBench(fork){
         .cached_state = cached_state,
+        .epoch_transition_cache = &epoch_transition_cache,
     }, .{});
 
     try bench.addParam("slashings_reset", &ProcessSlashingsResetBench(fork){
         .cached_state = cached_state,
+        .epoch_transition_cache = &epoch_transition_cache,
     }, .{});
 
     try bench.addParam("randao_mixes_reset", &ProcessRandaoMixesResetBench(fork){
         .cached_state = cached_state,
+        .epoch_transition_cache = &epoch_transition_cache,
     }, .{});
 
     if (comptime fork.gte(.capella)) {
         try bench.addParam("historical_summaries", &ProcessHistoricalSummariesUpdateBench(fork){
             .cached_state = cached_state,
+            .epoch_transition_cache = &epoch_transition_cache,
         }, .{});
     }
 
     if (comptime fork.gte(.altair)) {
         try bench.addParam("participation_flags", &ProcessParticipationFlagUpdatesBench(fork){
             .cached_state = cached_state,
+            .epoch_transition_cache = &epoch_transition_cache,
         }, .{});
 
         try bench.addParam("sync_committee_updates", &ProcessSyncCommitteeUpdatesBench(fork){
             .cached_state = cached_state,
+            .epoch_transition_cache = &epoch_transition_cache,
         }, .{});
     }
 
     if (comptime fork.gte(.fulu)) {
         try bench.addParam("proposer_lookahead", &ProcessProposerLookaheadBench(fork){
             .cached_state = cached_state,
+            .epoch_transition_cache = &epoch_transition_cache,
         }, .{});
     }
 
     // Non-segmented
-    try bench.addParam("epoch(non-segmented)", &ProcessEpochBench(fork){ .cached_state = cached_state }, .{});
+    try bench.addParam("epoch(non-segmented)", &ProcessEpochBench(fork){
+        .cached_state = cached_state,
+        .epoch_transition_cache = &epoch_transition_cache,
+    }, .{});
 
     // Segmented (step-by-step timing)
     resetSegmentStats();
-    try bench.addParam("epoch(segmented)", &ProcessEpochSegmentedBench(fork){ .cached_state = cached_state }, .{});
+    try bench.addParam("epoch(segmented)", &ProcessEpochSegmentedBench(fork){
+        .cached_state = cached_state,
+        .epoch_transition_cache = &epoch_transition_cache,
+    }, .{});
 
     try bench.run(stdout);
     try printSegmentStats(stdout);

--- a/bench/state_transition/process_epoch.zig
+++ b/bench/state_transition/process_epoch.zig
@@ -37,6 +37,26 @@ fn ProcessJustificationAndFinalizationBench(comptime fork: ForkSeq) type {
     };
 }
 
+fn ProcessBeforeProcessEpochBench(comptime fork: ForkSeq) type {
+    comptime _ = fork;
+    return struct {
+        cached_state: *CachedBeaconState,
+
+        pub fn run(self: @This(), allocator: std.mem.Allocator) void {
+            const cloned = self.cached_state;
+            cloned.state.commit() catch unreachable;
+
+            var epoch_transition_cache = EpochTransitionCache.init(
+                allocator,
+                cloned.config,
+                cloned.epoch_cache,
+                cloned.state,
+            ) catch unreachable;
+            defer epoch_transition_cache.deinit();
+        }
+    };
+}
+
 fn ProcessInactivityUpdatesBench(comptime fork: ForkSeq) type {
     return struct {
         cached_state: *CachedBeaconState,
@@ -322,6 +342,7 @@ fn ProcessProposerLookaheadBench(comptime fork: ForkSeq) type {
 
 const Step = enum {
     epoch_total,
+    before_process_epoch,
     justification_finalization,
     inactivity_updates,
     rewards_and_penalties,
@@ -693,6 +714,10 @@ fn runBenchmark(
 
     var bench = zbench.Benchmark.init(allocator, .{ .iterations = 50 });
     defer bench.deinit();
+
+    try bench.addParam("before_process_epoch", &ProcessBeforeProcessEpochBench(fork){
+        .cached_state = cached_state,
+    }, .{});
 
     try bench.addParam("justification_finalization", &ProcessJustificationAndFinalizationBench(fork){
         .cached_state = cached_state,

--- a/bench/state_transition/process_epoch.zig
+++ b/bench/state_transition/process_epoch.zig
@@ -25,8 +25,11 @@ fn ProcessJustificationAndFinalizationBench(comptime fork: ForkSeq) type {
         epoch_transition_cache: *EpochTransitionCache,
 
         pub fn run(self: @This(), allocator: std.mem.Allocator) void {
-            _ = allocator;
-            const cloned = self.cached_state;
+            const cloned = self.cached_state.clone(allocator, .{}) catch unreachable;
+            defer {
+                cloned.deinit();
+                allocator.destroy(cloned);
+            }
             const cache = self.epoch_transition_cache;
             state_transition.processJustificationAndFinalization(
                 fork,
@@ -43,7 +46,11 @@ fn ProcessBeforeProcessEpochBench(comptime fork: ForkSeq) type {
         cached_state: *CachedBeaconState,
 
         pub fn run(self: @This(), allocator: std.mem.Allocator) void {
-            const cloned = self.cached_state;
+            const cloned = self.cached_state.clone(allocator, .{}) catch unreachable;
+            defer {
+                cloned.deinit();
+                allocator.destroy(cloned);
+            }
             cloned.state.commit() catch unreachable;
 
             var epoch_transition_cache = EpochTransitionCache.init(
@@ -63,7 +70,11 @@ fn ProcessInactivityUpdatesBench(comptime fork: ForkSeq) type {
         epoch_transition_cache: *EpochTransitionCache,
 
         pub fn run(self: @This(), allocator: std.mem.Allocator) void {
-            const cloned = self.cached_state;
+            const cloned = self.cached_state.clone(allocator, .{}) catch unreachable;
+            defer {
+                cloned.deinit();
+                allocator.destroy(cloned);
+            }
             const cache = self.epoch_transition_cache;
             state_transition.processInactivityUpdates(
                 fork,
@@ -83,7 +94,11 @@ fn ProcessRewardsAndPenaltiesBench(comptime fork: ForkSeq) type {
         epoch_transition_cache: *EpochTransitionCache,
 
         pub fn run(self: @This(), allocator: std.mem.Allocator) void {
-            const cloned = self.cached_state;
+            const cloned = self.cached_state.clone(allocator, .{}) catch unreachable;
+            defer {
+                cloned.deinit();
+                allocator.destroy(cloned);
+            }
             const cache = self.epoch_transition_cache;
             const validator_count = cloned.state.validatorsCount() catch unreachable;
             cache.syncRewardPenaltyLengths(validator_count) catch unreachable;
@@ -106,8 +121,11 @@ fn ProcessRegistryUpdatesBench(comptime fork: ForkSeq) type {
         epoch_transition_cache: *EpochTransitionCache,
 
         pub fn run(self: @This(), allocator: std.mem.Allocator) void {
-            _ = allocator;
-            const cloned = self.cached_state;
+            const cloned = self.cached_state.clone(allocator, .{}) catch unreachable;
+            defer {
+                cloned.deinit();
+                allocator.destroy(cloned);
+            }
             const cache = self.epoch_transition_cache;
             state_transition.processRegistryUpdates(
                 fork,
@@ -126,7 +144,11 @@ fn ProcessSlashingsBench(comptime fork: ForkSeq) type {
         epoch_transition_cache: *EpochTransitionCache,
 
         pub fn run(self: @This(), allocator: std.mem.Allocator) void {
-            const cloned = self.cached_state;
+            const cloned = self.cached_state.clone(allocator, .{}) catch unreachable;
+            defer {
+                cloned.deinit();
+                allocator.destroy(cloned);
+            }
             const cache = self.epoch_transition_cache;
             _ = state_transition.processSlashings(
                 fork,
@@ -146,8 +168,11 @@ fn ProcessEth1DataResetBench(comptime fork: ForkSeq) type {
         epoch_transition_cache: *EpochTransitionCache,
 
         pub fn run(self: @This(), allocator: std.mem.Allocator) void {
-            _ = allocator;
-            const cloned = self.cached_state;
+            const cloned = self.cached_state.clone(allocator, .{}) catch unreachable;
+            defer {
+                cloned.deinit();
+                allocator.destroy(cloned);
+            }
             const cache = self.epoch_transition_cache;
 
             state_transition.processEth1DataReset(
@@ -165,7 +190,11 @@ fn ProcessPendingDepositsBench(comptime fork: ForkSeq) type {
         epoch_transition_cache: *EpochTransitionCache,
 
         pub fn run(self: @This(), allocator: std.mem.Allocator) void {
-            const cloned = self.cached_state;
+            const cloned = self.cached_state.clone(allocator, .{}) catch unreachable;
+            defer {
+                cloned.deinit();
+                allocator.destroy(cloned);
+            }
             const cache = self.epoch_transition_cache;
 
             state_transition.processPendingDeposits(
@@ -186,8 +215,11 @@ fn ProcessPendingConsolidationsBench(comptime fork: ForkSeq) type {
         epoch_transition_cache: *EpochTransitionCache,
 
         pub fn run(self: @This(), allocator: std.mem.Allocator) void {
-            _ = allocator;
-            const cloned = self.cached_state;
+            const cloned = self.cached_state.clone(allocator, .{}) catch unreachable;
+            defer {
+                cloned.deinit();
+                allocator.destroy(cloned);
+            }
             const cache = self.epoch_transition_cache;
 
             state_transition.processPendingConsolidations(
@@ -206,7 +238,11 @@ fn ProcessEffectiveBalanceUpdatesBench(comptime fork: ForkSeq) type {
         epoch_transition_cache: *EpochTransitionCache,
 
         pub fn run(self: @This(), allocator: std.mem.Allocator) void {
-            const cloned = self.cached_state;
+            const cloned = self.cached_state.clone(allocator, .{}) catch unreachable;
+            defer {
+                cloned.deinit();
+                allocator.destroy(cloned);
+            }
             const cache = self.epoch_transition_cache;
 
             _ = state_transition.processEffectiveBalanceUpdates(
@@ -226,8 +262,11 @@ fn ProcessSlashingsResetBench(comptime fork: ForkSeq) type {
         epoch_transition_cache: *EpochTransitionCache,
 
         pub fn run(self: @This(), allocator: std.mem.Allocator) void {
-            _ = allocator;
-            const cloned = self.cached_state;
+            const cloned = self.cached_state.clone(allocator, .{}) catch unreachable;
+            defer {
+                cloned.deinit();
+                allocator.destroy(cloned);
+            }
             const cache = self.epoch_transition_cache;
 
             state_transition.processSlashingsReset(
@@ -246,8 +285,11 @@ fn ProcessRandaoMixesResetBench(comptime fork: ForkSeq) type {
         epoch_transition_cache: *EpochTransitionCache,
 
         pub fn run(self: @This(), allocator: std.mem.Allocator) void {
-            _ = allocator;
-            const cloned = self.cached_state;
+            const cloned = self.cached_state.clone(allocator, .{}) catch unreachable;
+            defer {
+                cloned.deinit();
+                allocator.destroy(cloned);
+            }
             const cache = self.epoch_transition_cache;
 
             state_transition.processRandaoMixesReset(
@@ -265,8 +307,11 @@ fn ProcessHistoricalSummariesUpdateBench(comptime fork: ForkSeq) type {
         epoch_transition_cache: *EpochTransitionCache,
 
         pub fn run(self: @This(), allocator: std.mem.Allocator) void {
-            _ = allocator;
-            const cloned = self.cached_state;
+            const cloned = self.cached_state.clone(allocator, .{}) catch unreachable;
+            defer {
+                cloned.deinit();
+                allocator.destroy(cloned);
+            }
             const cache = self.epoch_transition_cache;
 
             state_transition.processHistoricalSummariesUpdate(
@@ -326,7 +371,11 @@ fn ProcessProposerLookaheadBench(comptime fork: ForkSeq) type {
         epoch_transition_cache: *EpochTransitionCache,
 
         pub fn run(self: @This(), allocator: std.mem.Allocator) void {
-            const cloned = self.cached_state;
+            const cloned = self.cached_state.clone(allocator, .{}) catch unreachable;
+            defer {
+                cloned.deinit();
+                allocator.destroy(cloned);
+            }
             const cache = self.epoch_transition_cache;
 
             state_transition.processProposerLookahead(
@@ -406,11 +455,21 @@ fn printSegmentStats(stdout: anytype) !void {
 fn ProcessEpochBench(comptime fork: ForkSeq) type {
     return struct {
         cached_state: *CachedBeaconState,
-        epoch_transition_cache: *EpochTransitionCache,
 
         pub fn run(self: @This(), allocator: std.mem.Allocator) void {
-            const cloned = self.cached_state;
-            const cache = self.epoch_transition_cache;
+            const cloned = self.cached_state.clone(allocator, .{}) catch unreachable;
+            defer {
+                cloned.deinit();
+                allocator.destroy(cloned);
+            }
+            var cache = EpochTransitionCache.init(
+                allocator,
+                cloned.config,
+                cloned.epoch_cache,
+                cloned.state,
+            ) catch unreachable;
+            defer cache.deinit();
+
             const validator_count = cloned.state.validatorsCount() catch unreachable;
             cache.syncRewardPenaltyLengths(validator_count) catch unreachable;
 
@@ -420,7 +479,7 @@ fn ProcessEpochBench(comptime fork: ForkSeq) type {
                 cloned.config,
                 cloned.epoch_cache,
                 cloned.state.castToFork(fork),
-                cache,
+                &cache,
             ) catch unreachable;
         }
     };
@@ -429,16 +488,29 @@ fn ProcessEpochBench(comptime fork: ForkSeq) type {
 fn ProcessEpochSegmentedBench(comptime fork: ForkSeq) type {
     return struct {
         cached_state: *CachedBeaconState,
-        epoch_transition_cache: *EpochTransitionCache,
 
         pub fn run(self: @This(), allocator: std.mem.Allocator) void {
-            const cloned = self.cached_state;
-            const cache = self.epoch_transition_cache;
+            const cloned = self.cached_state.clone(allocator, .{}) catch unreachable;
+            defer {
+                cloned.deinit();
+                allocator.destroy(cloned);
+            }
+            const epoch_start = std.time.nanoTimestamp();
+
+            const before_start = std.time.nanoTimestamp();
+            cloned.state.commit() catch unreachable;
+            var cache_val = EpochTransitionCache.init(
+                allocator,
+                cloned.config,
+                cloned.epoch_cache,
+                cloned.state,
+            ) catch unreachable;
+            defer cache_val.deinit();
+            const cache = &cache_val;
+            recordSegment(.before_process_epoch, elapsedSince(before_start));
 
             const fork_state = cloned.state.castToFork(fork);
             const epoch_cache = cloned.epoch_cache;
-
-            const epoch_start = std.time.nanoTimestamp();
 
             const jf_start = std.time.nanoTimestamp();
             state_transition.processJustificationAndFinalization(fork, fork_state, cache) catch unreachable;
@@ -807,14 +879,12 @@ fn runBenchmark(
     // Non-segmented
     try bench.addParam("epoch(non-segmented)", &ProcessEpochBench(fork){
         .cached_state = cached_state,
-        .epoch_transition_cache = &epoch_transition_cache,
     }, .{});
 
     // Segmented (step-by-step timing)
     resetSegmentStats();
     try bench.addParam("epoch(segmented)", &ProcessEpochSegmentedBench(fork){
         .cached_state = cached_state,
-        .epoch_transition_cache = &epoch_transition_cache,
     }, .{});
 
     try bench.run(stdout);

--- a/src/state_transition/cache/epoch_transition_cache.zig
+++ b/src/state_transition/cache/epoch_transition_cache.zig
@@ -559,6 +559,7 @@ pub const EpochTransitionCache = struct {
     }
 
     /// Ensure rewards/penalties arrays match the current validator count.
+    /// This is only used in benchmark tests where we want to reuse the cache across steps.
     pub fn syncRewardPenaltyLengths(self: *EpochTransitionCache, validator_count: usize) !void {
         _reused_lock.lock();
         defer _reused_lock.unlock();

--- a/src/state_transition/cache/epoch_transition_cache.zig
+++ b/src/state_transition/cache/epoch_transition_cache.zig
@@ -557,6 +557,18 @@ pub const EpochTransitionCache = struct {
             balances.deinit();
         }
     }
+
+    /// Ensure rewards/penalties arrays match the current validator count.
+    pub fn syncRewardPenaltyLengths(self: *EpochTransitionCache, validator_count: usize) !void {
+        _reused_lock.lock();
+        defer _reused_lock.unlock();
+
+        const reused_cache = _reused_cache orelse return error.ReusedEpochTransitionCacheUnavailable;
+        try reused_cache.rewards.resize(validator_count);
+        try reused_cache.penalties.resize(validator_count);
+        self.rewards = reused_cache.rewards.items;
+        self.penalties = reused_cache.penalties.items;
+    }
 };
 
 test "EpochTransitionCache - finalProcessEpoch" {


### PR DESCRIPTION
**Motivation**
- building epoch transition cache takes ~1s, we should not bundle this step with others

**Description**
- build `EpochTransitionCache` once and use it for other steps
- also found an issue that we cannot load the 1st era file but we downloaded multi of them, so did a for loop to run the benchmark

**Test**
```
zig build run:bench_process_epoch
Skipping ERA file fixtures/era/mainnet-01628-47ac89fb.era: InvalidSlotIndexCount
State file loaded from fixtures/era/mainnet-01629-f4b834bc.era: 306761407 bytes
Benchmarking processEpoch with state at fork: fulu (slot 13344768)
State deserialized: slot=13344768, validators=2178282
Cached state created at slot 13344768

Starting process_epoch benchmarks for fulu fork...

benchmark              runs     total time     time/run (avg ± σ)     (min ... max)                p75        p99        p995      
-----------------------------------------------------------------------------------------------------------------------------
before_process_epoch   50       52.57s         1.051s ± 16.036ms      (1.031s ... 1.124s)          1.054s     1.124s     1.124s    
justification_finaliza 50       1.415ms        28.315us ± 8.15us      (26.416us ... 83.291us)      26.667us   83.291us   83.291us  
inactivity_updates     50       9.177s         183.546ms ± 18.268ms   (177.437ms ... 308.13ms)     181.533ms  308.13ms   308.13ms  
rewards_and_penalties  50       24.993s        499.866ms ± 8.529ms    (491.702ms ... 541.117ms)    500.489ms  541.117ms  541.117ms 
registry_updates       50       29.583us       591ns ± 618ns          (458ns ... 4.875us)          500ns      4.875us    4.875us   
slashings              50       2.459us        49ns ± 60ns            (0ns ... 459ns)              42ns       459ns      459ns     
eth1_data_reset        50       4.998us        99ns ± 448ns           (0ns ... 3.209us)            42ns       3.209us    3.209us   
pending_deposits       50       354.393ms      7.087ms ± 5.338ms      (1.959us ... 14.785ms)       11.07ms    14.785ms   14.785ms  
pending_consolidations 50       124.743us      2.494us ± 4.422us      (1.75us ... 33.125us)        1.916us    33.125us   33.125us  
effective_balance_upda 50       9.698s         193.967ms ± 20.148ms   (185.874ms ... 331.517ms)    193.14ms   331.517ms  331.517ms 
slashings_reset        50       56.084us       1.121us ± 2.723us      (666ns ... 19.958us)         709ns      19.958us   19.958us  
randao_mixes_reset     50       378.166us      7.563us ± 2.929us      (6.625us ... 26.959us)       7.458us    26.959us   26.959us  
historical_summaries   50       1.414us        28ns ± 48ns            (0ns ... 333ns)              42ns       333ns      333ns     
participation_flags    50       45.143ms       902.879us ± 5.752ms    (84.75us ... 40.766ms)       89.5us     40.766ms   40.766ms  
sync_committee_updates 50       1.578ms        31.564us ± 5.962us     (29.166us ... 69.666us)      31.166us   69.666us   69.666us  
proposer_lookahead     50       3.999s         79.984ms ± 446.267us   (78.791ms ... 80.747ms)      80.321ms   80.747ms   80.747ms  
epoch(non-segmented)   50       48.323s        966.475ms ± 33.016ms   (940.598ms ... 1.186s)       967.367ms  1.186s     1.186s    
epoch(segmented)       50       47.948s        958.961ms ± 17.776ms   (945.923ms ... 1.066s)       962.974ms  1.066s     1.066s    

Segmented epoch breakdown:
step                         runs     total time     time/run (avg)
------------------------------------------------------------------
epoch_total                  50           47.947s      958.950ms
justification_finalization   50            1.913ms        0.038ms
inactivity_updates           50            9.112s      182.235ms
rewards_and_penalties        50           18.595s      371.890ms
registry_updates             50            0.277ms        0.006ms
slashings                    50            3.514ms        0.070ms
eth1_data_reset              50            0.006ms        0.000ms
pending_deposits             50            5.337ms        0.107ms
pending_consolidations       50            0.201ms        0.004ms
effective_balance_updates    50           16.182s      323.643ms
slashings_reset              50            0.227ms        0.005ms
randao_mixes_reset           50            0.619ms        0.012ms
historical_summaries         50            0.009ms        0.000ms
participation_flags          50            1.796ms        0.036ms
sync_committee_updates       50            0.009ms        0.000ms
proposer_lookahead           50            4.045s       80.902ms
```