### PR TITLE
test(utils): add unit tests for attestation slashing utilities

### DIFF
--- a/src/state_transition/utils/attestation.zig
+++ b/src/state_transition/utils/attestation.zig
@@ -48,3 +48,164 @@ pub fn findAttesterSlashableIndices(attester_slashing: *const AttesterSlashing, 
     // we must reach the end of one of the indices
     std.debug.assert(i == a.len or j == b.len);
 }
+
+test "isSlashableAttestationData - double vote" {
+    // Same target epoch, different data = double vote
+    const data1 = AttestationData{
+        .slot = 10,
+        .index = 0,
+        .beacon_block_root = [_]u8{0xaa} ** 32,
+        .source = .{ .epoch = 1, .root = [_]u8{0} ** 32 },
+        .target = .{ .epoch = 5, .root = [_]u8{0x11} ** 32 },
+    };
+    const data2 = AttestationData{
+        .slot = 10,
+        .index = 0,
+        .beacon_block_root = [_]u8{0xbb} ** 32, // different block root
+        .source = .{ .epoch = 1, .root = [_]u8{0} ** 32 },
+        .target = .{ .epoch = 5, .root = [_]u8{0x22} ** 32 }, // same epoch, different root
+    };
+    try std.testing.expect(isSlashableAttestationData(&data1, &data2));
+}
+
+test "isSlashableAttestationData - surround vote" {
+    // data1 surrounds data2: source1 < source2 AND target2 < target1
+    const data1 = AttestationData{
+        .slot = 10,
+        .index = 0,
+        .beacon_block_root = [_]u8{0} ** 32,
+        .source = .{ .epoch = 1, .root = [_]u8{0} ** 32 },
+        .target = .{ .epoch = 10, .root = [_]u8{0} ** 32 },
+    };
+    const data2 = AttestationData{
+        .slot = 10,
+        .index = 0,
+        .beacon_block_root = [_]u8{0} ** 32,
+        .source = .{ .epoch = 3, .root = [_]u8{0} ** 32 },
+        .target = .{ .epoch = 7, .root = [_]u8{0} ** 32 },
+    };
+    try std.testing.expect(isSlashableAttestationData(&data1, &data2));
+}
+
+test "isSlashableAttestationData - identical data is not slashable" {
+    const data = AttestationData{
+        .slot = 10,
+        .index = 0,
+        .beacon_block_root = [_]u8{0} ** 32,
+        .source = .{ .epoch = 1, .root = [_]u8{0} ** 32 },
+        .target = .{ .epoch = 5, .root = [_]u8{0} ** 32 },
+    };
+    // Identical data — not a double vote (same attestation, not slashable)
+    try std.testing.expect(!isSlashableAttestationData(&data, &data));
+}
+
+test "isSlashableAttestationData - different epochs not surrounding" {
+    const data1 = AttestationData{
+        .slot = 10,
+        .index = 0,
+        .beacon_block_root = [_]u8{0} ** 32,
+        .source = .{ .epoch = 1, .root = [_]u8{0} ** 32 },
+        .target = .{ .epoch = 5, .root = [_]u8{0} ** 32 },
+    };
+    const data2 = AttestationData{
+        .slot = 20,
+        .index = 0,
+        .beacon_block_root = [_]u8{0} ** 32,
+        .source = .{ .epoch = 3, .root = [_]u8{0} ** 32 },
+        .target = .{ .epoch = 8, .root = [_]u8{0} ** 32 },
+    };
+    // Different target epochs and no surround = not slashable
+    try std.testing.expect(!isSlashableAttestationData(&data1, &data2));
+}
+
+test "findAttesterSlashableIndices - common indices" {
+    const allocator = std.testing.allocator;
+
+    // Simulate an AttesterSlashing with overlapping attesting indices
+    // attestation_1 indices: [1, 3, 5, 7]
+    // attestation_2 indices: [2, 3, 6, 7]
+    // expected intersection: [3, 7]
+    var att1_indices = try std.ArrayList(ValidatorIndex).initCapacity(allocator, 4);
+    defer att1_indices.deinit();
+    try att1_indices.appendSlice(&.{ 1, 3, 5, 7 });
+
+    var att2_indices = try std.ArrayList(ValidatorIndex).initCapacity(allocator, 4);
+    defer att2_indices.deinit();
+    try att2_indices.appendSlice(&.{ 2, 3, 6, 7 });
+
+    var slashing = AttesterSlashing{
+        .attestation_1 = .{
+            .attesting_indices = .{ .items = att1_indices.items, .capacity = att1_indices.capacity },
+            .data = .{
+                .slot = 0,
+                .index = 0,
+                .beacon_block_root = [_]u8{0} ** 32,
+                .source = .{ .epoch = 0, .root = [_]u8{0} ** 32 },
+                .target = .{ .epoch = 0, .root = [_]u8{0} ** 32 },
+            },
+            .signature = [_]u8{0} ** 96,
+        },
+        .attestation_2 = .{
+            .attesting_indices = .{ .items = att2_indices.items, .capacity = att2_indices.capacity },
+            .data = .{
+                .slot = 0,
+                .index = 0,
+                .beacon_block_root = [_]u8{0} ** 32,
+                .source = .{ .epoch = 0, .root = [_]u8{0} ** 32 },
+                .target = .{ .epoch = 0, .root = [_]u8{0} ** 32 },
+            },
+            .signature = [_]u8{0} ** 96,
+        },
+    };
+
+    var result = std.ArrayList(ValidatorIndex).init(allocator);
+    defer result.deinit();
+    try findAttesterSlashableIndices(&slashing, &result);
+
+    try std.testing.expectEqual(@as(usize, 2), result.items.len);
+    try std.testing.expectEqual(@as(ValidatorIndex, 3), result.items[0]);
+    try std.testing.expectEqual(@as(ValidatorIndex, 7), result.items[1]);
+}
+
+test "findAttesterSlashableIndices - no overlap" {
+    const allocator = std.testing.allocator;
+
+    var att1_indices = try std.ArrayList(ValidatorIndex).initCapacity(allocator, 3);
+    defer att1_indices.deinit();
+    try att1_indices.appendSlice(&.{ 1, 3, 5 });
+
+    var att2_indices = try std.ArrayList(ValidatorIndex).initCapacity(allocator, 3);
+    defer att2_indices.deinit();
+    try att2_indices.appendSlice(&.{ 2, 4, 6 });
+
+    var slashing = AttesterSlashing{
+        .attestation_1 = .{
+            .attesting_indices = .{ .items = att1_indices.items, .capacity = att1_indices.capacity },
+            .data = .{
+                .slot = 0,
+                .index = 0,
+                .beacon_block_root = [_]u8{0} ** 32,
+                .source = .{ .epoch = 0, .root = [_]u8{0} ** 32 },
+                .target = .{ .epoch = 0, .root = [_]u8{0} ** 32 },
+            },
+            .signature = [_]u8{0} ** 96,
+        },
+        .attestation_2 = .{
+            .attesting_indices = .{ .items = att2_indices.items, .capacity = att2_indices.capacity },
+            .data = .{
+                .slot = 0,
+                .index = 0,
+                .beacon_block_root = [_]u8{0} ** 32,
+                .source = .{ .epoch = 0, .root = [_]u8{0} ** 32 },
+                .target = .{ .epoch = 0, .root = [_]u8{0} ** 32 },
+            },
+            .signature = [_]u8{0} ** 96,
+        },
+    };
+
+    var result = std.ArrayList(ValidatorIndex).init(allocator);
+    defer result.deinit();
+    try findAttesterSlashableIndices(&slashing, &result);
+
+    try std.testing.expectEqual(@as(usize, 0), result.items.len);
+}


### PR DESCRIPTION
## Summary

Add 6 unit tests for the attestation slashing utility functions in `src/state_transition/utils/attestation.zig` (previously 0 tests).

### Tests added

**isSlashableAttestationData** (4 tests):
- Double vote detection — same target epoch, different attestation data
- Surround vote detection — source/target range containment
- Identical data is not slashable — same attestation twice
- Different epochs without surrounding — not slashable

**findAttesterSlashableIndices** (2 tests):
- Common indices intersection — two-pointer sorted merge produces correct overlap
- No overlap case — disjoint index sets produce empty result

### Context

Part of the block processing test coverage campaign. These utility functions underpin attester slashing validation (`assertValidAttesterSlashing`).
