### PR TITLE
perf: use saturating arithmetic in balance updates for SIMD vectorization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ node_modules/
 # Claude Code local config
 .claude/settings.local.json
 .claude/plans/
+zig-pkg/

--- a/src/state_transition/epoch/process_rewards_and_penalties.zig
+++ b/src/state_transition/epoch/process_rewards_and_penalties.zig
@@ -31,18 +31,19 @@ pub fn processRewardsAndPenalties(
     const balances = try state.balancesSlice(allocator);
     defer allocator.free(balances);
 
-    // Use saturating arithmetic instead of checked (`std.math.add`):
-    // - Overflow is impossible: max ETH supply ~120M ETH = ~1.2e17 Gwei,
-    //   u64 max = ~1.8e19, giving 154x headroom even with all rewards summed.
-    // - Saturating ops are branchless, enabling SIMD auto-vectorization of the
-    //   balance loop (~3.4x speedup on the inner loop for 500k+ validators).
+    // Use saturating arithmetic for performance. Saturating operations are branchless, which
+    // enables SIMD auto-vectorization of the balance update loop. This is safe because a
+    // balance overflow is mathematically impossible: the maximum total ETH supply (~1.2e17 Gwei)
+    // is more than 150x smaller than the max u64 value (~1.8e19 Gwei).
     if (slashing_penalties) |slashings| {
         for (rewards, penalties, balances, 0..) |reward, penalty, *balance, i| {
             const slashing: u64 = if (i < slashings.len) slashings[i] else 0;
+            std.debug.assert(balance.* <= std.math.maxInt(u64) - reward);
             balance.* = ((balance.* +| reward) -| penalty) -| slashing;
         }
     } else {
         for (rewards, penalties, balances) |reward, penalty, *balance| {
+            std.debug.assert(balance.* <= std.math.maxInt(u64) - reward);
             balance.* = (balance.* +| reward) -| penalty;
         }
     }

--- a/src/state_transition/epoch/process_rewards_and_penalties.zig
+++ b/src/state_transition/epoch/process_rewards_and_penalties.zig
@@ -31,14 +31,19 @@ pub fn processRewardsAndPenalties(
     const balances = try state.balancesSlice(allocator);
     defer allocator.free(balances);
 
+    // Use saturating arithmetic instead of checked (`std.math.add`):
+    // - Overflow is impossible: max ETH supply ~120M ETH = ~1.2e17 Gwei,
+    //   u64 max = ~1.8e19, giving 154x headroom even with all rewards summed.
+    // - Saturating ops are branchless, enabling SIMD auto-vectorization of the
+    //   balance loop (~3.4x speedup on the inner loop for 500k+ validators).
     if (slashing_penalties) |slashings| {
         for (rewards, penalties, balances, 0..) |reward, penalty, *balance, i| {
             const slashing: u64 = if (i < slashings.len) slashings[i] else 0;
-            balance.* = (try std.math.add(u64, balance.*, reward)) -| penalty -| slashing;
+            balance.* = ((balance.* +| reward) -| penalty) -| slashing;
         }
     } else {
         for (rewards, penalties, balances) |reward, penalty, *balance| {
-            balance.* = (try std.math.add(u64, balance.*, reward)) -| penalty;
+            balance.* = (balance.* +| reward) -| penalty;
         }
     }
 


### PR DESCRIPTION
## Current status — historical claims corrected

The measurements below are historical ReleaseFast results, not evidence of SIMD vectorization or an end-to-end gain on the current ReleaseSafe build. The assertion-bearing head has not demonstrated a ReleaseSafe improvement. [Latest maintainer measurements](https://github.com/ChainSafe/lodestar-z/pull/282#discussion_r3988193013) report a benefit for a different variant with the assertions removed; that variant is not this PR head.

The earlier “zero risk of behavior change” claim is withdrawn. Replacing `try std.math.add` with `std.debug.assert` plus saturating addition changes overflow handling from a returned `error.Overflow` to safety-checked illegal behavior (normally a panic) in ReleaseSafe. In ReleaseFast, violating the assertion reaches unchecked `unreachable`; saturation is not a guaranteed fallback while the assertion remains. Removing the assertion would give defined saturating addition, but still would not preserve the checked-add error contract. The ETH-supply argument alone is not a proof covering every state accepted by this API.

The branch is unchanged pending agreement on the intended overflow contract and current-compiler performance evidence.

---

## Motivation

`processRewardsAndPenalties` iterates over all validator balances (2.18M on mainnet). The inner loop used `try std.math.add(u64, ...)` which generates a branch per addition, preventing LLVM from auto-vectorizing.

## Change

Replace `try std.math.add` with saturating add (`+|`). Overflow is mathematically impossible:
- Max ETH supply: ~120M ETH ≈ 1.2 × 10¹⁷ Gwei
- u64 max: 1.8 × 10¹⁹
- Headroom: 154×

## Results

**Isolated microbenchmark** (500k validators, 100 iterations, ReleaseFast):
```
try std.math.add: 618.6 µs/iter
saturating +|:    179.6 µs/iter
speedup:          3.44×
```

**Full epoch benchmark** (`bench_process_epoch`, mainnet state at slot 13336576, 2.18M validators, 50 iterations, ReleaseFast):

| Metric | Checked (`try std.math.add`) | Saturating (`+\|`) | Δ |
|---|---|---|---|
| `rewards_and_penalties` (isolated) | 119.4ms ± 6.2ms | 117.5ms ± 5.7ms | −1.6% |
| Full epoch (segmented) | 794.1ms | 785.5ms | −1.1% |

The inner loop speedup (3.44×) is real but `processRewardsAndPenalties` is dominated by reward/penalty computation, so the end-to-end improvement is modest. That historical result does not establish the safety or current-build performance claims; see the current-status correction above.
