### PR TITLE
feat(types): add Fulu cell dissemination SSZ types

### DIFF
--- a/src/consensus_types/fulu.zig
+++ b/src/consensus_types/fulu.zig
@@ -102,6 +102,26 @@ pub const MatrixEntry = ssz.FixedContainerType(struct {
     row_index: RowIndex,
 });
 
+// Cell Dissemination types (consensus-specs #4558)
+pub const PartialDataColumnSidecar = ssz.VariableContainerType(struct {
+    cells_present_bitmap: ssz.BitListType(preset.MAX_BLOB_COMMITMENTS_PER_BLOCK),
+    partial_column: ssz.FixedListType(Cell, preset.MAX_BLOB_COMMITMENTS_PER_BLOCK),
+    kzg_proofs: ssz.FixedListType(p.KZGProof, preset.MAX_BLOB_COMMITMENTS_PER_BLOCK),
+    // Optional header, only sent on eager pushes
+    header: ssz.VariableListType(PartialDataColumnHeader, 1),
+});
+
+pub const PartialDataColumnPartsMetadata = ssz.VariableContainerType(struct {
+    available: ssz.BitListType(preset.MAX_BLOB_COMMITMENTS_PER_BLOCK),
+    requests: ssz.BitListType(preset.MAX_BLOB_COMMITMENTS_PER_BLOCK),
+});
+
+pub const PartialDataColumnHeader = ssz.VariableContainerType(struct {
+    kzg_commitments: ssz.FixedListType(p.KZGCommitment, preset.MAX_BLOB_COMMITMENTS_PER_BLOCK),
+    signed_block_header: SignedBeaconBlockHeader,
+    kzg_commitments_inclusion_proof: ssz.FixedVectorType(p.Bytes32, preset.KZG_COMMITMENTS_INCLUSION_PROOF_DEPTH),
+});
+
 // Light client types
 pub const LightClientHeader = electra.LightClientHeader;
 pub const LightClientBootstrap = electra.LightClientBootstrap;

--- a/src/consensus_types/fulu.zig
+++ b/src/consensus_types/fulu.zig
@@ -102,6 +102,12 @@ pub const MatrixEntry = ssz.FixedContainerType(struct {
     row_index: RowIndex,
 });
 
+// Networking request/response identifiers
+pub const DataColumnsByRootIdentifier = ssz.VariableContainerType(struct {
+    block_root: p.Root,
+    columns: ssz.FixedListType(ColumnIndex, @import("preset").NUMBER_OF_COLUMNS),
+});
+
 // Cell Dissemination types (consensus-specs #4558)
 pub const PartialDataColumnSidecar = ssz.VariableContainerType(struct {
     cells_present_bitmap: ssz.BitListType(preset.MAX_BLOB_COMMITMENTS_PER_BLOCK),

--- a/src/consensus_types/fulu.zig
+++ b/src/consensus_types/fulu.zig
@@ -92,7 +92,10 @@ pub const DataColumnSidecar = ssz.VariableContainerType(struct {
     kzg_commitments: ssz.FixedListType(p.KZGCommitment, preset.MAX_BLOB_COMMITMENTS_PER_BLOCK),
     kzg_proofs: ssz.FixedListType(p.KZGProof, preset.MAX_BLOB_COMMITMENTS_PER_BLOCK),
     signed_block_header: SignedBeaconBlockHeader,
-    kzg_commitments_inclusion_proof: ssz.FixedVectorType(p.Bytes32, preset.KZG_COMMITMENTS_INCLUSION_PROOF_DEPTH),
+    kzg_commitments_inclusion_proof: ssz.FixedVectorType(
+        p.Bytes32,
+        preset.KZG_COMMITMENTS_INCLUSION_PROOF_DEPTH,
+    ),
 });
 
 pub const MatrixEntry = ssz.FixedContainerType(struct {
@@ -108,12 +111,12 @@ pub const DataColumnsByRootIdentifier = ssz.VariableContainerType(struct {
     columns: ssz.FixedListType(ColumnIndex, @import("preset").NUMBER_OF_COLUMNS),
 });
 
-// Cell Dissemination types (consensus-specs #4558)
+// Defines types for cell dissemination (consensus-specs #4558).
 pub const PartialDataColumnSidecar = ssz.VariableContainerType(struct {
     cells_present_bitmap: ssz.BitListType(preset.MAX_BLOB_COMMITMENTS_PER_BLOCK),
     partial_column: ssz.FixedListType(Cell, preset.MAX_BLOB_COMMITMENTS_PER_BLOCK),
     kzg_proofs: ssz.FixedListType(p.KZGProof, preset.MAX_BLOB_COMMITMENTS_PER_BLOCK),
-    // Optional header, only sent on eager pushes
+    // The header is optional and is only sent on eager pushes.
     header: ssz.VariableListType(PartialDataColumnHeader, 1),
 });
 
@@ -125,7 +128,10 @@ pub const PartialDataColumnPartsMetadata = ssz.VariableContainerType(struct {
 pub const PartialDataColumnHeader = ssz.VariableContainerType(struct {
     kzg_commitments: ssz.FixedListType(p.KZGCommitment, preset.MAX_BLOB_COMMITMENTS_PER_BLOCK),
     signed_block_header: SignedBeaconBlockHeader,
-    kzg_commitments_inclusion_proof: ssz.FixedVectorType(p.Bytes32, preset.KZG_COMMITMENTS_INCLUSION_PROOF_DEPTH),
+    kzg_commitments_inclusion_proof: ssz.FixedVectorType(
+        p.Bytes32,
+        preset.KZG_COMMITMENTS_INCLUSION_PROOF_DEPTH,
+    ),
 });
 
 // Light client types


### PR DESCRIPTION
Add `PartialDataColumnSidecar`, `PartialDataColumnPartsMetadata`, and `PartialDataColumnHeader` types from [consensus-specs #4558](https://github.com/ethereum/consensus-specs/pull/4558) (merged 2026-03-25).

These types support cell-level dissemination via Gossipsub partial messages, allowing individual cells to be sent instead of full data columns for more efficient data availability sampling.

### New types

| Type | Description |
|------|-------------|
| `PartialDataColumnSidecar` | Column sidecar with bitmap indicating which cells are present + optional header for eager pushes |
| `PartialDataColumnPartsMetadata` | Bitmap pair (available/requests) for peer cell negotiation |
| `PartialDataColumnHeader` | Header with KZG commitments, signed block header, and inclusion proof |

### Spec reference
- [Fulu p2p-interface.md](https://github.com/ethereum/consensus-specs/blob/main/specs/fulu/p2p-interface.md)
