### PR TITLE
perf(ssz): bulk memcpy for uint list/vector on little-endian

### DIFF
--- a/src/ssz/type/list.zig
+++ b/src/ssz/type/list.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const TypeKind = @import("type_kind.zig").TypeKind;
 const isBasicType = @import("type_kind.zig").isBasicType;
 const isFixedType = @import("type_kind.zig").isFixedType;
+const canMemcpySsz = @import("type_kind.zig").canMemcpySsz;
 const OffsetIterator = @import("offsets.zig").OffsetIterator;
 const merkleize = @import("hashing").merkleize;
 const mixInLength = @import("hashing").mixInLength;
@@ -109,6 +110,11 @@ pub fn FixedListType(comptime ST: type, comptime _limit: comptime_int) type {
         }
 
         pub fn serializeIntoBytes(value: *const Type, out: []u8) usize {
+            if (comptime canMemcpySsz(Element)) {
+                const bytes = std.mem.sliceAsBytes(value.items);
+                @memcpy(out[0..bytes.len], bytes);
+                return bytes.len;
+            }
             var i: usize = 0;
             for (value.items) |element| {
                 i += Element.serializeIntoBytes(&element, out[i..]);
@@ -123,6 +129,10 @@ pub fn FixedListType(comptime ST: type, comptime _limit: comptime_int) type {
             }
 
             try out.resize(allocator, len);
+            if (comptime canMemcpySsz(Element)) {
+                @memcpy(std.mem.sliceAsBytes(out.items[0..len]), data);
+                return;
+            }
             @memset(out.items[0..len], Element.default_value);
             for (0..len) |i| {
                 try Element.deserializeFromBytes(

--- a/src/ssz/type/type_kind.zig
+++ b/src/ssz/type/type_kind.zig
@@ -11,6 +11,18 @@ pub fn isBasicType(T: type) bool {
     return T.kind == .uint or T.kind == .bool;
 }
 
+const builtin = @import("builtin");
+const native_endian = builtin.target.cpu.arch.endian();
+
+/// Whether a bulk memcpy can replace per-element serialize/deserialize.
+///
+/// SSZ encodes integers in little-endian. On little-endian platforms,
+/// the in-memory layout of uint types already matches SSZ encoding,
+/// so a single memcpy replaces N individual writeInt/readInt calls.
+pub fn canMemcpySsz(comptime T: type) bool {
+    return T.kind == .uint and native_endian == .little;
+}
+
 // Fixed-size types have a known size
 pub fn isFixedType(T: type) bool {
     return switch (T.kind) {

--- a/src/ssz/type/vector.zig
+++ b/src/ssz/type/vector.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const TypeKind = @import("type_kind.zig").TypeKind;
 const isBasicType = @import("type_kind.zig").isBasicType;
 const isFixedType = @import("type_kind.zig").isFixedType;
+const canMemcpySsz = @import("type_kind.zig").canMemcpySsz;
 const OffsetIterator = @import("offsets.zig").OffsetIterator;
 const merkleize = @import("hashing").merkleize;
 const maxChunksToDepth = @import("hashing").maxChunksToDepth;
@@ -76,6 +77,11 @@ pub fn FixedVectorType(comptime ST: type, comptime _length: comptime_int) type {
         }
 
         pub fn serializeIntoBytes(value: *const Type, out: []u8) usize {
+            if (comptime canMemcpySsz(Element)) {
+                const bytes = std.mem.sliceAsBytes(value);
+                @memcpy(out[0..fixed_size], bytes);
+                return fixed_size;
+            }
             var i: usize = 0;
             for (value) |element| {
                 i += Element.serializeIntoBytes(&element, out[i..]);
@@ -88,6 +94,10 @@ pub fn FixedVectorType(comptime ST: type, comptime _length: comptime_int) type {
                 return error.InvalidSize;
             }
 
+            if (comptime canMemcpySsz(Element)) {
+                @memcpy(std.mem.sliceAsBytes(out), data[0..fixed_size]);
+                return;
+            }
             for (0..length) |i| {
                 try Element.deserializeFromBytes(
                     data[i * Element.fixed_size .. (i + 1) * Element.fixed_size],


### PR DESCRIPTION
## Summary

- Add `canMemcpySsz()` comptime helper in `type_kind.zig` to check if a type is uint AND the platform is little-endian
- Optimize `FixedListType` and `FixedVectorType` serialize/deserialize: replace per-element `writeInt`/`readInt` loops with a single `@memcpy` via `std.mem.sliceAsBytes` when `canMemcpySsz` is true
- On little-endian platforms (x86, ARM), uint memory layout already matches SSZ encoding, making per-element conversion redundant

Inspired by [libssz](https://blog.lambdaclass.com/libssz-a-blazing-fast-zkvm-friendly-ssz-rust-library/).