### PR TITLE
fix(build): remove windows as one of the targets in zapi

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,8 +38,7 @@
       "aarch64-unknown-linux-gnu",
       "x86_64-apple-darwin",
       "x86_64-unknown-linux-gnu",
-      "x86_64-unknown-linux-musl",
-      "x86_64-pc-windows-msvc"
+      "x86_64-unknown-linux-musl"
     ]
   },
   "dependencies": {


### PR DESCRIPTION
lodestar-z does not support windows binaries (and have no intention in the near future)