### PR TITLE
chore(bls): expose bls sizes

### DIFF
--- a/bindings/napi/blst.zig
+++ b/bindings/napi/blst.zig
@@ -990,6 +990,8 @@ pub fn register(env: napi.Env, exports: napi.Value) !void {
         method(2, PublicKey_fromBytes),
         method(2, PublicKey_fromHex),
     });
+    try pk_ctor.setNamedProperty("COMPRESS_SIZE", try env.createUint32(@intCast(PublicKey.COMPRESS_SIZE)));
+    try pk_ctor.setNamedProperty("SERIALIZE_SIZE", try env.createUint32(@intCast(PublicKey.SERIALIZE_SIZE)));
 
     const sig_ctor = try env.defineClass(
         "Signature",
@@ -1007,6 +1009,8 @@ pub fn register(env: napi.Env, exports: napi.Value) !void {
         method(3, Signature_fromHex),
         method(2, Signature_aggregate),
     });
+    try sig_ctor.setNamedProperty("COMPRESS_SIZE", try env.createUint32(@intCast(Signature.COMPRESS_SIZE)));
+    try sig_ctor.setNamedProperty("SERIALIZE_SIZE", try env.createUint32(@intCast(Signature.SERIALIZE_SIZE)));
 
     const state = try InstanceData.init(env);
     try setRef(env, pk_ctor, &state.public_key_ctor_ref);

--- a/bindings/src/blst.d.ts
+++ b/bindings/src/blst.d.ts
@@ -1,4 +1,8 @@
 export class PublicKey {
+  /** Size of a compressed public key in bytes (48). */
+  static readonly COMPRESS_SIZE: number;
+  /** Size of an uncompressed public key in bytes (96). */
+  static readonly SERIALIZE_SIZE: number;
   /**
    * Deserialize a public key from a byte array.
    *
@@ -40,6 +44,10 @@ export class SecretKey {
 }
 
 export class Signature {
+  /** Size of a compressed signature in bytes (96). */
+  static readonly COMPRESS_SIZE: number;
+  /** Size of an uncompressed signature in bytes (192). */
+  static readonly SERIALIZE_SIZE: number;
   /**
    * Deserialize a signature from a byte array.
    *


### PR DESCRIPTION
exposes bls pk/sig sizes for use in lodestar

see: https://github.com/chainsafe/lodestar/pull/8900#discussion_r3113294940