### PR TITLE
fix(ssz): ignore BitVector padding bits

### DIFF
--- a/src/ssz/type/bit_vector.zig
+++ b/src/ssz/type/bit_vector.zig
@@ -40,6 +40,15 @@ pub fn BitVector(comptime _length: comptime_int) type {
             }
         }
 
+        fn maskedByte(self: *const @This(), i_byte: usize) u8 {
+            const remainder_bits = length % 8;
+            if (remainder_bits == 0 or i_byte + 1 < byte_len) {
+                return self.data[i_byte];
+            }
+            const tail_mask: u8 = (@as(u8, 1) << @intCast(remainder_bits)) - 1;
+            return self.data[i_byte] & tail_mask;
+        }
+
         pub fn getTrueBitIndexes(self: *const @This(), out: []usize) !usize {
             if (out.len < length) {
                 return error.InvalidSize;
@@ -47,7 +56,7 @@ pub fn BitVector(comptime _length: comptime_int) type {
             var true_bit_count: usize = 0;
 
             for (0..byte_len) |i_byte| {
-                var b = self.data[i_byte];
+                var b = self.maskedByte(i_byte);
 
                 while (b != 0) {
                     const lsb: usize = @as(u8, @ctz(b));
@@ -65,7 +74,7 @@ pub fn BitVector(comptime _length: comptime_int) type {
             var found_index: ?usize = null;
 
             for (0..byte_len) |i_byte| {
-                var b = self.data[i_byte];
+                var b = self.maskedByte(i_byte);
 
                 while (b != 0) {
                     if (found_index != null) {
@@ -132,10 +141,10 @@ pub fn BitVector(comptime _length: comptime_int) type {
             allocator: std.mem.Allocator,
             values: *const [length]T,
         ) !std.array_list.AlignedManaged(T, null) {
-            var indices = try std.array_list.AlignedManaged(T, null).initCapacity(allocator, byte_len * 8);
+            var indices = try std.array_list.AlignedManaged(T, null).initCapacity(allocator, length);
 
             for (0..byte_len) |i_byte| {
-                var b = self.data[i_byte];
+                var b = self.maskedByte(i_byte);
                 // Kernighan's algorithm to count the set bits instead of going through 0..8 for every byte
                 while (b != 0) {
                     const lsb: usize = @as(u8, @ctz(b)); // Get the index of least significant bit
@@ -557,6 +566,26 @@ test "BitVectorType - tree.deserializeFromBytes 128 bits" {
         try Bits.hashTreeRoot(&value_from_tree, &hash_root);
         try std.testing.expectEqualSlices(u8, &tc.expected_root, &hash_root);
     }
+}
+
+test "BitVectorType helpers ignore padding bits" {
+    const allocator = std.testing.allocator;
+    const Bits = BitVectorType(4);
+
+    var value = Bits.Type.empty;
+    value.data[0] = 0b1111_0001;
+
+    var indexes: [Bits.length]usize = undefined;
+    const count = try value.getTrueBitIndexes(indexes[0..]);
+    try std.testing.expectEqual(@as(usize, 1), count);
+    try std.testing.expectEqualSlices(usize, &.{0}, indexes[0..count]);
+
+    try std.testing.expectEqual(@as(?usize, 0), value.getSingleTrueBit());
+
+    const input_values = [_]u8{ 10, 11, 12, 13 };
+    var intersected = try value.intersectValues(u8, allocator, &input_values);
+    defer intersected.deinit();
+    try std.testing.expectEqualSlices(u8, &.{10}, intersected.items);
 }
 
 const TypeTestCase = @import("test_utils.zig").TypeTestCase;

--- a/src/ssz/type/bit_vector.zig
+++ b/src/ssz/type/bit_vector.zig
@@ -40,13 +40,11 @@ pub fn BitVector(comptime _length: comptime_int) type {
             }
         }
 
-        fn maskedByte(self: *const @This(), i_byte: usize) u8 {
+        fn maskedFinalByte(self: *const @This()) u8 {
             const remainder_bits = length % 8;
-            if (remainder_bits == 0 or i_byte + 1 < byte_len) {
-                return self.data[i_byte];
-            }
+            std.debug.assert(remainder_bits != 0);
             const tail_mask: u8 = (@as(u8, 1) << @intCast(remainder_bits)) - 1;
-            return self.data[i_byte] & tail_mask;
+            return self.data[byte_len - 1] & tail_mask;
         }
 
         pub fn getTrueBitIndexes(self: *const @This(), out: []usize) !usize {
@@ -56,7 +54,12 @@ pub fn BitVector(comptime _length: comptime_int) type {
             var true_bit_count: usize = 0;
 
             for (0..byte_len) |i_byte| {
-                var b = self.maskedByte(i_byte);
+                var b = self.data[i_byte];
+                if (length % 8 != 0) {
+                    if (i_byte + 1 == byte_len) {
+                        b = self.maskedFinalByte();
+                    }
+                }
 
                 while (b != 0) {
                     const lsb: usize = @as(u8, @ctz(b));
@@ -74,7 +77,12 @@ pub fn BitVector(comptime _length: comptime_int) type {
             var found_index: ?usize = null;
 
             for (0..byte_len) |i_byte| {
-                var b = self.maskedByte(i_byte);
+                var b = self.data[i_byte];
+                if (length % 8 != 0) {
+                    if (i_byte + 1 == byte_len) {
+                        b = self.maskedFinalByte();
+                    }
+                }
 
                 while (b != 0) {
                     if (found_index != null) {
@@ -144,7 +152,12 @@ pub fn BitVector(comptime _length: comptime_int) type {
             var indices = try std.array_list.AlignedManaged(T, null).initCapacity(allocator, length);
 
             for (0..byte_len) |i_byte| {
-                var b = self.maskedByte(i_byte);
+                var b = self.data[i_byte];
+                if (length % 8 != 0) {
+                    if (i_byte + 1 == byte_len) {
+                        b = self.maskedFinalByte();
+                    }
+                }
                 // Kernighan's algorithm to count the set bits instead of going through 0..8 for every byte
                 while (b != 0) {
                     const lsb: usize = @as(u8, @ctz(b)); // Get the index of least significant bit


### PR DESCRIPTION
## Summary
- Mask padding bits only in the final byte of non-byte-aligned BitVectors in `getTrueBitIndexes`, `getSingleTrueBit`, and `intersectValues`.
- Prevent `getTrueBitIndexes` from writing beyond a correctly sized logical-length output buffer when an in-memory value contains dirty padding. For `BitVector[4]`, unmasked storage can emit eight indexes into a four-element buffer; checked builds panic, while unchecked builds risk an out-of-bounds write.
- Cover dirty padding with a four-bit regression and a logical-length output buffer.

## Scope and production context
This is defensive handling of dirty **in-memory** padding, not a demonstrated wire-triggered vulnerability. BitVector deserialization already rejects non-zero trailing bits. Mainnet-preset `committee_bits` is `BitVector[64]`, so it has no padding; the minimal preset uses four bits.

The earlier claim that this fixes the nogroup Electra/Fulu attestation crash was not established and is withdrawn. Deployment of this change does not establish the incident's root cause or resolution; that requires separate evidence.

This PR targets `feat/beacon-node`, where `BitList.getSingleTrueBit` already masks its tail and has a regression from f87edc14275fb747e5966ccbac6d4a35954c56bc. Current `main` still has the unmasked BitList implementation; that is a separate backport scope, not a missing change on this PR's base.
