### PR TITLE
fix(stf): commit before bulk read

### DIFF
--- a/src/fork_types/any_beacon_state.zig
+++ b/src/fork_types/any_beacon_state.zig
@@ -376,6 +376,7 @@ pub const AnyBeaconState = union(ForkSeq) {
         return switch (self.*) {
             inline else => |state| {
                 var validators_view = try state.getReadonly("validators");
+                try validators_view.commit();
                 return validators_view.getAllReadonlyValues(allocator);
             },
         };

--- a/src/fork_types/beacon_state.zig
+++ b/src/fork_types/beacon_state.zig
@@ -140,6 +140,7 @@ pub fn BeaconState(comptime f: ForkSeq) type {
 
         pub fn validatorsSlice(self: *Self, allocator: std.mem.Allocator) ![]ForkTypes(f).Validator.Type {
             var validators_view = try self.inner.getReadonly("validators");
+            try validators_view.commit();
             return validators_view.getAllReadonlyValues(allocator);
         }
 

--- a/src/state_transition/utils/balance.zig
+++ b/src/state_transition/utils/balance.zig
@@ -27,7 +27,6 @@ pub fn getEffectiveBalanceIncrementsZeroInactive(allocator: Allocator, cached_st
     const active_indices = cached_state.epoch_cache.getCurrentShuffling().active_indices;
     // 5x faster than reading from state.validators, with validator Nodes as values
 
-    try cached_state.state.commit();
     const validators = try cached_state.state.validatorsSlice(allocator);
     defer allocator.free(validators);
     const validator_count = validators.len;

--- a/src/state_transition/utils/balance.zig
+++ b/src/state_transition/utils/balance.zig
@@ -26,6 +26,8 @@ pub fn decreaseBalance(comptime fork: ForkSeq, state: *BeaconState(fork), index:
 pub fn getEffectiveBalanceIncrementsZeroInactive(allocator: Allocator, cached_state: *CachedBeaconState) !EffectiveBalanceIncrements {
     const active_indices = cached_state.epoch_cache.getCurrentShuffling().active_indices;
     // 5x faster than reading from state.validators, with validator Nodes as values
+
+    try cached_state.state.commit();
     const validators = try cached_state.state.validatorsSlice(allocator);
     defer allocator.free(validators);
     const validator_count = validators.len;


### PR DESCRIPTION
`validatorsSlice()` returns the error `MustCommitBeforeRead` if we do not commit prior to read.