### PR TITLE
refactor: make XXXDecisionRoot fns return `js.String`

### DIFF
--- a/bindings/napi/BeaconStateView.zig
+++ b/bindings/napi/BeaconStateView.zig
@@ -371,37 +371,39 @@ pub fn proposerLookahead(self: *const BeaconStateView) !js.Uint32Array {
 
 // pub fn BeaconStateView_getShufflingAtEpoch
 
-pub fn previousDecisionRoot(self: *const BeaconStateView) !js.Uint8Array {
+fn rootToHexString(root: *const [32]u8) !js.String {
     const env = js.env();
-    const cached_state = try self.requireState();
-    const root = cached_state.previousDecisionRoot();
-    return js_types.wrap(js.Uint8Array, try sszValueToNapiValue(env, ct.primitive.Root, &root));
+    var hex_buf: [66]u8 = undefined;
+    try @import("hex").rootIntoHex(&hex_buf, root);
+    return js_types.wrap(js.String, try env.createStringUtf8(&hex_buf));
 }
 
-pub fn currentDecisionRoot(self: *const BeaconStateView) !js.Uint8Array {
-    const env = js.env();
+pub fn previousDecisionRoot(self: *const BeaconStateView) !js.String {
+    const cached_state = try self.requireState();
+    const root = cached_state.previousDecisionRoot();
+    return rootToHexString(&root);
+}
+
+pub fn currentDecisionRoot(self: *const BeaconStateView) !js.String {
     const cached_state = try self.requireState();
     const root = cached_state.currentDecisionRoot();
-    return js_types.wrap(js.Uint8Array, try sszValueToNapiValue(env, ct.primitive.Root, &root));
+    return rootToHexString(&root);
 }
 
 /// Get the next decision root for the state.
-pub fn nextDecisionRoot(self: *const BeaconStateView) !js.Uint8Array {
-    const env = js.env();
+pub fn nextDecisionRoot(self: *const BeaconStateView) !js.String {
     const cached_state = try self.requireState();
     const root = cached_state.nextDecisionRoot();
-    return js_types.wrap(js.Uint8Array, try sszValueToNapiValue(env, ct.primitive.Root, &root));
+    return rootToHexString(&root);
 }
 
 /// Get the shuffling decision root for a given epoch.
-pub fn getShufflingDecisionRoot(self: *const BeaconStateView, epoch_arg: js.Number) !js.Uint8Array {
-    const env = js.env();
+pub fn getShufflingDecisionRoot(self: *const BeaconStateView, epoch_arg: js.Number) !js.String {
     const cached_state = try self.requireState();
-    const epoch_value: u64 = @intCast(try epoch_arg.toI64());
-    const root = st.calculateShufflingDecisionRoot(cached_state.state, epoch_value) catch {
-        return throwNullAs(js.Uint8Array, "STATE_ERROR", "Failed to calculate shuffling decision root");
+    const root = st.calculateShufflingDecisionRoot(cached_state.state, try epoch_arg.toU32()) catch {
+        return throwNullAs(js.String, "STATE_ERROR", "Failed to calculate shuffling decision root");
     };
-    return js_types.wrap(js.Uint8Array, try sszValueToNapiValue(env, ct.primitive.Root, &root));
+    return rootToHexString(&root);
 }
 
 pub fn previousProposers(self: *const BeaconStateView) !?js.Array {

--- a/bindings/test/beaconStateView.test.ts
+++ b/bindings/test/beaconStateView.test.ts
@@ -397,15 +397,15 @@ describe("BeaconStateView", () => {
       expect(proposer).toBeLessThan(state.validatorCount);
     });
 
-    it("decision roots should be 32 bytes each", () => {
-      expect(state.previousDecisionRoot.length).toBe(32);
-      expect(state.currentDecisionRoot.length).toBe(32);
-      expect(state.nextDecisionRoot.length).toBe(32);
+    it("decision roots should be 66 bytes each", () => {
+      expect(state.previousDecisionRoot.length).toBe(66);
+      expect(state.currentDecisionRoot.length).toBe(66);
+      expect(state.nextDecisionRoot.length).toBe(66);
     });
 
-    it("getShufflingDecisionRoot should return 32 bytes", () => {
+    it("getShufflingDecisionRoot should return 66 bytes", () => {
       const decisionRoot = state.getShufflingDecisionRoot(state.epoch);
-      expect(decisionRoot.length).toBe(32);
+      expect(decisionRoot.length).toBe(66);
     });
   });
 

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -298,6 +298,7 @@
                 .imports = .{
                     .bls,
                     .bls_options,
+                    .hex,
                     .persistent_merkle_tree,
                     .ssz,
                     .consensus_types,


### PR DESCRIPTION
extracted from https://github.com/ChainSafe/lodestar-z/pull/347

`IBeaconStateView` expects `RootHex` (66-char string) for these outputs. it also happens that it's cheaper to just create a string upfront than go through a typed array

see: https://github.com/ChainSafe/lodestar/blob/35940ffd61ad7e29f5de376e13587d044b27b246/packages/state-transition/src/stateView/interface.ts#L78-L82