### PR TITLE
chore: add repository.url to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,10 @@
   "keywords": [],
   "author": "ChainSafe Systems",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ChainSafe/lodestar-z.git"
+  },
   "packageManager": "pnpm@10.24.0",
   "zapi": {
     "binaryName": "bindings",


### PR DESCRIPTION
Publishing on npm via ci requires repository info