### PR TITLE
feat: bindings to `getExpectedWithdrawals` and native tweaks

### DIFF
--- a/bench/state_transition/process_block.zig
+++ b/bench/state_transition/process_block.zig
@@ -79,7 +79,6 @@ fn ProcessWithdrawalsBench(comptime fork: ForkSeq) type {
             const state = cloned.state.castToFork(fork);
             state_transition.getExpectedWithdrawals(
                 fork,
-                allocator,
                 cloned.epoch_cache,
                 state,
                 &withdrawals_result,
@@ -347,7 +346,6 @@ fn ProcessBlockSegmentedBench(comptime fork: ForkSeq) type {
                 defer withdrawal_balances.deinit();
                 state_transition.getExpectedWithdrawals(
                     fork,
-                    allocator,
                     epoch_cache,
                     state,
                     &withdrawals_result,

--- a/bench/state_transition/process_block.zig
+++ b/bench/state_transition/process_block.zig
@@ -68,10 +68,10 @@ fn ProcessWithdrawalsBench(comptime fork: ForkSeq) type {
                 allocator.destroy(cloned);
             }
 
+            var withdrawals_buf: [preset.MAX_WITHDRAWALS_PER_PAYLOAD]types.capella.Withdrawal.Type = undefined;
             var withdrawals_result = WithdrawalsResult{
-                .withdrawals = Withdrawals.initCapacity(allocator, preset.MAX_WITHDRAWALS_PER_PAYLOAD) catch unreachable,
+                .withdrawals = Withdrawals.initBuffer(&withdrawals_buf),
             };
-            defer withdrawals_result.withdrawals.deinit(allocator);
 
             var withdrawal_balances = std.AutoHashMap(ValidatorIndex, usize).init(allocator);
             defer withdrawal_balances.deinit();
@@ -338,10 +338,11 @@ fn ProcessBlockSegmentedBench(comptime fork: ForkSeq) type {
 
             if (comptime fork.gte(.capella)) {
                 const withdrawals_start = time.timestampNow(io);
+
+                var withdrawals_buf: [preset.MAX_WITHDRAWALS_PER_PAYLOAD]types.capella.Withdrawal.Type = undefined;
                 var withdrawals_result = WithdrawalsResult{
-                    .withdrawals = Withdrawals.initCapacity(allocator, preset.MAX_WITHDRAWALS_PER_PAYLOAD) catch unreachable,
+                    .withdrawals = Withdrawals.initBuffer(&withdrawals_buf),
                 };
-                defer withdrawals_result.withdrawals.deinit(allocator);
                 var withdrawal_balances = std.AutoHashMap(ValidatorIndex, usize).init(allocator);
                 defer withdrawal_balances.deinit();
                 state_transition.getExpectedWithdrawals(

--- a/bindings/napi/BeaconStateView.zig
+++ b/bindings/napi/BeaconStateView.zig
@@ -937,6 +937,58 @@ pub fn processSlots(self: *const BeaconStateView, slot_arg: js.Number, options: 
     return .{ .cached_state = post_state };
 }
 
+/// Compute expected withdrawals for the next payload (capella+).
+/// Returns: { expectedWithdrawals: Withdrawal[], processedPartialWithdrawalsCount, processedValidatorSweepCount,
+///           processedBuilderWithdrawalsCount, processedBuildersSweepCount }
+/// The latter two are Gloas-only — always 0 here since Zig STF doesn't process Gloas yet.
+pub fn getExpectedWithdrawals(self: *const BeaconStateView) !js.Value {
+    const env = js.env();
+    const cached_state = try self.requireState();
+    const fork_seq = cached_state.state.forkSeq();
+
+    // We also check this within the native fn itself but this lets us avoid allocating an `AutoHashMap` early.
+    if (fork_seq.lt(.capella)) {
+        return throwNullAs(js.Value, "INVALID_FORK", "getExpectedWithdrawals only supported capella+");
+    }
+
+    var withdrawals_buf: [preset.MAX_WITHDRAWALS_PER_PAYLOAD]ct.capella.Withdrawal.Type = undefined;
+    var withdrawals_result = st.WithdrawalsResult{
+        .withdrawals = ct.capella.Withdrawals.Type.initBuffer(&withdrawals_buf),
+    };
+
+    var withdrawal_balances = std.AutoHashMap(ct.primitive.ValidatorIndex.Type, usize).init(allocator);
+    defer withdrawal_balances.deinit();
+
+    switch (fork_seq) {
+        inline .capella, .deneb, .electra, .fulu => |f| {
+            try st.getExpectedWithdrawals(
+                f,
+                cached_state.epoch_cache,
+                cached_state.state.castToFork(f),
+                &withdrawals_result,
+                &withdrawal_balances,
+            );
+        },
+        else => unreachable,
+    }
+
+    const obj = try env.createObject();
+
+    const withdrawals_arr = try env.createArray();
+    for (withdrawals_result.withdrawals.items, 0..) |*w, i| {
+        const w_value = try sszValueToNapiValue(env, ct.capella.Withdrawal, w);
+        try withdrawals_arr.setElement(@intCast(i), w_value);
+    }
+    try obj.setNamedProperty("expectedWithdrawals", withdrawals_arr);
+    try obj.setNamedProperty("processedPartialWithdrawalsCount", try env.createUint32(@intCast(withdrawals_result.processed_partial_withdrawals_count)));
+    try obj.setNamedProperty("processedValidatorSweepCount", try env.createUint32(@intCast(withdrawals_result.sampled_validators)));
+    // TODO(bing): Implement when we support Gloas.
+    try obj.setNamedProperty("processedBuilderWithdrawalsCount", try env.createUint32(0));
+    try obj.setNamedProperty("processedBuildersSweepCount", try env.createUint32(0));
+
+    return js_types.wrap(js.Value, obj);
+}
+
 fn requireState(self: *const BeaconStateView) !*CachedBeaconState {
     return self.cached_state orelse error.InvalidState;
 }

--- a/bindings/src/index.d.ts
+++ b/bindings/src/index.d.ts
@@ -199,8 +199,25 @@ declare class BeaconStateView {
   isValidVoluntaryExit(signedVoluntaryExitBytes: Uint8Array, verifySignature: boolean): boolean;
 
   getFinalizedRootProof(): Uint8Array[];
-  // getSyncCommitteesWitness(): SyncCommitteeWitness;
-  getSingleProof(gindex: number): Uint8Array[];
+  // getSyncCommitteesWitness(): any;
+  /**
+   * Compute expected withdrawals for the next payload (capella+).
+   *
+   * processedBuilderWithdrawalsCount is withdrawals coming from builder payment since gloas (EIP-7732)
+   * processedPartialWithdrawalsCount is withdrawals coming from EL since electra (EIP-7002)
+   * processedBuildersSweepCount is withdrawals from builder sweep since gloas (EIP-7732)
+   * processedValidatorSweepCount is withdrawals coming from validator sweep
+
+   * TODO(bing): `processedBuilderWithdrawalsCount` and `processedBuildersSweepCount` are Gloas-only
+   * and always 0 here since Zig STF doesn't process Gloas yet.
+   */
+  getExpectedWithdrawals(): {
+    expectedWithdrawals: {index: number; validatorIndex: number; address: Uint8Array; amount: number}[];
+    processedBuilderWithdrawalsCount: number;
+    processedPartialWithdrawalsCount: number;
+    processedBuildersSweepCount: number;
+    processedValidatorSweepCount: number;
+  };
   // createMultiProof(descriptor: Uint8Array): CompactMultiProof;
 
   computeUnrealizedCheckpoints(): {

--- a/src/state_transition/block/process_block.zig
+++ b/src/state_transition/block/process_block.zig
@@ -61,17 +61,13 @@ pub fn processBlock(
             // TODO Deneb: Allow to disable withdrawals for interop testing
             // https://github.com/ethereum/consensus-specs/blob/b62c9e877990242d63aa17a2a59a49bc649a2f2e/specs/eip4844/beacon-chain.md#disabling-withdrawals
             if (comptime fork.gte(.capella)) {
-                // TODO: given max withdrawals of MAX_WITHDRAWALS_PER_PAYLOAD, can use fixed size array instead of heap alloc
-                var withdrawals_result = WithdrawalsResult{ .withdrawals = try Withdrawals.initCapacity(
-                    allocator,
-                    preset.MAX_WITHDRAWALS_PER_PAYLOAD,
-                ) };
+                var withdrawals_buf: [preset.MAX_WITHDRAWALS_PER_PAYLOAD]types.capella.Withdrawal.Type = undefined;
+                var withdrawals_result = WithdrawalsResult{ .withdrawals = Withdrawals.initBuffer(&withdrawals_buf) };
                 var withdrawal_balances = std.AutoHashMap(ValidatorIndex, usize).init(allocator);
                 defer withdrawal_balances.deinit();
 
                 try getExpectedWithdrawals(
                     fork,
-                    allocator,
                     epoch_cache,
                     state,
                     &withdrawals_result,

--- a/src/state_transition/block/process_block.zig
+++ b/src/state_transition/block/process_block.zig
@@ -73,7 +73,6 @@ pub fn processBlock(
                     &withdrawals_result,
                     &withdrawal_balances,
                 );
-                defer withdrawals_result.withdrawals.deinit(allocator);
 
                 const payload_withdrawals_root = switch (block_type) {
                     .full => blk: {

--- a/src/state_transition/block/process_withdrawals.zig
+++ b/src/state_transition/block/process_withdrawals.zig
@@ -229,13 +229,10 @@ test "process withdrawals - sanity" {
     var test_state = try TestCachedBeaconState.init(allocator, &pool, 256);
     defer test_state.deinit();
 
+    var withdrawals_buf: [preset.MAX_WITHDRAWALS_PER_PAYLOAD]types.capella.Withdrawal.Type = undefined;
     var withdrawals_result = WithdrawalsResult{
-        .withdrawals = try Withdrawals.initCapacity(
-            allocator,
-            preset.MAX_WITHDRAWALS_PER_PAYLOAD,
-        ),
+        .withdrawals = Withdrawals.initBuffer(&withdrawals_buf),
     };
-    defer withdrawals_result.withdrawals.deinit(allocator);
     var withdrawal_balances = std.AutoHashMap(ValidatorIndex, usize).init(allocator);
     defer withdrawal_balances.deinit();
 

--- a/src/state_transition/block/process_withdrawals.zig
+++ b/src/state_transition/block/process_withdrawals.zig
@@ -82,18 +82,20 @@ pub fn processWithdrawals(
     }
 }
 
-// Consumer should deinit WithdrawalsResult with .deinit() after use
+/// Called by the block proposer to find a list of withdrawals to include in the block.
+///
+/// This list is assumed to be bounded by `preset.MAX_WITHDRAWALS_PER_PAYLOAD`.
+///
+/// Caller should deinit `withdrawal_balances` with .deinit() after use.
 pub fn getExpectedWithdrawals(
     comptime fork: ForkSeq,
-    allocator: Allocator,
     epoch_cache: *const EpochCache,
     state: *BeaconState(fork),
     withdrawals_result: *WithdrawalsResult,
     withdrawal_balances: *std.AutoHashMap(ValidatorIndex, usize),
 ) !void {
-    if (comptime fork.lt(.capella)) {
-        return error.InvalidForkSequence;
-    }
+    std.debug.assert(withdrawals_result.withdrawals.capacity == preset.MAX_WITHDRAWALS_PER_PAYLOAD);
+    if (comptime fork.lt(.capella)) return error.InvalidForkSequence;
 
     const epoch = epoch_cache.epoch;
     var withdrawal_index = try state.nextWithdrawalIndex();
@@ -134,7 +136,7 @@ pub fn getExpectedWithdrawals(
                 const withdrawable_balance = if (balance_over_min_activation_balance < withdrawal.amount) balance_over_min_activation_balance else withdrawal.amount;
                 var execution_address: ExecutionAddress = undefined;
                 @memcpy(&execution_address, validator.withdrawal_credentials[12..]);
-                try withdrawals_result.withdrawals.append(allocator, .{
+                withdrawals_result.withdrawals.appendAssumeCapacity(.{
                     .index = withdrawal_index,
                     .validator_index = withdrawal.validator_index,
                     .address = execution_address,
@@ -179,7 +181,7 @@ pub fn getExpectedWithdrawals(
         if (withdrawable_epoch <= epoch) {
             var execution_address: ExecutionAddress = undefined;
             @memcpy(&execution_address, withdrawal_credentials[12..]);
-            try withdrawals_result.withdrawals.append(allocator, .{
+            withdrawals_result.withdrawals.appendAssumeCapacity(.{
                 .index = withdrawal_index,
                 .validator_index = validator_index,
                 .address = execution_address,
@@ -195,7 +197,7 @@ pub fn getExpectedWithdrawals(
             const partial_amount = balance - effective_balance;
             var execution_address: ExecutionAddress = undefined;
             @memcpy(&execution_address, withdrawal_credentials[12..]);
-            try withdrawals_result.withdrawals.append(allocator, .{
+            withdrawals_result.withdrawals.appendAssumeCapacity(.{
                 .index = withdrawal_index,
                 .validator_index = validator_index,
                 .address = execution_address,
@@ -242,7 +244,6 @@ test "process withdrawals - sanity" {
 
     try getExpectedWithdrawals(
         .electra,
-        allocator,
         test_state.cached_state.epoch_cache,
         test_state.cached_state.state.castToFork(.electra),
         &withdrawals_result,

--- a/test/spec/runner/operations.zig
+++ b/test/spec/runner/operations.zig
@@ -279,7 +279,6 @@ pub fn TestCase(comptime fork: ForkSeq, comptime operation: Operation) type {
 
                     try state_transition.getExpectedWithdrawals(
                         fork,
-                        allocator,
                         epoch_cache,
                         state,
                         &withdrawals_result,

--- a/test/spec/runner/operations.zig
+++ b/test/spec/runner/operations.zig
@@ -267,11 +267,10 @@ pub fn TestCase(comptime fork: ForkSeq, comptime operation: Operation) type {
                 },
                 .withdrawals => {
                     const epoch_cache = cached_state.epoch_cache;
+
+                    var withdrawals_buf: [preset.MAX_WITHDRAWALS_PER_PAYLOAD]Withdrawals = undefined;
                     var withdrawals_result = WithdrawalsResult{
-                        .withdrawals = try Withdrawals.initCapacity(
-                            allocator,
-                            preset.MAX_WITHDRAWALS_PER_PAYLOAD,
-                        ),
+                        .withdrawals = Withdrawals.initBuffer(&withdrawals_buf),
                     };
 
                     var withdrawal_balances = std.AutoHashMap(u64, usize).init(allocator);
@@ -284,7 +283,6 @@ pub fn TestCase(comptime fork: ForkSeq, comptime operation: Operation) type {
                         &withdrawals_result,
                         &withdrawal_balances,
                     );
-                    defer withdrawals_result.withdrawals.deinit(allocator);
 
                     var payload_withdrawals_root: Root = undefined;
                     // self.op is ExecutionPayload in this case

--- a/test/spec/runner/operations.zig
+++ b/test/spec/runner/operations.zig
@@ -268,7 +268,7 @@ pub fn TestCase(comptime fork: ForkSeq, comptime operation: Operation) type {
                 .withdrawals => {
                     const epoch_cache = cached_state.epoch_cache;
 
-                    var withdrawals_buf: [preset.MAX_WITHDRAWALS_PER_PAYLOAD]Withdrawals = undefined;
+                    var withdrawals_buf: [preset.MAX_WITHDRAWALS_PER_PAYLOAD]ssz.capella.Withdrawal.Type = undefined;
                     var withdrawals_result = WithdrawalsResult{
                         .withdrawals = Withdrawals.initBuffer(&withdrawals_buf),
                     };


### PR DESCRIPTION
- add bindings to it
- don't heap allocate for `withdrawals_results` since it is capped at `preset.MAX_WITHDRAWALS_PER_PAYLOAD == 16`. This is about max ~800 bytes on mainnet preset
- add assertions to assert the above

extracted from #347 