### PR TITLE
feat: asyncAggregateWithRandomness

### DIFF
--- a/bindings/napi/blst.zig
+++ b/bindings/napi/blst.zig
@@ -798,11 +798,7 @@ pub fn asyncAggregateWithRandomness(env: napi.Env, cb: napi.CallbackInfo(1)) !na
     data.err = null;
     data.deferred = undefined;
     data.work = undefined;
-
-    var seed_bytes: [8]u8 = undefined;
-    napi_io.get().random(&seed_bytes);
-    var prng = std.Random.DefaultPrng.init(std.mem.readInt(u64, &seed_bytes, .little));
-    prng.random().bytes(data.randomness);
+    napi_io.get().random(data.randomness);
 
     for (0..n) |i| {
         const set_value = try sets.getElement(@intCast(i));

--- a/bindings/napi/blst.zig
+++ b/bindings/napi/blst.zig
@@ -305,7 +305,6 @@ pub const SecretKey = struct {
         return formatHex(bytes[0..]);
     }
 };
-
 /// Verifies a given `msg` against a `Signature` and a `PublicKey`.
 ///
 /// Returns `true` if signature is valid, `false` otherwise.

--- a/bindings/napi/blst.zig
+++ b/bindings/napi/blst.zig
@@ -647,3 +647,192 @@ pub fn aggregateWithRandomness(sets: js.Array) !js.Value {
     try result.setNamedProperty("sig", sig_value);
     return .{ .val = result };
 }
+
+/// Heap-allocated context shared between the JS thread (which kicks off the work),
+/// the libuv worker thread (which calls `ThreadPool.aggregateWithRandomness`), and
+/// the JS thread again (which resolves/rejects the Promise).
+///
+/// All input data should be copied into this struct so the worker thread doesn't depend on
+/// any JS-managed memory staying alive.
+const AsyncAggRandData = struct {
+    pks: []PublicKey,
+    sigs: []Signature,
+    pk_ptrs: []*const PublicKey,
+    sig_ptrs: []*const Signature,
+    randomness: []u8,
+    pk_out: PublicKey,
+    sig_out: Signature,
+    err: ?anyerror,
+    deferred: napi.Deferred,
+    work: napi.c.napi_async_work,
+
+    fn destroy(self: *AsyncAggRandData) void {
+        allocator.free(self.pks);
+        allocator.free(self.sigs);
+        allocator.free(self.pk_ptrs);
+        allocator.free(self.sig_ptrs);
+        allocator.free(self.randomness);
+        allocator.destroy(self);
+    }
+};
+
+/// Execute `aggregateWithRandomness` on a libuv worker thread.
+///
+/// Assumes that:
+/// 1) pubkeys are already validated,
+/// 2) signatures are not group-checked on JS thread
+///
+/// Note: MUST NOT call any napi APIs.
+fn asyncAggRand_execute(_: napi.Env, data: *AsyncAggRandData) void {
+    const pool = thread_pool orelse {
+        data.err = error.PoolNotInitialized;
+        return;
+    };
+    pool.aggregateWithRandomness(
+        napi_io.get(),
+        data.pk_ptrs,
+        data.sig_ptrs,
+        data.randomness,
+        false, // pks already validated implicitly by being deserialized PublicKey instances
+        true, // sigs were deserialized but not group-checked on the JS thread
+        &data.pk_out,
+        &data.sig_out,
+    ) catch |err| {
+        data.err = err;
+    };
+}
+
+/// Ran on the JS thread once the worker has finished. Always settles the
+/// promise — `settle` does the resolve/reject; if it errors we fall back to a
+/// bare reject so callers never see a dangling Promise.
+fn asyncAggRand_complete(env: napi.Env, status: napi.status.Status, data: *AsyncAggRandData) void {
+    defer {
+        napi.status.check(napi.c.napi_delete_async_work(env.env, data.work)) catch {};
+        data.destroy();
+    }
+
+    settle(env, status, data) catch {
+        // Catch all rejection: if we reach this point we might want
+        // better errors upstream
+        rejectWithError(env, data.deferred, "asyncAggregateWithRandomness", "InternalError") catch {};
+    };
+}
+
+fn settle(env: napi.Env, status: napi.status.Status, data: *AsyncAggRandData) !void {
+    if (status != .ok) {
+        // libuv's async work itself failed (e.g. cancelled), not crypto.
+        return rejectWithError(env, data.deferred, "asyncAggregateWithRandomness/asyncWork", @tagName(status));
+    }
+    if (data.err) |err| {
+        // Worker captured a Zig error — surface its name as the JS Error.code
+        // (e.g. "PointNotInGroup", "PoolNotInitialized", "OutOfMemory") so JS
+        // callers can branch on it.
+        return rejectWithError(env, data.deferred, "asyncAggregateWithRandomness", @errorName(err));
+    }
+
+    const pk_value: NativePublicKey = .{};
+    const pk_unwrapped = try env.unwrap(PublicKey, pk_value);
+    pk_unwrapped.* = data.pk_out;
+
+    const sig_value: NativeSignature = .{};
+    const sig_unwrapped = try env.unwrap(Signature, sig_value);
+    sig_unwrapped.* = data.sig_out;
+
+    const result = try env.createObject();
+    try result.setNamedProperty("pk", pk_value);
+    try result.setNamedProperty("sig", sig_value);
+
+    try data.deferred.resolve(result);
+}
+
+/// Build a JS `Error` with `.code = code` and `.message = "<where>: <code>"`
+/// and reject `deferred` with it. JS callers see a real `Error` instance, not
+/// a bare string, so they can branch on `err.code` cleanly.
+fn rejectWithError(env: napi.Env, deferred: napi.Deferred, where: []const u8, code: []const u8) !void {
+    var msg_buf: [256]u8 = undefined;
+    const msg = std.fmt.bufPrint(&msg_buf, "{s}: {s}", .{ where, code }) catch code;
+
+    const code_val = try env.createStringUtf8(code);
+    const msg_val = try env.createStringUtf8(msg);
+    const err_val = try env.createError(code_val, msg_val);
+    try deferred.reject(err_val);
+}
+
+/// Asynchronously aggregates public keys and signatures with randomness using
+/// Pippenger multi-scalar multiplication. The PK and Sig multi-scalar mults
+/// run in parallel on the bls `ThreadPool`.
+///
+/// This call is non-blocking.
+///
+/// This is modeled after blst's rust pippenger implementation.
+///
+/// See: https://github.com/supranational/blst/blob/dece82ea537b422890888bacde4034ca5b5a44d8/bindings/rust/src/pippenger.rs
+///
+/// Arguments:
+/// 1) sets: Array of {pk: PublicKey, sig: Uint8Array}
+///
+/// Returns: Promise<{pk: PublicKey, sig: Signature}>
+pub fn asyncAggregateWithRandomness(env: napi.Env, cb: napi.CallbackInfo(1)) !napi.Value {
+    const sets = cb.arg(0);
+    const n = try sets.getArrayLength();
+
+    if (n == 0) return error.EmptyArray;
+    if (n > MAX_AGGREGATE_PER_JOB) return error.TooManySets;
+    if (thread_pool == null) return error.PoolNotInitialized;
+
+    const data = try allocator.create(AsyncAggRandData);
+    errdefer allocator.destroy(data);
+
+    data.pks = try allocator.alloc(PublicKey, n);
+    errdefer allocator.free(data.pks);
+    data.sigs = try allocator.alloc(Signature, n);
+    errdefer allocator.free(data.sigs);
+    data.pk_ptrs = try allocator.alloc(*const PublicKey, n);
+    errdefer allocator.free(data.pk_ptrs);
+    data.sig_ptrs = try allocator.alloc(*const Signature, n);
+    errdefer allocator.free(data.sig_ptrs);
+    data.randomness = try allocator.alloc(u8, n * 32);
+    errdefer allocator.free(data.randomness);
+
+    data.pk_out = .{};
+    data.sig_out = .{};
+    data.err = null;
+    data.deferred = undefined;
+    data.work = undefined;
+
+    var seed_bytes: [8]u8 = undefined;
+    napi_io.get().random(&seed_bytes);
+    var prng = std.Random.DefaultPrng.init(std.mem.readInt(u64, &seed_bytes, .little));
+    prng.random().bytes(data.randomness);
+
+    for (0..n) |i| {
+        const set_value = try sets.getElement(@intCast(i));
+
+        const pk_value = try set_value.getNamedProperty("pk");
+        const unwrapped_pk = try env.unwrap(PublicKey, pk_value);
+        data.pks[i] = unwrapped_pk.*;
+        data.pk_ptrs[i] = &data.pks[i];
+
+        const sig_value = try set_value.getNamedProperty("sig");
+        const sig_bytes = try sig_value.getTypedarrayInfo();
+        data.sigs[i] = Signature.deserialize(sig_bytes.data[0..]) catch return error.DeserializationFailed;
+        data.sig_ptrs[i] = &data.sigs[i];
+    }
+
+    data.deferred = try env.createPromise();
+
+    const resource_name = try env.createStringUtf8("asyncAggregateWithRandomness");
+    const work = try env.createAsyncWork(
+        AsyncAggRandData,
+        null,
+        resource_name,
+        asyncAggRand_execute,
+        asyncAggRand_complete,
+        data,
+    );
+    data.work = work.work;
+
+    try work.queue();
+
+    return data.deferred.getPromise();
+}

--- a/bindings/perf/blst.test.ts
+++ b/bindings/perf/blst.test.ts
@@ -9,6 +9,7 @@ import {
   aggregateSignatures as aggregateSignaturesTS,
   aggregateVerify as aggregateVerifyTS,
   aggregateWithRandomness as aggregateWithRandomnessTS,
+  asyncAggregateWithRandomness as asyncAggregateWithRandomnessTS,
   verifyMultipleAggregateSignatures as verifyTS,
 } from "@chainsafe/blst";
 import {
@@ -18,6 +19,7 @@ import {
   aggregateSignatures as aggregateSignaturesZig,
   aggregateVerify as aggregateVerifyZig,
   aggregateWithRandomness as aggregateWithRandomnessZig,
+  asyncAggregateWithRandomness as asyncAggregateWithRandomnessZig,
   verifyMultipleAggregateSignatures as verifyZig,
 } from "../src/blst.js";
 
@@ -173,6 +175,32 @@ describe("aggregateWithRandomness", () => {
         aggregateWithRandomnessTS(sets);
       },
       id: `aggregateWithRandomness @chainsafe/blst  ${count} sets`,
+    });
+  }
+});
+
+describe("asyncAggregateWithRandomness", () => {
+  for (const count of [1, 8, 32, 64, 128]) {
+    bench({
+      beforeEach: () => {
+        const sets = generateZigSets(count);
+        return sets.map((s) => ({pk: s.pk, sig: s.sig.toBytes()}));
+      },
+      fn: async (sets) => {
+        await asyncAggregateWithRandomnessZig(sets);
+      },
+      id: `asyncAggregateWithRandomness lodestar-z  ${count} sets`,
+    });
+
+    bench({
+      beforeEach: () => {
+        const sets = generateTSSets(count);
+        return sets.map((s) => ({pk: s.pk, sig: s.sig.toBytes()}));
+      },
+      fn: async (sets) => {
+        await asyncAggregateWithRandomnessTS(sets);
+      },
+      id: `asyncAggregateWithRandomness @chainsafe/blst  ${count} sets`,
     });
   }
 });

--- a/bindings/src/blst.d.ts
+++ b/bindings/src/blst.d.ts
@@ -167,6 +167,12 @@ export function verifyMultipleAggregateSignatures(
 export declare function aggregateWithRandomness(sets: PkAndSerializedSig[]): PkAndSig;
 
 /**
+ * Same as `aggregateWithRandomness`, but the multi-scalar multiplications run on the
+ * native thread pool and the call returns a Promise instead of blocking the JS thread.
+ */
+export declare function asyncAggregateWithRandomness(sets: PkAndSerializedSig[]): Promise<PkAndSig>;
+
+/**
  * Aggregate multiple signatures into a single signature.
  *
  * If `sigsGroupcheck` is `true`, the signatures will be group checked.

--- a/bindings/src/blst.js
+++ b/bindings/src/blst.js
@@ -14,3 +14,4 @@ export const aggregateSignatures = blst.aggregateSignatures;
 export const aggregatePublicKeys = blst.aggregatePublicKeys;
 export const aggregateSerializedPublicKeys = blst.aggregateSerializedPublicKeys;
 export const aggregateWithRandomness = blst.aggregateWithRandomness;
+export const asyncAggregateWithRandomness = blst.asyncAggregateWithRandomness;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chainsafe/lodestar-z",
-  "version": "0.1.2-rc.0",
+  "version": "0.1.2-rc.1",
   "description": "Lodestar-z NAPI bindings",
   "files": [
     "bindings/src/",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chainsafe/lodestar-z",
-  "version": "0.1.1",
+  "version": "0.1.2-rc.0",
   "description": "Lodestar-z NAPI bindings",
   "files": [
     "bindings/src/",

--- a/src/bls/ThreadPool.zig
+++ b/src/bls/ThreadPool.zig
@@ -489,7 +489,7 @@ pub fn aggregateWithRandomness(
     if (randomness.len < pks.len * 32) return BlstError.AggrTypeMismatch;
 
     if (pks_validate) for (pks) |pk| try pk.validate();
-    if (sigs_groupcheck) for (sigs) |sig| try sig.validate(false);
+    if (sigs_groupcheck) for (sigs) |sig| try sig.validate(true);
 
     var scalars_refs: [blst.MAX_AGGREGATE_PER_JOB]*const u8 = undefined;
     for (0..pks.len) |i| scalars_refs[i] = &randomness[i * 32];

--- a/src/bls/ThreadPool.zig
+++ b/src/bls/ThreadPool.zig
@@ -17,10 +17,13 @@ const Pairing = @import("Pairing.zig");
 const blst = @import("root.zig");
 const PublicKey = blst.PublicKey;
 const Signature = blst.Signature;
+const AggregatePublicKey = blst.AggregatePublicKey;
+const AggregateSignature = blst.AggregateSignature;
 const BlstError = @import("error.zig").BlstError;
 const SecretKey = @import("SecretKey.zig");
+const pippenger = @import("pippenger.zig");
 
-const PoolError = error{
+pub const PoolError = error{
     /// Pool is currently shutting down.
     ShuttingDown,
 };
@@ -94,7 +97,7 @@ const JobQueue = struct {
 
 /// A work item submitted to the queue. Each worker that picks one up
 /// executes the work function, then signals `done`.
-const WorkItem = struct {
+pub const WorkItem = struct {
     exec_fn: *const fn (*WorkItem) void,
     done: std.Io.Event = .unset,
     next: ?*WorkItem = null,
@@ -168,7 +171,7 @@ fn workerLoop(pool: *ThreadPool, io: std.Io) void {
 }
 
 /// Submit work items to the pool and wait for all to complete.
-fn submitAndWait(pool: *ThreadPool, io: std.Io, items: []*WorkItem) (PoolError || std.Io.Cancelable)!void {
+pub fn submitAndWait(pool: *ThreadPool, io: std.Io, items: []*WorkItem) (PoolError || std.Io.Cancelable)!void {
     if (!try pool.queue.pushBatch(io, pool, items)) return PoolError.ShuttingDown;
     // NOTE: must be uncancelable — work items live on the caller's stack, so a
     // cancel here would let workers write into freed frames.
@@ -459,6 +462,47 @@ fn mergeAndVerify(
     return acc.finalVerify(gtsig);
 }
 
+/// Aggregates `pks` and `sigs` with multi-scalar multiplication using `randomness`.
+/// Each MSM (PK then Sig) is fully fanned out across the pool via tile Pippenger
+/// (see `pippenger.zig`).
+///
+///
+/// ## Invariants:
+/// - `pks` and `sigs` are paired by index.
+/// - `randomness` must contain at least `pks.len * 32` bytes;
+/// - only the first 8 bytes per 32-byte slot are read by
+///   the underlying 64-bit Pippenger, but the 32-byte stride matches the existing
+///   `AggregatePublicKey.aggregateWithRandomness` layout.
+pub fn aggregateWithRandomness(
+    pool: *ThreadPool,
+    io: std.Io,
+    pks: []*const PublicKey,
+    sigs: []*const Signature,
+    randomness: []const u8,
+    pks_validate: bool,
+    sigs_groupcheck: bool,
+    pk_out: *PublicKey,
+    sig_out: *Signature,
+) (BlstError || PoolError || std.Io.Cancelable || std.mem.Allocator.Error)!void {
+    if (pks.len == 0 or pks.len != sigs.len) return BlstError.AggrTypeMismatch;
+    if (pks.len > blst.MAX_AGGREGATE_PER_JOB) return BlstError.AggrTypeMismatch;
+    if (randomness.len < pks.len * 32) return BlstError.AggrTypeMismatch;
+
+    if (pks_validate) for (pks) |pk| try pk.validate();
+    if (sigs_groupcheck) for (sigs) |sig| try sig.validate(false);
+
+    var scalars_refs: [blst.MAX_AGGREGATE_PER_JOB]*const u8 = undefined;
+    for (0..pks.len) |i| scalars_refs[i] = &randomness[i * 32];
+
+    var pk_proj: c.blst_p1 = undefined;
+    try pippenger.parallelMSMG1(pool, io, pks, scalars_refs[0..pks.len], 64, &pk_proj);
+    c.blst_p1_to_affine(&pk_out.point, &pk_proj);
+
+    var sig_proj: c.blst_p2 = undefined;
+    try pippenger.parallelMSMG2(pool, io, sigs, scalars_refs[0..sigs.len], 64, &sig_proj);
+    c.blst_p2_to_affine(&sig_out.point, &sig_proj);
+}
+
 test "verifyMultipleAggregateSignatures multi-threaded" {
     const pool = try ThreadPool.init(std.testing.allocator, std.testing.io, .{ .n_workers = 4 });
     defer pool.deinit(std.testing.io);
@@ -518,8 +562,6 @@ test "aggregateVerify multi-threaded" {
     const pool = try ThreadPool.init(std.testing.allocator, std.testing.io, .{ .n_workers = 4 });
     defer pool.deinit(std.testing.io);
 
-    const AggregateSignature = blst.AggregateSignature;
-
     const ikm: [32]u8 = .{
         0x93, 0xad, 0x7e, 0x65, 0xde, 0xad, 0x05, 0x2a, 0x08, 0x3a,
         0x91, 0x0c, 0x8b, 0x72, 0x85, 0x91, 0x46, 0x4c, 0xca, 0x56,
@@ -551,7 +593,7 @@ test "aggregateVerify multi-threaded" {
         pk_ptrs[i] = &pks[i];
     }
 
-    const agg_sig = AggregateSignature.aggregate(&sigs, false) catch return error.AggregationFailed;
+    const agg_sig = blst.AggregateSignature.aggregate(&sigs, false) catch return error.AggregationFailed;
     const final_sig = agg_sig.toSignature();
 
     try std.testing.expect(try pool.aggregateVerify(
@@ -563,4 +605,61 @@ test "aggregateVerify multi-threaded" {
         &pk_ptrs,
         true,
     ));
+}
+
+test "aggregateWithRandomness multi-threaded" {
+    const pool = try ThreadPool.init(std.testing.allocator, std.testing.io, .{ .n_workers = 4 });
+    defer pool.deinit(std.testing.io);
+
+    const ikm: [32]u8 = .{
+        0x93, 0xad, 0x7e, 0x65, 0xde, 0xad, 0x05, 0x2a, 0x08, 0x3a,
+        0x91, 0x0c, 0x8b, 0x72, 0x85, 0x91, 0x46, 0x4c, 0xca, 0x56,
+        0x60, 0x5b, 0xb0, 0x56, 0xed, 0xfe, 0x2b, 0x60, 0xa6, 0x3c,
+        0x48, 0x99,
+    };
+
+    const num_sigs = blst.MAX_AGGREGATE_PER_JOB;
+
+    var msg: [32]u8 = undefined;
+    var pks: [num_sigs]PublicKey = undefined;
+    var sigs: [num_sigs]Signature = undefined;
+    var pk_ptrs: [num_sigs]*const PublicKey = undefined;
+    var sig_ptrs: [num_sigs]*const Signature = undefined;
+
+    var prng = std.Random.DefaultPrng.init(blk: {
+        var seed: u64 = undefined;
+        std.testing.io.random(std.mem.asBytes(&seed));
+        break :blk seed;
+    });
+    const rand = prng.random();
+    std.Random.bytes(rand, &msg);
+
+    for (0..num_sigs) |i| {
+        var ikm_i = ikm;
+        ikm_i[0] = @intCast(i & 0xff);
+        const sk = try SecretKey.keyGen(&ikm_i, null);
+        pks[i] = sk.toPublicKey();
+        sigs[i] = sk.sign(&msg, blst.DST, null);
+        pk_ptrs[i] = &pks[i];
+        sig_ptrs[i] = &sigs[i];
+    }
+
+    var randomness: [32 * num_sigs]u8 = undefined;
+    std.Random.bytes(rand, &randomness);
+
+    var agg_pk: PublicKey = .{};
+    var agg_sig: Signature = .{};
+
+    try pool.aggregateWithRandomness(
+        std.testing.io,
+        &pk_ptrs,
+        &sig_ptrs,
+        &randomness,
+        true,
+        true,
+        &agg_pk,
+        &agg_sig,
+    );
+
+    try agg_sig.verify(true, &msg, blst.DST, null, &agg_pk, true);
 }

--- a/src/bls/pippenger.zig
+++ b/src/bls/pippenger.zig
@@ -1,0 +1,401 @@
+//! Parallel multi-scalar multiplication via tile Pippenger.
+//!
+//! The MSM is split into an `nx × ny` grid of independent tiles — each tile covers
+//! a chunk of points × a window of scalar bits. Workers race for tiles via an
+//! atomic counter and call `blst_p?s_tile_pippenger`; once every tile is done
+//! the calling thread assembles them top-to-bottom Horner-style (double `wnd`
+//! times between rows, then add that row's tiles).
+//!
+//! ## Curve genericity
+//!
+//! The algorithm is identical for G1 (public keys) and G2 (signatures) — only
+//! the C entry points and point types change. We capture that in a
+//! `CurveDescriptor` value (`G1` / `G2` below) and write the algorithm once in
+//! `parallelMSM(comptime Curve: CurveDescriptor, ...)`. `parallelMSMG1` /
+//! `parallelMSMG2` are thin wrappers that fix the curve.
+//!
+//! ## Fallback
+//!
+//! For `pool.n_workers < 2` or `npoints < 2` we skip the grid and call
+//! single-threaded `Curve.mult_pippenger` directly since the overhead is not
+//! worth it.
+//!
+//! Note: This is a direct port of blst's Rust binding `MultiPoint::mult` (pippenger.rs).
+
+const std = @import("std");
+const c = @import("root.zig").c;
+const blst = @import("root.zig");
+const PublicKey = blst.PublicKey;
+const Signature = blst.Signature;
+const ThreadPool = @import("ThreadPool.zig");
+const WorkItem = ThreadPool.WorkItem;
+const PoolError = ThreadPool.PoolError;
+const MAX_WORKERS = ThreadPool.MAX_WORKERS;
+
+/// Curve descriptor: bundles the projective point type, the affine wrapper
+/// (`PublicKey` / `Signature` — both wrap the corresponding `*_affine` C type
+/// at offset 0, so `@ptrCast` to `*const blst_p?_affine` is sound), and the
+/// five blst C entry points the algorithm needs.
+///
+/// The four point-typed function pointers are stored as `*const anyopaque`
+/// because their typed signatures reference `Projective` / `Wrapper` from the
+/// same struct, and Zig can't cross-reference fields like that. `parallelMSM`
+/// reconstructs the typed function-pointer types from `Projective` / `Wrapper`
+/// and `@ptrCast`s back at call sites at comptime.
+const CurveDescriptor = struct {
+    Projective: type,
+    Wrapper: type,
+    scratch_sizeof: *const fn (npoints: usize) callconv(.c) usize,
+    mult_pippenger: *const anyopaque,
+    tile_pippenger: *const anyopaque,
+    add_or_double: *const anyopaque,
+    double: *const anyopaque,
+};
+
+const G1: CurveDescriptor = .{
+    .Projective = c.blst_p1,
+    .Wrapper = PublicKey,
+    .scratch_sizeof = c.blst_p1s_mult_pippenger_scratch_sizeof,
+    .mult_pippenger = @ptrCast(&c.blst_p1s_mult_pippenger),
+    .tile_pippenger = @ptrCast(&c.blst_p1s_tile_pippenger),
+    .add_or_double = @ptrCast(&c.blst_p1_add_or_double),
+    .double = @ptrCast(&c.blst_p1_double),
+};
+
+const G2: CurveDescriptor = .{
+    .Projective = c.blst_p2,
+    .Wrapper = Signature,
+    .scratch_sizeof = c.blst_p2s_mult_pippenger_scratch_sizeof,
+    .mult_pippenger = @ptrCast(&c.blst_p2s_mult_pippenger),
+    .tile_pippenger = @ptrCast(&c.blst_p2s_tile_pippenger),
+    .add_or_double = @ptrCast(&c.blst_p2_add_or_double),
+    .double = @ptrCast(&c.blst_p2_double),
+};
+
+/// Number of significant bits in `l`. Returns 0 for 0.
+fn numBits(l: usize) usize {
+    return @bitSizeOf(usize) - @clz(l);
+}
+
+/// Pippenger window size before the breakdown decides how to slice it across
+/// workers.
+fn pippengerWindowSize(npoints: usize) usize {
+    const wbits = numBits(npoints);
+    if (wbits > 13) return wbits - 4;
+    if (wbits > 5) return wbits - 3;
+    return 2;
+}
+
+/// Direct port of blst's Rust `breakdown` (pippenger.rs:503). Picks the grid
+/// shape that splits the work evenly across `ncpus` while keeping each tile's
+/// scratch buffer small.
+///
+/// Returns:
+///   - `nx`: number of point-chunks per row (columns in the grid).
+///   - `ny`: number of bit-windows (rows in the grid).
+///   - `wnd`: window size used for tiles below the top row; the top row covers
+///     whatever bits remain (`nbits - wnd*(ny-1)`) and is auto-clipped by
+///     `tile_pippenger`.
+fn breakdownTiles(
+    nbits: usize,
+    window: usize,
+    ncpus: usize,
+) struct { nx: usize, ny: usize, wnd: usize } {
+    var nx: usize = undefined;
+    var wnd: usize = undefined;
+
+    if (nbits > window * ncpus) {
+        nx = 1;
+        wnd = numBits(ncpus / 4);
+        if (window + wnd > 18) {
+            wnd = window - wnd;
+        } else {
+            const a = (nbits / window + ncpus - 1) / ncpus;
+            const b = (nbits / (window + 1) + ncpus - 1) / ncpus;
+            wnd = if (b < a) window + 1 else window;
+        }
+    } else {
+        nx = 2;
+        wnd = window - 2;
+        while ((nbits / wnd + 1) * nx < ncpus) {
+            nx += 1;
+            wnd = window - numBits(3 * nx / 2);
+        }
+        nx -= 1;
+        wnd = window - numBits(3 * nx / 2);
+    }
+
+    const ny = nbits / wnd + 1;
+    wnd = nbits / ny + 1;
+    return .{ .nx = nx, .ny = ny, .wnd = wnd };
+}
+
+/// One tile of the Pippenger grid:
+///   - `x`: starting point index.
+///   - `dx`: number of points covered by this tile.
+///   - `y`: starting bit position of the scalar window.
+///
+/// Note: we do not have `dy` here because `dy` is written and never read
+/// upstream!
+const TileDesc = struct { x: usize, dx: usize, y: usize };
+
+/// Lays out `tiles` top row first (highest `y`), going down. Each row has
+/// `nx` tiles covering point chunks `[i*dx, (i+1)*dx)`; the last column in
+/// the top row absorbs any rounding remainder so every point is covered.
+/// We don't precompute the top row's window — `tile_pippenger` clips
+/// internally when `bit0 + window > nbits`, so passing `window` for every
+/// tile is correct.
+fn buildTiles(npoints: usize, nx: usize, ny: usize, window: usize, tiles: []TileDesc) void {
+    const dx = npoints / nx;
+    const y_top: usize = window * (ny - 1);
+
+    var total: usize = 0;
+    while (total < nx) : (total += 1) {
+        tiles[total] = .{ .x = total * dx, .dx = dx, .y = y_top };
+    }
+    if (nx > 0) tiles[nx - 1].dx = npoints - tiles[nx - 1].x;
+
+    var y_cur = y_top;
+    while (y_cur != 0) {
+        y_cur -= window;
+        for (0..nx) |i| {
+            tiles[total] = .{ .x = tiles[i].x, .dx = tiles[i].dx, .y = y_cur };
+            total += 1;
+        }
+    }
+}
+
+/// Typed function-pointer signature for `blst_p?s_tile_pippenger`, reconstructed
+/// from a `CurveDescriptor`. Matches the C ABI for both G1 and G2 once
+/// `Projective` and `Wrapper` are fixed.
+fn TilePippengerFn(comptime Curve: CurveDescriptor) type {
+    return *const fn (
+        *Curve.Projective,
+        [*c]*const Curve.Wrapper,
+        usize,
+        [*c]*const u8,
+        usize,
+        [*c]u64,
+        usize,
+        usize,
+    ) callconv(.c) void;
+}
+
+/// Typed function-pointer signature for `blst_p?s_mult_pippenger`.
+fn MultPippengerFn(comptime Curve: CurveDescriptor) type {
+    return *const fn (
+        *Curve.Projective,
+        [*c]*const Curve.Wrapper,
+        usize,
+        [*c]*const u8,
+        usize,
+        [*c]u64,
+    ) callconv(.c) void;
+}
+
+/// Typed function-pointer signature for `blst_p?_add_or_double`.
+fn AddOrDoubleFn(comptime Curve: CurveDescriptor) type {
+    return *const fn (*Curve.Projective, *const Curve.Projective, *const Curve.Projective) callconv(.c) void;
+}
+
+/// Typed function-pointer signature for `blst_p?_double`.
+fn DoubleFn(comptime Curve: CurveDescriptor) type {
+    return *const fn (*Curve.Projective, *const Curve.Projective) callconv(.c) void;
+}
+
+/// Shared state for a single `parallelMSM` invocation. Lives on the calling
+/// thread's stack; workers read it through their `TilePippengerWorkItem`.
+/// `scratch_buf` is split into `n_active` per-worker chunks of
+/// `scratch_per_worker` u64s; each worker only touches its own slice, so no
+/// synchronization is needed. `results` is similarly partitioned by the
+/// `counter` — each tile index is claimed by exactly one worker.
+fn TilePippengerJob(comptime Curve: CurveDescriptor) type {
+    return struct {
+        points: []*const Curve.Wrapper,
+        scalars_refs: []*const u8,
+        nbits: usize,
+        wnd: usize,
+        tiles: []const TileDesc,
+        results: []Curve.Projective,
+        scratch_buf: []u64,
+        scratch_per_worker: usize,
+        counter: std.atomic.Value(usize),
+    };
+}
+
+/// A worker on the bls `ThreadPool`. Each work item holds a `worker_id` so
+/// it can find its scratch slice; multiple work items share one job and race
+/// on `job.counter` to claim tiles.
+fn TilePippengerWorkItem(comptime Curve: CurveDescriptor) type {
+    return struct {
+        const Self = @This();
+
+        base: WorkItem,
+        job: *TilePippengerJob(Curve),
+        worker_id: usize,
+
+        fn exec(base_item: *WorkItem) void {
+            const self: *Self = @fieldParentPtr("base", base_item);
+            const job = self.job;
+            const offset = self.worker_id * job.scratch_per_worker;
+            const scratch = job.scratch_buf[offset .. offset + job.scratch_per_worker];
+            const tile_pippenger: TilePippengerFn(Curve) = @ptrCast(@alignCast(Curve.tile_pippenger));
+
+            while (true) {
+                const i = job.counter.fetchAdd(1, .monotonic);
+                if (i >= job.tiles.len) break;
+
+                const tile = job.tiles[i];
+                tile_pippenger(
+                    &job.results[i],
+                    @ptrCast(job.points[tile.x..].ptr),
+                    tile.dx,
+                    @ptrCast(job.scalars_refs[tile.x..].ptr),
+                    job.nbits,
+                    @ptrCast(scratch.ptr),
+                    tile.y,
+                    job.wnd,
+                );
+            }
+        }
+    };
+}
+
+/// Generic parallel multi-scalar multiplication. Computes
+/// `out = sum_i points[i] * scalars[i]` over either curve.
+///
+/// Caller invariants:
+///   - `points.len > 0` and `points.len == scalars_refs.len` (asserted).
+///   - Each `scalars_refs[i]` points to at least `(nbits + 7) / 8` bytes.
+///   - `scalars_refs` follows blst's "array of pointers" calling convention:
+///     each element is a distinct pointer; no NULL sentinel needed (blst
+///     handles both `[start_ptr, NULL]` and per-point arrays).
+///
+/// Notes on the implementation:
+///   - `Curve.scratch_sizeof(0)` returns `2 * sizeof(point_xyzz)` bytes (the
+///     base bucket size for `pippenger_window_size(0) = 2`); per-worker scratch
+///     is `(that / 8) << (wnd-1)` u64s, matching Rust's formula.
+///   - We must zero `scratch_buf` on first use because blst's static
+///     `tile_pippenger` doesn't zero buckets — its companion
+///     `integrate_buckets` zeros them while consuming, so the second call onward
+///     starts from zero again, but the first does not.
+///   - Top-to-bottom Horner assembly: `out = top_row`, then for each row
+///     below, double `wnd` times and add the row's tiles. Equivalent to
+///     `sum_r row_r * 2^((ny-1-r)*wnd)`.
+fn parallelMSM(
+    comptime Curve: CurveDescriptor,
+    pool: *ThreadPool,
+    io: std.Io,
+    points: []*const Curve.Wrapper,
+    scalars_refs: []*const u8,
+    nbits: usize,
+    out: *Curve.Projective,
+) (PoolError || std.Io.Cancelable || std.mem.Allocator.Error)!void {
+    const npoints = points.len;
+    std.debug.assert(npoints > 0);
+    std.debug.assert(npoints == scalars_refs.len);
+
+    const ncpus = pool.n_workers;
+
+    if (ncpus < 2 or npoints < 2) {
+        const scratch_size_u64 = Curve.scratch_sizeof(npoints) / @sizeOf(u64);
+        const scratch = try pool.allocator.alloc(u64, scratch_size_u64);
+        defer pool.allocator.free(scratch);
+        const mult_pippenger: MultPippengerFn(Curve) = @ptrCast(@alignCast(Curve.mult_pippenger));
+        mult_pippenger(
+            out,
+            @ptrCast(points.ptr),
+            npoints,
+            @ptrCast(scalars_refs.ptr),
+            nbits,
+            scratch.ptr,
+        );
+        return;
+    }
+
+    const window = pippengerWindowSize(npoints);
+    const bd = breakdownTiles(nbits, window, ncpus);
+    const total = bd.nx * bd.ny;
+    const n_active = @min(ncpus, total);
+
+    const sz_bytes = Curve.scratch_sizeof(0);
+    const scratch_per_worker = (sz_bytes / @sizeOf(u64)) << @intCast(bd.wnd - 1);
+
+    const scratch_buf = try pool.allocator.alloc(u64, scratch_per_worker * n_active);
+    defer pool.allocator.free(scratch_buf);
+    @memset(scratch_buf, 0);
+
+    const tiles = try pool.allocator.alloc(TileDesc, total);
+    defer pool.allocator.free(tiles);
+    buildTiles(npoints, bd.nx, bd.ny, bd.wnd, tiles);
+
+    const results = try pool.allocator.alloc(Curve.Projective, total);
+    defer pool.allocator.free(results);
+
+    const Job = TilePippengerJob(Curve);
+    const Item = TilePippengerWorkItem(Curve);
+
+    var job = Job{
+        .points = points,
+        .scalars_refs = scalars_refs,
+        .nbits = nbits,
+        .wnd = bd.wnd,
+        .tiles = tiles,
+        .results = results,
+        .scratch_buf = scratch_buf,
+        .scratch_per_worker = scratch_per_worker,
+        .counter = std.atomic.Value(usize).init(0),
+    };
+
+    var work_items: [MAX_WORKERS]Item = undefined;
+    var item_ptrs: [MAX_WORKERS]*WorkItem = undefined;
+    for (0..n_active) |i| {
+        work_items[i] = .{
+            .base = .{ .exec_fn = Item.exec },
+            .job = &job,
+            .worker_id = i,
+        };
+        item_ptrs[i] = &work_items[i].base;
+    }
+
+    try pool.submitAndWait(io, item_ptrs[0..n_active]);
+
+    // Sequential top-to-bottom Horner assembly.
+    // Note this is where implementation differs: The Rust binding pipelines this
+    // with worker progress (channel + per-row atomic counter + readiness array,
+    // so accumulation can start on the top row while lower rows are still
+    // computing). We don't — `submitAndWait` already drained every worker, so
+    // every row is ready, in order.
+    const add_or_double: AddOrDoubleFn(Curve) = @ptrCast(@alignCast(Curve.add_or_double));
+    const double: DoubleFn(Curve) = @ptrCast(@alignCast(Curve.double));
+    out.* = results[0];
+    for (1..bd.nx) |i| add_or_double(out, out, &results[i]);
+    for (1..bd.ny) |row| {
+        for (0..bd.wnd) |_| double(out, out);
+        for (0..bd.nx) |col| add_or_double(out, out, &results[row * bd.nx + col]);
+    }
+}
+
+/// MSM in G1 (public-key curve). Specialization of `parallelMSM` to `G1`.
+pub fn parallelMSMG1(
+    pool: *ThreadPool,
+    io: std.Io,
+    pks: []*const PublicKey,
+    scalars_refs: []*const u8,
+    nbits: usize,
+    out: *c.blst_p1,
+) (PoolError || std.Io.Cancelable || std.mem.Allocator.Error)!void {
+    return parallelMSM(G1, pool, io, pks, scalars_refs, nbits, out);
+}
+
+/// MSM in G2 (signature curve). Specialization of `parallelMSM` to `G2`.
+pub fn parallelMSMG2(
+    pool: *ThreadPool,
+    io: std.Io,
+    sigs: []*const Signature,
+    scalars_refs: []*const u8,
+    nbits: usize,
+    out: *c.blst_p2,
+) (PoolError || std.Io.Cancelable || std.mem.Allocator.Error)!void {
+    return parallelMSM(G2, pool, io, sigs, scalars_refs, nbits, out);
+}

--- a/src/bls/root.zig
+++ b/src/bls/root.zig
@@ -17,6 +17,7 @@ pub const BlstError = @import("error.zig").BlstError;
 
 pub const verifyMultipleAggregateSignatures = @import("fast_verify.zig").verifyMultipleAggregateSignatures;
 pub const ThreadPool = @import("ThreadPool.zig");
+pub const pippenger = @import("pippenger.zig");
 
 /// Maximum number of signatures that can be aggregated in a single job.
 pub const MAX_AGGREGATE_PER_JOB: usize = 128;
@@ -35,4 +36,5 @@ test {
     testing.refAllDecls(AggregatePublicKey);
     testing.refAllDecls(AggregateSignature);
     testing.refAllDecls(ThreadPool);
+    testing.refAllDecls(pippenger);
 }


### PR DESCRIPTION
This PR reintroduces pippenger based `asyncAggregateWithRandomness`, heavily modelled after the [rust bindings](https://github.com/supranational/blst/blob/dece82ea537b422890888bacde4034ca5b5a44d8/bindings/rust/src/pippenger.rs ).

We use a comptime `parallelMSM` fn which accepts a `Curve`. The underlying algorithm is the same, we just need to choose the usage (at comptime) between `G1`, which is the pubkey, or `G2`, the signature.

We don't necessarily have to do this but I thought it looks cleaner rather than repeating the algo twice. Of course this means we have to do some ugly things like defining a `CurveDescriptor` struct and use a bunch of pointer casts to anyopaque functions.

## Implementation details

Note that there are a few key differences:

- instead of using `blst`'s internal threadpool, we use our own `ThreadPool`
- Rust version uses pipelining to accumulate work. Key difference here is that the rows can come out of order because the top rows can start being summed while bottom rows are still computing; we use `submitAndWait` which assembles work sequentially from top to bottom. This has the benefit of allowing us to drop one of the outer loops that Rust does to handle out-of-order rows from workers. We have the benefit of simpler code here.

## Benchmarks

Looks pretty comparable on M2 Mac:

```
bindings/perf/blst.test.ts
  asyncAggregateWithRandomness
    ✔ asyncAggregateWithRandomness lodestar-z  1 sets                     5456.162 ops/s    183.2790 us/op        -        713 runs  0.996 s
    ✔ asyncAggregateWithRandomness @chainsafe/blst  1 sets                4940.736 ops/s    202.3990 us/op        -        524 runs  0.891 s
    ✔ asyncAggregateWithRandomness lodestar-z  8 sets                     1274.951 ops/s    784.3440 us/op        -         82 runs   1.82 s
    ✔ asyncAggregateWithRandomness @chainsafe/blst  8 sets                1295.293 ops/s    772.0260 us/op        -        138 runs   2.02 s
    ✔ asyncAggregateWithRandomness lodestar-z  32 sets                    408.2397 ops/s    2.449541 ms/op        -         44 runs   2.16 s
    ✔ asyncAggregateWithRandomness @chainsafe/blst  32 sets               413.3244 ops/s    2.419407 ms/op        -         31 runs   1.96 s
    ✔ asyncAggregateWithRandomness lodestar-z  64 sets                    221.6369 ops/s    4.511884 ms/op        -          9 runs   1.80 s
    ✔ asyncAggregateWithRandomness @chainsafe/blst  64 sets               218.6257 ops/s    4.574028 ms/op        -         13 runs   1.90 s
    ✔ asyncAggregateWithRandomness lodestar-z  128 sets                   111.7445 ops/s    8.948983 ms/op        -          5 runs   1.88 s
    ✔ asyncAggregateWithRandomness @chainsafe/blst  128 sets              113.1346 ops/s    8.839029 ms/op        -          7 runs   1.99 s

```

EDIT: Something to note is that this was mostly claude; but i did audit the code against the existing rust bindings and it's more or less doing the same stuff, would appreciate a separate pair of eyes to see if i missed something though.