### PR TITLE
feat(blst): use external buffers for blst operations

### DIFF
--- a/bindings/napi/blst.zig
+++ b/bindings/napi/blst.zig
@@ -136,10 +136,10 @@ pub const PublicKey = struct {
     pub fn toBytes(self: *const PublicKey, compress: ?js.Boolean) !js.Uint8Array {
         if (try boolOrDefault(compress, true)) {
             const bytes = self.raw.compress();
-            return js.Uint8Array.from(bytes[0..]);
+            return js.Uint8Array.fromExternal(bytes[0..]);
         }
         const bytes = self.raw.serialize();
-        return js.Uint8Array.from(bytes[0..]);
+        return js.Uint8Array.fromExternal(bytes[0..]);
     }
 
     pub fn toHex(self: *const PublicKey, compress: ?js.Boolean) !js.String {
@@ -214,10 +214,10 @@ pub const Signature = struct {
     pub fn toBytes(self: *const Signature, compress: ?js.Boolean) !js.Uint8Array {
         if (try boolOrDefault(compress, true)) {
             const bytes = self.raw.compress();
-            return js.Uint8Array.from(bytes[0..]);
+            return js.Uint8Array.fromExternal(bytes[0..]);
         }
         const bytes = self.raw.serialize();
-        return js.Uint8Array.from(bytes[0..]);
+        return js.Uint8Array.fromExternal(bytes[0..]);
     }
 
     pub fn toHex(self: *const Signature, compress: ?js.Boolean) !js.String {
@@ -295,9 +295,9 @@ pub const SecretKey = struct {
     }
 
     /// Serializes the SecretKey to bytes (32 bytes).
-    pub fn toBytes(self: *const SecretKey) js.Uint8Array {
+    pub fn toBytes(self: *const SecretKey) !js.Uint8Array {
         const bytes = self.raw.serialize();
-        return js.Uint8Array.from(bytes[0..]);
+        return js.Uint8Array.fromExternal(bytes[0..]);
     }
 
     pub fn toHex(self: *const SecretKey) !js.String {

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -36,8 +36,8 @@
             .hash = "zig_yaml-0.1.0-C1161kFWAwDxjKAFmklKwWVDvz2mmq0Q__bDhGGjeyd3",
         },
         .zapi = .{
-            .url = "git+https://github.com/chainsafe/zapi?ref=zapi-v2.0.0#f9fa8b0237352326e9f970b62588b6af01e3e384",
-            .hash = "zapi-2.0.0-rIqzUcc3BABKRuJlzpYNtiMVCOFybuVSGOLmk0KOCeel",
+            .url = "git+https://github.com/chainsafe/zapi#40377b142304fe890ace0dc8978dc43f22efea9e",
+            .hash = "zapi-2.0.0-rIqzUUJNBABUXYIA67bxe5aDS5J2asn27TOHn3YTsHDL",
         },
         .zbench = .{
             .url = "git+https://github.com/hendriknielaender/zBench#b2b89c475e3ef1bb2bd71255c80478a82d3e0ca8",

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -36,8 +36,8 @@
             .hash = "zig_yaml-0.1.0-C1161kFWAwDxjKAFmklKwWVDvz2mmq0Q__bDhGGjeyd3",
         },
         .zapi = .{
-            .url = "git+https://github.com/chainsafe/zapi#40377b142304fe890ace0dc8978dc43f22efea9e",
-            .hash = "zapi-2.0.0-rIqzUUJNBABUXYIA67bxe5aDS5J2asn27TOHn3YTsHDL",
+            .url = "git+https://github.com/chainsafe/zapi?ref=zapi-v2.1.0#c5c877af9742d9d7fd6cab2ce6fec698817d56cd",
+            .hash = "zapi-2.1.0-rIqzUbxNBADOW16nSYQfUOtib1TgC8PxbR4ggN6ezYfA",
         },
         .zbench = .{
             .url = "git+https://github.com/hendriknielaender/zBench#b2b89c475e3ef1bb2bd71255c80478a82d3e0ca8",


### PR DESCRIPTION
Depends on ChainSafe/zapi#30 (we need to release zapi and update the dep)

This is one of possible likely causes for increased GC pressure on experiments to swap out blst-ts for lodestar-z/bls, as observed on feat2 and feat3 deployments in [this
PR](https://github.com/ChainSafe/lodestar/pull/9342/).

With external array buffers, V8 is only aware of the pointer to the backing memory, instead of having to track both the pointer and the backing memory. This means that during marking phase the GC does not have to walk the backing memory to mark it as 'live' - the frequency of the GC firing off is still the same, but each cycle does less work.

This of course comes with a tradeoff, we need a
**finalizer** to let V8 know how much external memory is in native heap  so that the GC tells the native impl to free the useless memory.

Though, regardless of the effect, we should still probably do this anyway, since [napi-rs does the same](https://github.com/napi-rs/napi-rs/blob/159395b365c583a6642ad481edc5708d9f36a24b/crates/napi/src/bindgen_runtime/js_values/arraybuffer.rs#L175), and only defaults to V8 managed array buffers if it is disallowed (like in Electron).