### PR TITLE
fix(build): remove `zig-out` from `files`

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,8 +3,7 @@
   "version": "0.1.2-rc.1",
   "description": "Lodestar-z NAPI bindings",
   "files": [
-    "bindings/src/",
-    "zig-out/lib/"
+    "bindings/src/"
   ],
   "type": "module",
   "exports": {


### PR DESCRIPTION
In zapi, [local path takes
preference](https://github.com/ChainSafe/zapi/blob/e522fa4beb5eacfb8ee0f9a964b435a88bb8f2ba/ts/lib.ts#L218) so we want to not publish with that entry under `files`, otherwise `lodestar` will attempt to load an architecture incompatible library on `dlopen`.

Locally testing after pulling from a published `lodestar-z` is failing because my machine (aarch64-apple-darwin) is trying to load from an x86_64-linux binary, so we'd need to re-publish after we fix this