### PR TITLE
chore: support dev workflow

### DIFF
--- a/.github/workflows/publish-bindings.yml
+++ b/.github/workflows/publish-bindings.yml
@@ -62,5 +62,5 @@ jobs:
         run: |
           pnpm zapi build-artifacts --optimize ReleaseSafe
           pnpm zapi prepublish
-          pnpm zapi publish --access public -- --provenance ${{ steps.detect_dist_tag.outputs.tag_flag }}
+          pnpm zapi publish --access public -- --ignore-scripts --provenance ${{ steps.detect_dist_tag.outputs.tag_flag }}
 

--- a/.github/workflows/publish-bindings.yml
+++ b/.github/workflows/publish-bindings.yml
@@ -62,5 +62,6 @@ jobs:
         run: |
           pnpm zapi build-artifacts --optimize ReleaseSafe
           pnpm zapi prepublish
+          rm -rf zig-out/lib
           pnpm zapi publish --access public -- --ignore-scripts --provenance ${{ steps.detect_dist_tag.outputs.tag_flag }}
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "version": "0.1.2-rc.1",
   "description": "Lodestar-z NAPI bindings",
   "files": [
-    "bindings/src/"
+    "bindings/src/",
+    "zig-out/lib/"
   ],
   "type": "module",
   "exports": {


### PR DESCRIPTION
- Motivation: https://github.com/ChainSafe/lodestar-z/pull/360#issuecomment-4462314964

Afaik, zig-out/lib/* must be in package.json `files` in order for the library to be part of the packed package when installing lodestar-z as a git dependency.
Unfortunately, that also allows it to be part of the package when _published_!! which breaks cross-platform usage of the library, short circuiting the correct library from being loaded.

To that end, this PR attempts to get the intended behavior for both cases:
- keep zig-out/lib in `files` so git-dependency-installed lodestar-z packs a freshly-built library
- but crucially suppress the prepare script from being run during publish via `--ignore-scripts` so npm-dependency-installed lodestar-z uses a platform-specific published library