### PR TITLE
fix: export asyncAggregateWithRandomness through napi binding

### DIFF
--- a/bindings/napi/blst.zig
+++ b/bindings/napi/blst.zig
@@ -710,23 +710,23 @@ fn asyncAggRand_execute(_: napi.Env, data: *AsyncAggRandData) void {
 /// Ran on the JS thread once the worker has finished. Always settles the
 /// promise — `settle` does the resolve/reject; if it errors we fall back to a
 /// bare reject so callers never see a dangling Promise.
-fn asyncAggRand_complete(env: napi.Env, stat: napi.status.Status, data: *AsyncAggRandData) void {
+fn asyncAggRand_complete(env: napi.Env, status: napi.status.Status, data: *AsyncAggRandData) void {
     defer {
         napi.status.check(napi.c.napi_delete_async_work(env.env, data.work)) catch {};
         data.destroy();
     }
 
-    settle(env, stat, data) catch {
+    settle(env, status, data) catch {
         // Catch all rejection: if we reach this point we might want
         // better errors upstream
         rejectWithError(env, data.deferred, "asyncAggregateWithRandomness", "InternalError") catch {};
     };
 }
 
-fn settle(env: napi.Env, stat: napi.status.Status, data: *AsyncAggRandData) !void {
-    if (stat != .ok) {
+fn settle(env: napi.Env, status: napi.status.Status, data: *AsyncAggRandData) !void {
+    if (status != .ok) {
         // libuv's async work itself failed (e.g. cancelled), not crypto.
-        return rejectWithError(env, data.deferred, "asyncAggregateWithRandomness/asyncWork", @tagName(stat));
+        return rejectWithError(env, data.deferred, "asyncAggregateWithRandomness/asyncWork", @tagName(status));
     }
     if (data.err) |err| {
         // Worker captured a Zig error — surface its name as the JS Error.code

--- a/bindings/napi/blst.zig
+++ b/bindings/napi/blst.zig
@@ -660,13 +660,13 @@ pub fn aggregateWithRandomness(sets: js.Array) !js.Value {
 /// All input data should be copied into this struct so the worker thread doesn't depend on
 /// any JS-managed memory staying alive.
 const AsyncAggRandData = struct {
-    pks: []PublicKey,
-    sigs: []Signature,
-    pk_ptrs: []*const PublicKey,
-    sig_ptrs: []*const Signature,
+    pks: []NativePublicKey,
+    sigs: []NativeSignature,
+    pk_ptrs: []*const NativePublicKey,
+    sig_ptrs: []*const NativeSignature,
     randomness: []u8,
-    pk_out: PublicKey,
-    sig_out: Signature,
+    pk_out: NativePublicKey,
+    sig_out: NativeSignature,
     err: ?anyerror,
     deferred: napi.Deferred,
     work: napi.c.napi_async_work,
@@ -710,23 +710,23 @@ fn asyncAggRand_execute(_: napi.Env, data: *AsyncAggRandData) void {
 /// Ran on the JS thread once the worker has finished. Always settles the
 /// promise — `settle` does the resolve/reject; if it errors we fall back to a
 /// bare reject so callers never see a dangling Promise.
-fn asyncAggRand_complete(env: napi.Env, status: napi.status.Status, data: *AsyncAggRandData) void {
+fn asyncAggRand_complete(env: napi.Env, stat: napi.status.Status, data: *AsyncAggRandData) void {
     defer {
         napi.status.check(napi.c.napi_delete_async_work(env.env, data.work)) catch {};
         data.destroy();
     }
 
-    settle(env, status, data) catch {
+    settle(env, stat, data) catch {
         // Catch all rejection: if we reach this point we might want
         // better errors upstream
         rejectWithError(env, data.deferred, "asyncAggregateWithRandomness", "InternalError") catch {};
     };
 }
 
-fn settle(env: napi.Env, status: napi.status.Status, data: *AsyncAggRandData) !void {
-    if (status != .ok) {
+fn settle(env: napi.Env, stat: napi.status.Status, data: *AsyncAggRandData) !void {
+    if (stat != .ok) {
         // libuv's async work itself failed (e.g. cancelled), not crypto.
-        return rejectWithError(env, data.deferred, "asyncAggregateWithRandomness/asyncWork", @tagName(status));
+        return rejectWithError(env, data.deferred, "asyncAggregateWithRandomness/asyncWork", @tagName(stat));
     }
     if (data.err) |err| {
         // Worker captured a Zig error — surface its name as the JS Error.code
@@ -735,13 +735,8 @@ fn settle(env: napi.Env, status: napi.status.Status, data: *AsyncAggRandData) !v
         return rejectWithError(env, data.deferred, "asyncAggregateWithRandomness", @errorName(err));
     }
 
-    const pk_value: NativePublicKey = .{};
-    const pk_unwrapped = try env.unwrap(PublicKey, pk_value);
-    pk_unwrapped.* = data.pk_out;
-
-    const sig_value: NativeSignature = .{};
-    const sig_unwrapped = try env.unwrap(Signature, sig_value);
-    sig_unwrapped.* = data.sig_out;
+    const pk_value = napi.Value{ .env = env.env, .value = js.convertReturn(PublicKey, .{ .raw = data.pk_out }, env.env) };
+    const sig_value = napi.Value{ .env = env.env, .value = js.convertReturn(Signature, .{ .raw = data.sig_out }, env.env) };
 
     const result = try env.createObject();
     try result.setNamedProperty("pk", pk_value);
@@ -777,24 +772,25 @@ fn rejectWithError(env: napi.Env, deferred: napi.Deferred, where: []const u8, co
 /// 1) sets: Array of {pk: PublicKey, sig: Uint8Array}
 ///
 /// Returns: Promise<{pk: PublicKey, sig: Signature}>
-pub fn asyncAggregateWithRandomness(env: napi.Env, cb: napi.CallbackInfo(1)) !napi.Value {
-    const sets = cb.arg(0);
-    const n = try sets.getArrayLength();
+pub fn asyncAggregateWithRandomness(sets: js.Array) !js.Value {
+    const n = try sets.length();
 
     if (n == 0) return error.EmptyArray;
     if (n > MAX_AGGREGATE_PER_JOB) return error.TooManySets;
     if (thread_pool == null) return error.PoolNotInitialized;
 
+    const env = js.env();
+
     const data = try allocator.create(AsyncAggRandData);
     errdefer allocator.destroy(data);
 
-    data.pks = try allocator.alloc(PublicKey, n);
+    data.pks = try allocator.alloc(NativePublicKey, n);
     errdefer allocator.free(data.pks);
-    data.sigs = try allocator.alloc(Signature, n);
+    data.sigs = try allocator.alloc(NativeSignature, n);
     errdefer allocator.free(data.sigs);
-    data.pk_ptrs = try allocator.alloc(*const PublicKey, n);
+    data.pk_ptrs = try allocator.alloc(*const NativePublicKey, n);
     errdefer allocator.free(data.pk_ptrs);
-    data.sig_ptrs = try allocator.alloc(*const Signature, n);
+    data.sig_ptrs = try allocator.alloc(*const NativeSignature, n);
     errdefer allocator.free(data.sig_ptrs);
     data.randomness = try allocator.alloc(u8, n * 32);
     errdefer allocator.free(data.randomness);
@@ -807,16 +803,16 @@ pub fn asyncAggregateWithRandomness(env: napi.Env, cb: napi.CallbackInfo(1)) !na
     napi_io.get().random(data.randomness);
 
     for (0..n) |i| {
-        const set_value = try sets.getElement(@intCast(i));
+        const set = (try sets.get(@intCast(i))).toValue();
 
-        const pk_value = try set_value.getNamedProperty("pk");
-        const unwrapped_pk = try env.unwrap(PublicKey, pk_value);
-        data.pks[i] = unwrapped_pk.*;
+        const pk_napi = try set.getNamedProperty("pk");
+        const wrapped_pk = try env.unwrap(PublicKey, pk_napi);
+        data.pks[i] = wrapped_pk.raw;
         data.pk_ptrs[i] = &data.pks[i];
 
-        const sig_value = try set_value.getNamedProperty("sig");
-        const sig_bytes = try sig_value.getTypedarrayInfo();
-        data.sigs[i] = Signature.deserialize(sig_bytes.data[0..]) catch return error.DeserializationFailed;
+        const sig_napi = try set.getNamedProperty("sig");
+        const sig_bytes = try uint8SliceFromValue(.{ .val = sig_napi });
+        data.sigs[i] = NativeSignature.deserialize(sig_bytes[0..]) catch return error.DeserializationFailed;
         data.sig_ptrs[i] = &data.sigs[i];
     }
 
@@ -835,5 +831,5 @@ pub fn asyncAggregateWithRandomness(env: napi.Env, cb: napi.CallbackInfo(1)) !na
 
     try work.queue();
 
-    return data.deferred.getPromise();
+    return .{ .val = data.deferred.getPromise() };
 }

--- a/bindings/test/blst.test.ts
+++ b/bindings/test/blst.test.ts
@@ -364,7 +364,15 @@ describe("blst", () => {
       expect(typeof asyncAggregateWithRandomness).toBe("function");
     });
 
-    it("should return a Promise that resolves with aggregated pk and sig", async () => {
+    it("should return a Promise", () => {
+      const {sets} = getTestSetsSameMessage(2);
+      const input = sets.map((s) => ({pk: s.pk, sig: s.sig.toBytes()}));
+      const result = asyncAggregateWithRandomness(input);
+      expect(result).toBeInstanceOf(Promise);
+      return result;
+    });
+
+    it("should resolve with aggregated pk and sig instances", async () => {
       const {sets} = getTestSetsSameMessage(8);
       const input = sets.map((s) => ({pk: s.pk, sig: s.sig.toBytes()}));
       const result = await asyncAggregateWithRandomness(input);
@@ -372,6 +380,63 @@ describe("blst", () => {
       expect(result).toHaveProperty("sig");
       expect(result.pk).toBeInstanceOf(PublicKey);
       expect(result.sig).toBeInstanceOf(Signature);
+    });
+
+    it("should produce a valid aggregated signature", async () => {
+      const {msg, sets} = getTestSetsSameMessage(8);
+      const input = sets.map((s) => ({pk: s.pk, sig: s.sig.toBytes()}));
+      const {pk, sig} = await asyncAggregateWithRandomness(input);
+      expect(verify(msg, pk, sig, false, false)).toBe(true);
+    });
+
+    it("should work with a single set", async () => {
+      const {msg, sets} = getTestSetsSameMessage(1);
+      const input = sets.map((s) => ({pk: s.pk, sig: s.sig.toBytes()}));
+      const {pk, sig} = await asyncAggregateWithRandomness(input);
+      expect(verify(msg, pk, sig, false, false)).toBe(true);
+    });
+
+    it("should fail verification against a different message", async () => {
+      const {sets} = getTestSetsSameMessage(4);
+      const input = sets.map((s) => ({pk: s.pk, sig: s.sig.toBytes()}));
+      const {pk, sig} = await asyncAggregateWithRandomness(input);
+      const wrongMessage = new Uint8Array(32).fill(0);
+      expect(verify(wrongMessage, pk, sig, false, false)).toBe(false);
+    });
+
+    it("should match the synchronous aggregateWithRandomness verification result", async () => {
+      const {msg, sets} = getTestSetsSameMessage(6);
+      const input = sets.map((s) => ({pk: s.pk, sig: s.sig.toBytes()}));
+      const syncResult = aggregateWithRandomness(input);
+      const asyncResult = await asyncAggregateWithRandomness(input);
+      // Randomness differs between calls so signatures aren't byte-equal,
+      // but both must verify against the shared message.
+      expect(verify(msg, syncResult.pk, syncResult.sig, false, false)).toBe(true);
+      expect(verify(msg, asyncResult.pk, asyncResult.sig, false, false)).toBe(true);
+    });
+
+    it("should reject on empty input", async () => {
+      await expect(Promise.resolve().then(() => asyncAggregateWithRandomness([]))).rejects.toThrow();
+    });
+
+    it("should reject on invalid signature bytes", async () => {
+      const {sets} = getTestSetsSameMessage(4);
+      const input = sets.map((s) => ({pk: s.pk, sig: s.sig.toBytes()}));
+      input[2].sig = new Uint8Array(96).fill(0xff);
+      await expect(Promise.resolve().then(() => asyncAggregateWithRandomness(input))).rejects.toThrow();
+    });
+
+    it("should resolve concurrent invocations correctly", async () => {
+      const {msg, sets} = getTestSetsSameMessage(8);
+      const input = sets.map((s) => ({pk: s.pk, sig: s.sig.toBytes()}));
+      const results = await Promise.all([
+        asyncAggregateWithRandomness(input),
+        asyncAggregateWithRandomness(input),
+        asyncAggregateWithRandomness(input),
+      ]);
+      for (const {pk, sig} of results) {
+        expect(verify(msg, pk, sig, false, false)).toBe(true);
+      }
     });
   });
 });

--- a/bindings/test/blst.test.ts
+++ b/bindings/test/blst.test.ts
@@ -8,6 +8,7 @@ import {
   aggregateSerializedPublicKeys,
   aggregateVerify,
   aggregateWithRandomness,
+  asyncAggregateWithRandomness,
   fastAggregateVerify,
   verify,
   verifyMultipleAggregateSignatures,
@@ -355,6 +356,22 @@ describe("blst", () => {
       const input = sets.map((s) => ({pk: s.pk, sig: s.sig.toBytes()}));
       input[2].sig = new Uint8Array(96).fill(0xff);
       expect(() => aggregateWithRandomness(input)).toThrow();
+    });
+  });
+
+  describe("asyncAggregateWithRandomness", () => {
+    it("should be exported as a function", () => {
+      expect(typeof asyncAggregateWithRandomness).toBe("function");
+    });
+
+    it("should return a Promise that resolves with aggregated pk and sig", async () => {
+      const {sets} = getTestSetsSameMessage(8);
+      const input = sets.map((s) => ({pk: s.pk, sig: s.sig.toBytes()}));
+      const result = await asyncAggregateWithRandomness(input);
+      expect(result).toHaveProperty("pk");
+      expect(result).toHaveProperty("sig");
+      expect(result.pk).toBeInstanceOf(PublicKey);
+      expect(result.sig).toBeInstanceOf(Signature);
     });
   });
 });


### PR DESCRIPTION
### Summary

`asyncAggregateWithRandomness` was declared as a `pub fn` in `bindings/napi/blst.zig` and re-exported from `bindings/src/blst.js`, but at runtime the JS-side binding was `undefined`. This PR rewrites the function to use the zapi DSL so it is actually registered as a JS export.

### Root cause

zapi's `exportModule` auto-registration (`export_module.zig`, `wrap_function.zig:isDslOrOptionalDsl`) only picks up a `pub fn` when **all** of its parameters are DSL types (`napi.Value`, DSL wrappers like `js.Array`, or class types). The previous signature

  ```zig
  pub fn asyncAggregateWithRandomness(env: napi.Env, cb: napi.CallbackInfo(1)) !napi.Value
```

uses raw NAPI types, so the function was silently skipped at registration. Because Zig is lazy about analyzing unreferenced functions, this also hid several internal bugs in the body that would otherwise have failed to compile.

### Test plan

- `pnpm test` 
- `zig build build-lib:bindings -Doptimize=ReleaseSafe` builds cleanly.