### PR TITLE
refactor: update APIs related to voluntary exits

### DIFF
--- a/bindings/napi/BeaconStateView.zig
+++ b/bindings/napi/BeaconStateView.zig
@@ -672,6 +672,7 @@ pub fn proposerRewards(self: *const BeaconStateView) !js_types.ProposerRewards {
 /// `{message: {epoch, validatorIndex}, signature: Uint8Array(96)}`. Matches `phase0.SignedVoluntaryExit`
 /// from `@lodestar/types`.
 fn signedVoluntaryExitFromJsValue(value: js.Value, out: *ct.phase0.SignedVoluntaryExit.Type) !void {
+    std.debug.assert(value.val != null);
     const raw = value.toValue();
     const message = try raw.getNamedProperty("message");
     out.message.epoch = @intCast(try (try message.getNamedProperty("epoch")).getValueInt64());
@@ -686,6 +687,7 @@ fn signedVoluntaryExitFromJsValue(value: js.Value, out: *ct.phase0.SignedVolunta
 }
 
 pub fn getVoluntaryExitValidity(self: *const BeaconStateView, signed_exit_value: js.Value, verify_signature_value: js.Boolean) !js.String {
+    std.debug.assert(self.cached_state != null);
     const env = js.env();
     const cached_state = try self.requireState();
     const verify_signature = verify_signature_value.assertBool();
@@ -713,6 +715,7 @@ pub fn getVoluntaryExitValidity(self: *const BeaconStateView, signed_exit_value:
 }
 
 pub fn isValidVoluntaryExit(self: *const BeaconStateView, signed_exit_value: js.Value, verify_signature_value: js.Boolean) !js.Boolean {
+    std.debug.assert(self.cached_state != null);
     const cached_state = try self.requireState();
     const verify_signature = verify_signature_value.assertBool();
 

--- a/bindings/napi/BeaconStateView.zig
+++ b/bindings/napi/BeaconStateView.zig
@@ -668,24 +668,31 @@ pub fn proposerRewards(self: *const BeaconStateView) !js_types.ProposerRewards {
     return .{ .val = obj };
 }
 
-// pub fn BeaconStateView_computeBlockRewards
+/// Populate a `SignedVoluntaryExit.Type` from a JS object of shape
+/// `{message: {epoch, validatorIndex}, signature: Uint8Array(96)}`. Matches `phase0.SignedVoluntaryExit`
+/// from `@lodestar/types`.
+fn signedVoluntaryExitFromJsValue(value: js.Value, out: *ct.phase0.SignedVoluntaryExit.Type) !void {
+    const raw = value.toValue();
+    const message = try raw.getNamedProperty("message");
+    out.message.epoch = @intCast(try (try message.getNamedProperty("epoch")).getValueInt64());
+    out.message.validator_index = @intCast(try (try message.getNamedProperty("validatorIndex")).getValueInt64());
 
-// pub fn BeaconStateView_computeAttestationRewards
+    const signature = try raw.getNamedProperty("signature");
+    if (!(try signature.isTypedarray())) return error.SignatureNotTypedArray;
+    const info = try signature.getTypedarrayInfo();
+    if (info.array_type != .uint8) return error.SignatureNotUint8Array;
+    if (info.data.len != out.signature.len) return error.InvalidSignatureLength;
+    @memcpy(&out.signature, info.data);
+}
 
-// pub fn BeaconStateView_computeSyncCommitteeRewards
-
-// pub fn BeaconStateView_getLatestWeakSubjectivityCheckpointEpoch
-
-/// Get the validity status of a signed voluntary exit.
-pub fn getVoluntaryExitValidity(self: *const BeaconStateView, signed_exit_bytes: js.Uint8Array, verify_signature_value: js.Boolean) !js.String {
+pub fn getVoluntaryExitValidity(self: *const BeaconStateView, signed_exit_value: js.Value, verify_signature_value: js.Boolean) !js.String {
     const env = js.env();
     const cached_state = try self.requireState();
     const verify_signature = verify_signature_value.assertBool();
-    const bytes = try signed_exit_bytes.toSlice();
 
     var signed_voluntary_exit: ct.phase0.SignedVoluntaryExit.Type = ct.phase0.SignedVoluntaryExit.default_value;
-    ct.phase0.SignedVoluntaryExit.deserializeFromBytes(bytes, &signed_voluntary_exit) catch {
-        return throwNullAs(js.String, "DESERIALIZE_ERROR", "Failed to deserialize SignedVoluntaryExit");
+    signedVoluntaryExitFromJsValue(signed_exit_value, &signed_voluntary_exit) catch {
+        return throwNullAs(js.String, "INVALID_ARG", "Failed to read SignedVoluntaryExit from JS object");
     };
 
     const result = switch (cached_state.state.forkSeq()) {
@@ -705,15 +712,13 @@ pub fn getVoluntaryExitValidity(self: *const BeaconStateView, signed_exit_bytes:
     return .{ .val = try env.createStringUtf8(@tagName(validity)) };
 }
 
-/// Check if a signed voluntary exit is valid.
-pub fn isValidVoluntaryExit(self: *const BeaconStateView, signed_exit_bytes: js.Uint8Array, verify_signature_value: js.Boolean) !js.Boolean {
+pub fn isValidVoluntaryExit(self: *const BeaconStateView, signed_exit_value: js.Value, verify_signature_value: js.Boolean) !js.Boolean {
     const cached_state = try self.requireState();
     const verify_signature = verify_signature_value.assertBool();
-    const bytes = try signed_exit_bytes.toSlice();
 
     var signed_voluntary_exit: ct.phase0.SignedVoluntaryExit.Type = ct.phase0.SignedVoluntaryExit.default_value;
-    ct.phase0.SignedVoluntaryExit.deserializeFromBytes(bytes, &signed_voluntary_exit) catch {
-        return throwNullAs(js.Boolean, "DESERIALIZE_ERROR", "Failed to deserialize SignedVoluntaryExit");
+    signedVoluntaryExitFromJsValue(signed_exit_value, &signed_voluntary_exit) catch {
+        return throwNullAs(js.Boolean, "INVALID_ARG", "Failed to read SignedVoluntaryExit from JS object");
     };
 
     const result = switch (cached_state.state.forkSeq()) {

--- a/bindings/src/index.d.ts
+++ b/bindings/src/index.d.ts
@@ -11,6 +11,16 @@ interface Checkpoint {
   root: Uint8Array;
 }
 
+interface VoluntaryExit {
+  epoch: number;
+  validatorIndex: number;
+}
+
+interface SignedVoluntaryExit {
+  message: VoluntaryExit;
+  signature: Uint8Array;
+}
+
 interface Eth1Data {
   depositRoot: Uint8Array;
   depositCount: number;
@@ -195,8 +205,8 @@ declare class BeaconStateView {
   // computeSyncCommitteeRewards(block: BeaconBlock, validatorIds?: (number | string)[]): SyncCommitteeRewards;
   // getLatestWeakSubjectivityCheckpointEpoch(): number;
 
-  getVoluntaryExitValidity(signedVoluntaryExitBytes: Uint8Array, verifySignature: boolean): VoluntaryExitValidity;
-  isValidVoluntaryExit(signedVoluntaryExitBytes: Uint8Array, verifySignature: boolean): boolean;
+  getVoluntaryExitValidity(signedVoluntaryExit: SignedVoluntaryExit, verifySignature: boolean): VoluntaryExitValidity;
+  isValidVoluntaryExit(signedVoluntaryExit: SignedVoluntaryExit, verifySignature: boolean): boolean;
 
   getFinalizedRootProof(): Uint8Array[];
   // getSyncCommitteesWitness(): any;

--- a/bindings/test/beaconStateView.test.ts
+++ b/bindings/test/beaconStateView.test.ts
@@ -514,15 +514,19 @@ describe("BeaconStateView", () => {
 
   describe("voluntary exit validation", () => {
     it("isValidVoluntaryExit should return boolean", () => {
-      // Invalid voluntary exit bytes (all zeros)
-      const invalidExit = new Uint8Array(112);
+      const invalidExit = {
+        message: {epoch: 0, validatorIndex: 0},
+        signature: new Uint8Array(96),
+      };
       const result = state.isValidVoluntaryExit(invalidExit, false);
       expect(typeof result).toBe("boolean");
     });
 
     it("getVoluntaryExitValidity should return validity reason", () => {
-      // Invalid voluntary exit bytes (all zeros)
-      const invalidExit = new Uint8Array(112);
+      const invalidExit = {
+        message: {epoch: 0, validatorIndex: 0},
+        signature: new Uint8Array(96),
+      };
       const result = state.getVoluntaryExitValidity(invalidExit, false);
 
       const validReasons = [

--- a/bindings/test/demo.ts
+++ b/bindings/test/demo.ts
@@ -115,8 +115,12 @@ printDuration("pendingPartialWithdrawals", () => state.pendingPartialWithdrawals
 printDuration("pendingConsolidations", () => state.pendingConsolidations);
 printDuration("proposerLookahead", () => state.proposerLookahead);
 printDuration("getSingleProof(169)", () => state.getSingleProof(169));
-printDuration("isValidVoluntaryExit", () => state.isValidVoluntaryExit(new Uint8Array(112), false));
-printDuration("getVoluntaryExitValidity", () => state.getVoluntaryExitValidity(new Uint8Array(112), false));
+const invalidVoluntaryExit = {
+  message: {epoch: 0, validatorIndex: 0},
+  signature: new Uint8Array(96),
+};
+printDuration("isValidVoluntaryExit", () => state.isValidVoluntaryExit(invalidVoluntaryExit, false));
+printDuration("getVoluntaryExitValidity", () => state.getVoluntaryExitValidity(invalidVoluntaryExit, false));
 printDuration("createMultiProof(descriptor for gindex 42)", () =>
   state.createMultiProof(Uint8Array.from([0x25, 0xe0]))
 );


### PR DESCRIPTION
In lodestar, once a `SignedVoluntaryExit` is received via gossip, we deserialize and deal with the object directly, same with the functions in lodestar-z. So we deal with passing it as a js object and walking its properties to build a native struct (which should be cheap anyway since the struct is small)

part of #347 