### PR TITLE
fix(bindings): misordering of print for cpu count

### DIFF
--- a/bindings/napi/root.zig
+++ b/bindings/napi/root.zig
@@ -20,8 +20,8 @@ fn init(old_ref_count: u32) !void {
 
         var cpu_count: u64 = options.thread_count;
         if (options.thread_count == 0) {
-            std.debug.print("Note: no -Dthread-count set, will use runtime CPU count minus 1: {}\n", .{cpu_count});
             cpu_count = @max((try std.Thread.getCpuCount()) - 1, 1);
+            std.debug.print("Note: no -Dthread-count set, will use runtime CPU count minus 1: {}\n", .{cpu_count});
         }
 
         const n_workers = @min(cpu_count, @import("bls").ThreadPool.MAX_WORKERS);


### PR DESCRIPTION
as title says, we were printing 0 because the print was misplaced