### PR TITLE
fix(blst): default signature infinity check to true if not provided

### DIFF
--- a/bindings/napi/blst.zig
+++ b/bindings/napi/blst.zig
@@ -172,7 +172,7 @@ pub const Signature = struct {
         const slice = try bytes.toSlice();
         var sig = NativeSignature.deserialize(slice) catch return error.DeserializationFailed;
         if (try boolOrDefault(sig_validate, false)) {
-            try sig.validate(try boolOrDefault(sig_infcheck, false));
+            try sig.validate(try boolOrDefault(sig_infcheck, true));
         }
         return .{ .raw = sig };
     }


### PR DESCRIPTION
`Signature.fromBytes` should do infinity check by default if not provided as an argument (in other words provided as `null`)

source: https://github.com/ChainSafe/blst-ts/blob/86c49590d37d4e1dd44b3b5ba604132f3b51d99d/src/lib.rs#L301