### PR TITLE
chore(deps): compile blst with ReleaseFast

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -22,6 +22,10 @@
         .blst = .{
             .url = "git+https://github.com/ChainSafe/blst.zig.git#5d9543be8a7a1a9942c62a097644286751f95dc7",
             .hash = "blst_zig-0.0.0-cnAxzisLAADc_A14MqXu_f_rLBRS6m6ki8zHrUjLXYoo",
+            .args = .{
+                .optimize = .ReleaseFast,
+                .portable = true,
+            },
         },
         .hashtree = .{
             .url = "git+https://github.com/ChainSafe/hashtree-z.git#81b7303f72e202e966f71eedf4be1d8d33e2fcaa",


### PR DESCRIPTION
By default --release on cargo build also compiles with a lot less guarantee checks, so we should do the same on the blst level