### PR TITLE
fix(state-transition): repair Pool.init call broken by #346×#367 merge skew

### DIFF
--- a/src/state_transition/sync_committees_witness.zig
+++ b/src/state_transition/sync_committees_witness.zig
@@ -145,7 +145,7 @@ const ProofFixture = struct {
 
     fn init(fork: ForkSeq) !ProofFixture {
         const allocator = std.testing.allocator;
-        var pool = try Node.Pool.init(allocator, 500_000);
+        var pool = try Node.Pool.init(.{ .page_allocator = allocator, .allocator = allocator, .pool_size = 500_000 });
         errdefer pool.deinit();
 
         var state = switch (fork) {


### PR DESCRIPTION
## Problem

`main` CI is red: the `build & test` job fails to **compile** `test:state_transition`:

\`\`\`
src/state_transition/sync_committees_witness.zig:148:33: error: expected 1 argument(s), found 2
    pub fn init(opts: InitOptions) Error!Pool {
\`\`\`

## Root cause — a semantic merge conflict (merge skew)

- **#346** (chunked-leaf) changed `Node.Pool.init(allocator, pool_size)` → `Node.Pool.init(opts: InitOptions)` (2 positional args → 1 options struct).
- **#367** (`getSyncCommitteesWitness`) landed `sync_committees_witness.zig` in parallel, still calling the **old 2-arg** form: `Node.Pool.init(allocator, 500_000)`.

Both PR branches were green because neither tree contained the *combination*: #346's branch didn't have `sync_committees_witness.zig` (it predates #367 and was never updated to the latest `main`), and #367's base still had the old `Pool.init`. Merging #346 into a `main` that already had #367 produced code git merged cleanly (different files, no textual conflict) but which no longer compiles.

## Fix

One line — update the stale call site to the new `InitOptions` form (matching every other PMT test in the repo, both fields pinned to the testing allocator for leak tracking). `git grep` confirms this is the only remaining old-style call site.

## Verification

`zig build test:state_transition` → **96/96 tests passed** (was: compile error).

## Prevention

Consider enabling **"Require branches to be up to date before merging"** or a **GitHub merge queue** so PR CI runs against the real post-merge tree and catches this class of logical conflict that git can't see.