### PR TITLE
feat(bindings): aggregate cached public keys by validator index

### DIFF
--- a/bindings/napi/pubkeys.zig
+++ b/bindings/napi/pubkeys.zig
@@ -11,6 +11,7 @@ const napi_io = @import("./io.zig");
 const allocator = std.heap.page_allocator;
 
 const default_initial_capacity: u32 = 0;
+const max_stack_aggregate_pubkeys = 512;
 
 pub const State = struct {
     pubkey2index: PubkeyIndexMap = undefined,
@@ -173,6 +174,46 @@ pub fn get(index: js.Number) !?blst_bindings.PublicKey {
     if (idx >= state.index2pubkey.items.len) return null;
 
     return .{ .raw = state.index2pubkey.items[@intCast(idx)] };
+}
+
+/// Aggregate multiple `PublicKey`s by the given
+/// validator `indices` into one.
+///
+/// Validation is not required here since it is done upon
+/// processing validator deposits.
+///
+/// JS: pubkeys.aggregate(indices) → PublicKey
+pub fn aggregate(indices: js.Array) !blst_bindings.PublicKey {
+    if (!state.initialized) return error.PubkeyIndexNotInitialized;
+
+    const len = try indices.length();
+    if (len == 0) return error.EmptyPublicKeyArray;
+
+    if (len == 1) {
+        const idx = try (try indices.getNumber(0)).toU32();
+        if (idx >= state.index2pubkey.items.len) return error.PubkeyIndexNotFound;
+        return .{ .raw = state.index2pubkey.items[@intCast(idx)] };
+    }
+
+    var pks_stack: [max_stack_aggregate_pubkeys]bls.PublicKey = undefined;
+    const pks = if (len <= pks_stack.len)
+        pks_stack[0..len]
+    else blk: {
+        const buf = try allocator.alloc(bls.PublicKey, len);
+        break :blk buf;
+    };
+    defer if (len > pks_stack.len) allocator.free(pks);
+
+    for (0..len) |i| {
+        const idx = try (try indices.getNumber(@intCast(i))).toU32();
+        if (idx >= state.index2pubkey.items.len) return error.PubkeyIndexNotFound;
+        pks[i] = state.index2pubkey.items[@intCast(idx)];
+    }
+
+    const agg_pk = bls.AggregatePublicKey.aggregate(pks, false) catch
+        return error.AggregationFailed;
+
+    return .{ .raw = agg_pk.toPublicKey() };
 }
 
 /// JS: pubkeys.set(index, pubkeyBytes)

--- a/bindings/src/pubkeys.d.ts
+++ b/bindings/src/pubkeys.d.ts
@@ -5,6 +5,8 @@ export interface PubkeyCache {
   get(index: number): PublicKey | undefined;
   /** Same as get(), but throws if the index is not in the cache */
   getOrThrow(index: number): PublicKey;
+  /** Aggregate cached public keys by validator index */
+  aggregate(indices: number[]): PublicKey;
   /** Get validator index by pubkey bytes */
   getIndex(pubkey: Uint8Array): number | null;
   /** Set both directions atomically — impl owns the PublicKey.fromBytes() deserialization */

--- a/bindings/src/pubkeys.js
+++ b/bindings/src/pubkeys.js
@@ -25,6 +25,11 @@ export const pubkeyCache = {
     return pk;
   },
 
+  aggregate(indices) {
+    if (indices.length === 1) return pubkeyCache.getOrThrow(indices[0]);
+    return native.aggregate(indices);
+  },
+
   getIndex(pubkey) {
     return native.getIndex(pubkey);
   },

--- a/bindings/test/pubkeys.test.ts
+++ b/bindings/test/pubkeys.test.ts
@@ -2,7 +2,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import {afterAll, beforeAll, describe, expect, it} from "vitest";
-import {SecretKey} from "../src/blst.js";
+import {SecretKey, aggregatePublicKeys} from "../src/blst.js";
 import {pubkeyCache} from "../src/pubkeys.js";
 
 // Generate deterministic valid BLS keypairs for testing
@@ -41,6 +41,16 @@ describe("pubkeys", () => {
     const pk1 = pubkeyCache.get(0);
     const pk2 = pubkeyCache.get(0);
     expect(pk1).toBe(pk2);
+  });
+
+  it("aggregates cached pubkeys by index", () => {
+    const indices = [0, 1, 2];
+    const expected = aggregatePublicKeys(indices.map((index) => pubkeyCache.getOrThrow(index)));
+    expect(pubkeyCache.aggregate(indices).toBytes()).toEqual(expected.toBytes());
+  });
+
+  it("returns the cached pubkey for a single-key aggregate", () => {
+    expect(pubkeyCache.aggregate([1]).toBytes()).toEqual(pubkeyCache.getOrThrow(1).toBytes());
   });
 
   it("get returns undefined for out-of-range index", () => {


### PR DESCRIPTION
Instead of getting the pk from cache and then passing it back through napi, we just pass the already known indices into the native layer and let the cache do the work.

On `feat3-super`, this halved pk aggregation time (8s to 4s):

<img width="731" height="290" alt="Screenshot 2026-06-09 at 5 26 16 PM" src="https://github.com/user-attachments/assets/0d4d0f1a-7097-4dac-bbf1-5b18db641c55" />

Notably, sig set verification time per set went up (530us -> 600us), but I suspect this is due to it becoming the bottleneck now. Job wait time has gone down (37-38ms to about 31-32ms), and we're doing less verifications in batches (88% to 87% roughly)

<img width="1463" height="777" alt="Screenshot 2026-06-09 at 5 27 09 PM" src="https://github.com/user-attachments/assets/4b68ec69-f29f-4620-9ebb-26691e7dd451" />

block processing looks better with this:

<img width="737" height="573" alt="Screenshot 2026-06-09 at 5 29 44 PM" src="https://github.com/user-attachments/assets/2f6bc9a7-36fc-4bbd-8b30-4baa3007281e" />

verification metrics across the board trending down with this:

<img width="1460" height="829" alt="Screenshot 2026-06-09 at 5 30 39 PM" src="https://github.com/user-attachments/assets/7ceeeb99-fd9a-4a2b-93ec-3736078c5b47" />
