### PR TITLE
fix(pmt,ssz): harden chunked-leaf and zero-copy tree-view memory safety

### DIFF
--- a/src/persistent_merkle_tree/ChunkedLeaf.zig
+++ b/src/persistent_merkle_tree/ChunkedLeaf.zig
@@ -4,7 +4,6 @@
 //! array + length) referenced by one `.chunked_leaf` Node. Self-contained,
 //! ref-counted via the Pool's Node ref count, copy-on-write on mutation.
 const std = @import("std");
-const Allocator = std.mem.Allocator;
 const hashing = @import("hashing");
 const hash = hashing.hash;
 
@@ -32,13 +31,14 @@ len: u16,
 /// padding. Each reduction is one batched `hash()` call so hashtree's
 /// SIMD lanes stay saturated.
 ///
-/// `scratch` is a caller-supplied K/2-element buffer. `computeRootAllocating`
-/// wraps this with a per-call `allocator.alignedAlloc` + free.
+/// `scratch` is a caller-supplied K/2-element buffer, so root computation is allocation-free
+/// and infallible.
 ///
 /// First round reads `chunks` directly into `scratch` (avoids the
 /// in-place mutation that `hashing.merkleize` would require on `*const
 /// chunks`). Later rounds halve in-place on `scratch`.
 pub fn computeRoot(self: *const ChunkedLeaf, scratch: *align(64) [K / 2][32]u8, out: *[32]u8) void {
+    for (self.chunks[self.len..]) |*chunk| std.debug.assert(std.mem.allEqual(u8, chunk, 0));
     hash(scratch[0..], self.chunks[0..]) catch unreachable;
 
     var width: usize = K / 2;
@@ -47,14 +47,6 @@ pub fn computeRoot(self: *const ChunkedLeaf, scratch: *align(64) [K / 2][32]u8, 
     }
 
     out.* = scratch[0];
-}
-
-/// `computeRoot` wrapper that owns the scratch via `allocator`.
-pub fn computeRootAllocating(self: *const ChunkedLeaf, allocator: Allocator, out: *[32]u8) void {
-    const scratch_slice = allocator.alignedAlloc([32]u8, .@"64", K / 2) catch @panic("OOM");
-    defer allocator.free(scratch_slice);
-    const scratch_arr: *align(64) [K / 2][32]u8 = @ptrCast(scratch_slice.ptr);
-    self.computeRoot(scratch_arr, out);
 }
 
 const Node = @import("Node.zig");

--- a/src/persistent_merkle_tree/Node.zig
+++ b/src/persistent_merkle_tree/Node.zig
@@ -261,6 +261,9 @@ pub const Pool = struct {
     allocator: Allocator,
     nodes: std.MultiArrayList(Node).Slice,
     next_free_node: Id,
+    // Reused scratch for chunked_leaf root recompute: single-threaded, and chunked_leaf is a leaf
+    // of getRoot's recursion, so at most one computeRoot uses it at a time.
+    chunked_leaf_scratch: [ChunkedLeaf.K / 2][32]u8 align(64),
 
     pub const InitOptions = struct {
         page_allocator: Allocator = std.heap.page_allocator,
@@ -278,6 +281,7 @@ pub const Pool = struct {
             .allocator = opts.allocator,
             .nodes = undefined,
             .next_free_node = @enumFromInt(max_depth),
+            .chunked_leaf_scratch = undefined,
         };
 
         var list = std.MultiArrayList(Node).empty;
@@ -776,7 +780,7 @@ pub const Id = enum(u32) {
                 }
                 const storage = chunkedLeafPtr(pool.nodes.items(.payload), idx);
                 var hash: [32]u8 = undefined;
-                storage.computeRootAllocating(pool.allocator, &hash);
+                storage.computeRoot(&pool.chunked_leaf_scratch, &hash);
                 roots[idx] = hash;
                 return &roots[idx];
             },
@@ -822,6 +826,7 @@ pub const Id = enum(u32) {
     pub fn getChunkedLeafPtr(node_id: Id, pool: *Pool) Error!*ChunkedLeaf {
         const idx = @intFromEnum(node_id);
         if (pool.nodes.items(.state)[idx].kind() != .chunked_leaf) return Error.InvalidNode;
+        std.debug.assert(pool.nodes.items(.state)[idx].refCount() == 0);
         return chunkedLeafPtr(pool.nodes.items(.payload), idx);
     }
 
@@ -1529,92 +1534,6 @@ pub const Id = enum(u32) {
         return node_id;
     }
 };
-
-/// Fill a view to the specified depth, returning the new root node id.
-pub fn fillToDepth(pool: *Pool, bottom: Id, depth: Depth) Error!Id {
-    var d = depth;
-    var node = bottom;
-    while (d > 0) : (d -= 1) {
-        node = try pool.createBranch(node, node);
-    }
-
-    return node;
-}
-
-/// Fill a view to the specified length and depth, returning the new root node id.
-pub fn fillToLength(pool: *Pool, leaf: Id, depth: Depth, length: usize) Error!Id {
-    const max_length = @as(Gindex.Uint, 1) << depth;
-    if (length > max_length) {
-        return Error.InvalidLength;
-    }
-
-    // fill a full view to the specified depth
-    var node_id = try fillToDepth(pool, leaf, depth);
-
-    // if the requested length is the same as the max length, return the node
-    if (length == max_length) {
-        return node_id;
-    }
-
-    // otherwise, traverse down to the specified length
-    const gindex: Gindex = @enumFromInt(max_length | length);
-    const path_len = gindex.pathLen();
-    var path = gindex.toPath();
-
-    var parents_buf: [max_depth]Id = undefined;
-    var lefts_buf: [max_depth]Id = undefined;
-    var rights_buf: [max_depth]Id = undefined;
-
-    const path_parents = parents_buf[0..path_len];
-    const path_lefts = lefts_buf[0..path_len];
-    const path_rights = rights_buf[0..path_len];
-
-    const states = pool.nodes.items(.state);
-    const payloads = pool.nodes.items(.payload);
-
-    for (0..path_len - 1) |i| {
-        const idx = @intFromEnum(node_id);
-        const k = states[idx].kind();
-        if (noChildKind(node_id, k)) {
-            return Error.InvalidNode;
-        }
-        const c = childrenOf(node_id, k, payloads);
-        if (path.left()) {
-            path_lefts[i] = path_parents[i + 1];
-            path_rights[i] = c.right;
-            node_id = c.left;
-        } else {
-            path_lefts[i] = c.left;
-            path_rights[i] = path_parents[i + 1];
-            node_id = c.right;
-        }
-        path.next();
-    }
-
-    // and rebind with zero(0)
-    {
-        const idx = @intFromEnum(node_id);
-        const k = states[idx].kind();
-        if (noChildKind(node_id, k)) return Error.InvalidNode;
-        const c = childrenOf(node_id, k, payloads);
-        if (path.left()) {
-            path_lefts[path_len - 1] = @enumFromInt(0);
-            path_rights[path_len - 1] = c.right;
-        } else {
-            path_lefts[path_len - 1] = c.left;
-            path_rights[path_len - 1] = @enumFromInt(0);
-        }
-    }
-
-    // and rebind with zero(0)
-    try pool.rebind(
-        path_parents,
-        path_lefts,
-        path_rights,
-    );
-
-    return path_parents[0];
-}
 
 /// Fill a view with the specified contents, returning the new root node id.
 ///

--- a/src/persistent_merkle_tree/node_test.zig
+++ b/src/persistent_merkle_tree/node_test.zig
@@ -5,6 +5,7 @@ const Depth = @import("hashing").Depth;
 
 const Node = @import("Node.zig");
 const Gindex = @import("gindex.zig").Gindex;
+const ChunkedLeaf = @import("ChunkedLeaf.zig");
 
 // Allocate until the pool is full, so the next request has to grow (and fail). Returns the filler.
 fn drainPoolToFull(pool: *Node.Pool, out: *std.ArrayList(Node.Id)) !void {
@@ -123,6 +124,22 @@ test "Node.State predicates" {
     try std.testing.expect(!free_state.isBranch());
     // Free slots expose the next-free link via `state.nextFree()`.
     _ = free_state.nextFree();
+}
+
+test "chunked_leaf getRoot recomputes without touching the pool allocator" {
+    var counter = std.testing.FailingAllocator.init(std.testing.allocator, .{ .fail_index = std.math.maxInt(usize) });
+    var pool = try Node.Pool.init(.{ .page_allocator = std.testing.allocator, .allocator = counter.allocator(), .pool_size = 16 });
+    defer pool.deinit();
+
+    var chunks: [ChunkedLeaf.K][32]u8 align(64) = undefined;
+    for (&chunks, 0..) |*c, i| c.* = [_]u8{@intCast(i & 0xff)} ** 32;
+
+    const node = try pool.createChunkedLeaf(&chunks, ChunkedLeaf.K);
+    defer pool.unref(node);
+
+    const allocs_before = counter.alloc_index;
+    _ = node.getRoot(&pool); // root starts lazy → this recomputes
+    try std.testing.expectEqual(allocs_before, counter.alloc_index);
 }
 
 test "Pool" {

--- a/src/persistent_merkle_tree/proof.zig
+++ b/src/persistent_merkle_tree/proof.zig
@@ -564,7 +564,7 @@ pub fn createNodeFromCompactMultiProof(
     leaves: [][32]u8,
     descriptor: []const u8,
 ) (Node.Error || Error)!Node.Id {
-    var arena = std.heap.ArenaAllocator.init(pool.page_allocator);
+    var arena = std.heap.ArenaAllocator.init(pool.allocator);
     defer arena.deinit();
     const temp_allocator = arena.allocator();
 

--- a/src/ssz/tree_view/array_basic.zig
+++ b/src/ssz/tree_view/array_basic.zig
@@ -174,6 +174,46 @@ test "TreeView vector element roundtrip" {
     try std.testing.expectEqualSlices(u64, &expected, &roundtrip);
 }
 
+test "TreeView vector chunked_leaf roundtrip across the chunked_leaf boundary" {
+    const allocator = std.testing.allocator;
+    var pool = try Node.Pool.init(.{ .page_allocator = allocator, .allocator = allocator, .pool_size = 4096 });
+    defer pool.deinit();
+
+    const Uint64 = UintType(64);
+    const VectorType = FixedVectorType(Uint64, 276, .{ .chunked_leaf = true });
+
+    var original: VectorType.Type = undefined;
+    for (&original, 0..) |*e, i| e.* = i;
+
+    const root_node = try VectorType.tree.fromValue(&pool, &original);
+    var view = try VectorType.TreeView.init(allocator, &pool, root_node);
+    defer view.deinit();
+
+    try std.testing.expectEqual(@as(u64, 0), try view.get(0));
+    try std.testing.expectEqual(@as(u64, 255), try view.get(255));
+    try std.testing.expectEqual(@as(u64, 256), try view.get(256));
+    try std.testing.expectEqual(@as(u64, 275), try view.get(275));
+
+    try view.set(255, 999);
+    try view.set(256, 1000);
+    try view.commit();
+
+    var expected = original;
+    expected[255] = 999;
+    expected[256] = 1000;
+
+    var expected_root: [32]u8 = undefined;
+    try VectorType.hashTreeRoot(&expected, &expected_root);
+
+    var actual_root: [32]u8 = undefined;
+    try view.hashTreeRootInto(&actual_root);
+    try std.testing.expectEqualSlices(u8, &expected_root, &actual_root);
+
+    var roundtrip: VectorType.Type = undefined;
+    try VectorType.tree.toValue(view.getRoot(), &pool, &roundtrip);
+    try std.testing.expectEqualSlices(u64, &expected, &roundtrip);
+}
+
 test "TreeView vector getAll fills provided buffer" {
     const allocator = std.testing.allocator;
     var pool = try Node.Pool.init(.{ .page_allocator = allocator, .allocator = allocator, .pool_size = 256 });

--- a/src/ssz/tree_view/chunks.zig
+++ b/src/ssz/tree_view/chunks.zig
@@ -442,20 +442,16 @@ pub fn CompositeChunks(
             return child_ptr;
         }
 
-        /// Takes ownership of `value` (and deinits it if a reservation fails). Deinits whatever
-        /// child was cached for `index`, so any earlier get()/getReadonly() of it is now invalid.
-        /// Pass a view you own — never a get()/getReadonly() pointer for this same index, or a
-        /// failed set would deinit a view the cache still holds (double-free).
+        /// Takes ownership of `value` only on success; on any error `value` is left untouched for
+        /// the caller to free. Deinits whatever child was cached for `index`, so any earlier
+        /// get()/getReadonly() of it is now invalid. Pass a view you own — never a
+        /// get()/getReadonly() pointer for this same index, or the displaced-old deinit would free a
+        /// view the cache still holds (double-free).
         pub fn set(self: *Self, index: usize, value: ElementPtr) !void {
             const gindex = Gindex.fromDepth(chunk_depth, index);
-            // Reserve before storing so neither store can fail. A failure mid-store would drop
-            // `value` (we own it now, the caller won't free it) or leave `changed` and
-            // `children_data` out of sync.
-            {
-                errdefer value.deinit();
-                try self.state.changed.ensureUnusedCapacity(self.state.allocator, 1);
-                try self.children_data.ensureUnusedCapacity(self.state.allocator, 1);
-            }
+            // Reserve first so the commit below cannot fail.
+            try self.state.changed.ensureUnusedCapacity(self.state.allocator, 1);
+            try self.children_data.ensureUnusedCapacity(self.state.allocator, 1);
             self.state.changed.putAssumeCapacity(gindex, {});
             const opt_old_data = self.children_data.fetchPutAssumeCapacity(gindex, value);
             if (opt_old_data) |old_data_value| {
@@ -505,12 +501,11 @@ pub fn CompositeChunks(
         /// Set a child from an SSZ value type.
         pub fn setValue(self: *Self, index: usize, value: *const Value) !void {
             const root = try ST.Element.tree.fromValue(self.state.pool, value);
-            // Free `root` only if init fails. Once init succeeds, `set` owns `child_view` on every
-            // path, so we must not deinit it here; that would double-free if set later fails.
             const child_view = Element.init(self.state.allocator, self.state.pool, root) catch |err| {
                 self.state.pool.unref(root);
                 return err;
             };
+            errdefer child_view.deinit();
             try self.set(index, child_view);
         }
 

--- a/src/ssz/tree_view/container.zig
+++ b/src/ssz/tree_view/container.zig
@@ -36,6 +36,9 @@ pub fn ContainerTreeView(comptime ST: type) type {
         /// whether the corresponding child node/data has changed since the last update of the root
         changed: std.StaticBitSet(ST.chunk_count),
         original_nodes: [ST.chunk_count]?Node.Id,
+        /// Stable backing store for `getFieldRoot` return pointers on dirty basic fields, so the
+        /// temporary PMT node can be unref'd instead of leaking a Pool slot per call.
+        field_root_cache: [ST.chunk_count][32]u8,
         pub const SszType = ST;
 
         const Self = @This();
@@ -54,6 +57,7 @@ pub fn ContainerTreeView(comptime ST: type) type {
                 .original_nodes = .{null} ** ST.chunk_count,
                 .root = root,
                 .changed = std.StaticBitSet(ST.chunk_count).initEmpty(),
+                .field_root_cache = undefined,
             };
             return ptr;
         }
@@ -290,6 +294,7 @@ pub fn ContainerTreeView(comptime ST: type) type {
 
         pub fn deserialize(allocator: Allocator, pool: *Node.Pool, bytes: []const u8) !*Self {
             const root = try ST.tree.deserializeFromBytes(pool, bytes);
+            errdefer pool.unref(root);
             return try Self.init(allocator, pool, root);
         }
 
@@ -331,12 +336,13 @@ pub fn ContainerTreeView(comptime ST: type) type {
             const field_index = comptime ST.getFieldIndex(field_name);
             const ChildST = ST.getFieldType(field_name);
             if (comptime isBasicType(ChildST)) {
-                // For basic types, get the node at the field's position and return its root
-                const node = if (self.child_data[field_index]) |child_value| blk: {
-                    break :blk try ChildST.tree.fromValue(self.pool, &child_value);
-                } else blk: {
-                    break :blk try self.root.getNodeAtDepth(self.pool, ST.chunk_depth, field_index);
-                };
+                if (self.child_data[field_index]) |child_value| {
+                    const node = try ChildST.tree.fromValue(self.pool, &child_value);
+                    defer self.pool.unref(node);
+                    self.field_root_cache[field_index] = node.getRoot(self.pool).*;
+                    return &self.field_root_cache[field_index];
+                }
+                const node = try self.root.getNodeAtDepth(self.pool, ST.chunk_depth, field_index);
                 return node.getRoot(self.pool);
             } else {
                 // For composite types, if we have a cached view, commit it and return its root
@@ -465,9 +471,9 @@ pub fn StructContainerTreeView(comptime ST: type) type {
             return ptr;
         }
 
+        /// Clones the committed state; uncommitted writes are dropped (from the source too on
+        /// transfer), matching the other tree views.
         pub fn clone(self: *Self, opts: CloneOpts) !*Self {
-            try self.commit();
-
             try self.pool.ref(self.root);
             errdefer self.pool.unref(self.root);
 
@@ -479,10 +485,14 @@ pub fn StructContainerTreeView(comptime ST: type) type {
             ptr.root = self.root;
             ptr.changed = std.StaticBitSet(ST.chunk_count).initEmpty();
 
-            if (opts.transfer_cache) {
+            if (opts.transfer_cache and self.changed.count() == 0) {
                 ptr.value = self.value;
             } else {
                 try ST.tree.toValue(self.root, self.pool, &ptr.value);
+            }
+            if (opts.transfer_cache and self.changed.count() != 0) {
+                self.value = ptr.value;
+                self.changed = std.StaticBitSet(ST.chunk_count).initEmpty();
             }
 
             return ptr;
@@ -798,6 +808,127 @@ test "TreeView container field roundtrip" {
         &htr_from_value,
         &htr_from_tree,
     );
+}
+
+test "StructContainerTreeView clone drops uncommitted changes" {
+    var pool = try Node.Pool.init(.{ .page_allocator = std.testing.allocator, .allocator = std.testing.allocator, .pool_size = 256 });
+    defer pool.deinit();
+
+    const StructCheckpoint = StructContainerType(struct {
+        epoch: UintType(64),
+        root: ByteVectorType(32),
+    });
+    const value: StructCheckpoint.Type = .{ .epoch = 1, .root = [_]u8{1} ** 32 };
+    var view = try StructCheckpoint.TreeView.fromValue(std.testing.allocator, &pool, &value);
+    defer view.deinit();
+    const committed_root = view.getRoot();
+
+    try view.set("epoch", 9);
+    var cloned = try view.clone(.{});
+    defer cloned.deinit();
+
+    try std.testing.expectEqual(@as(u64, 1), try cloned.get("epoch"));
+    try std.testing.expectEqual(@as(u64, 1), try view.get("epoch"));
+    try std.testing.expectEqual(committed_root, cloned.getRoot());
+    try std.testing.expectEqual(committed_root, view.getRoot());
+
+    try view.set("epoch", 5);
+    var kept = try view.clone(.{ .transfer_cache = false });
+    defer kept.deinit();
+    try std.testing.expectEqual(@as(u64, 1), try kept.get("epoch"));
+    try std.testing.expectEqual(@as(u64, 5), try view.get("epoch"));
+}
+
+const DoubleFreeDetectAllocator = @import("testing_allocators").DoubleFreeDetectAllocator;
+
+test "TreeView container setValue/commit - OOM does not double-free" {
+    const new_root_bytes: [32]u8 = [_]u8{0xee} ** 32;
+
+    var fail_at: usize = 0;
+    while (fail_at < 200) : (fail_at += 1) {
+        var oom = DoubleFreeDetectAllocator.init(std.testing.allocator, fail_at);
+        defer oom.deinit();
+        const alloc = oom.allocator();
+
+        var pool = Node.Pool.init(.{ .page_allocator = alloc, .allocator = alloc, .pool_size = 0 }) catch continue;
+        defer pool.deinit();
+
+        const checkpoint: Checkpoint.Type = .{ .epoch = 1, .root = [_]u8{1} ** 32 };
+        const root_node = Checkpoint.tree.fromValue(&pool, &checkpoint) catch continue;
+        var view = Checkpoint.TreeView.init(alloc, &pool, root_node) catch {
+            pool.unref(root_node);
+            continue;
+        };
+        defer view.deinit();
+
+        view.setValue("root", &new_root_bytes) catch {
+            try std.testing.expect(!oom.double_free);
+            continue;
+        };
+        view.commit() catch {};
+        try std.testing.expect(!oom.double_free);
+    }
+}
+
+test "TreeView container fromValue - OOM leaves no orphan pool nodes" {
+    const checkpoint: Checkpoint.Type = .{ .epoch = 7, .root = [_]u8{7} ** 32 };
+
+    var fail_at: usize = 0;
+    while (fail_at < 200) : (fail_at += 1) {
+        var failing = std.testing.FailingAllocator.init(std.testing.allocator, .{ .fail_index = fail_at, .resize_fail_index = 0 });
+        var pool = Node.Pool.init(.{ .page_allocator = failing.allocator(), .allocator = failing.allocator(), .pool_size = 0 }) catch continue;
+        defer pool.deinit();
+
+        const baseline = pool.getNodesInUse();
+        const view = Checkpoint.TreeView.fromValue(failing.allocator(), &pool, &checkpoint) catch {
+            try std.testing.expectEqual(baseline, pool.getNodesInUse());
+            continue;
+        };
+        view.deinit();
+        try std.testing.expectEqual(baseline, pool.getNodesInUse());
+    }
+}
+
+test "TreeView container getFieldRoot on a dirty basic field leaves no orphan pool nodes" {
+    var pool = try Node.Pool.init(.{ .page_allocator = std.testing.allocator, .allocator = std.testing.allocator, .pool_size = 256 });
+    defer pool.deinit();
+
+    const checkpoint: Checkpoint.Type = .{ .epoch = 1, .root = [_]u8{1} ** 32 };
+    const root_node = try Checkpoint.tree.fromValue(&pool, &checkpoint);
+    var view = try Checkpoint.TreeView.init(std.testing.allocator, &pool, root_node);
+    defer view.deinit();
+
+    try view.set("epoch", 99);
+    const baseline = pool.getNodesInUse();
+
+    var expected = [_]u8{0} ** 32;
+    std.mem.writeInt(u64, expected[0..8], 99, .little);
+    for (0..10) |_| {
+        const field_root = try view.getFieldRoot("epoch");
+        try std.testing.expectEqualSlices(u8, &expected, field_root);
+    }
+    try std.testing.expectEqual(baseline, pool.getNodesInUse());
+}
+
+test "TreeView container deserialize - OOM leaves no orphan pool nodes" {
+    const value: Checkpoint.Type = .{ .epoch = 7, .root = [_]u8{0x5a} ** 32 };
+    var bytes: [Checkpoint.fixed_size]u8 = undefined;
+    _ = Checkpoint.serializeIntoBytes(&value, &bytes);
+
+    var fail_at: usize = 0;
+    while (fail_at < 200) : (fail_at += 1) {
+        var failing = std.testing.FailingAllocator.init(std.testing.allocator, .{ .fail_index = fail_at, .resize_fail_index = 0 });
+        var pool = Node.Pool.init(.{ .page_allocator = failing.allocator(), .allocator = failing.allocator(), .pool_size = 0 }) catch continue;
+        defer pool.deinit();
+
+        const baseline = pool.getNodesInUse();
+        const view = Checkpoint.TreeView.deserialize(failing.allocator(), &pool, &bytes) catch {
+            try std.testing.expectEqual(baseline, pool.getNodesInUse());
+            continue;
+        };
+        view.deinit();
+        try std.testing.expectEqual(baseline, pool.getNodesInUse());
+    }
 }
 
 test "TreeView container nested types set/get/commit" {

--- a/src/ssz/tree_view/list_basic.zig
+++ b/src/ssz/tree_view/list_basic.zig
@@ -73,7 +73,9 @@ pub fn ListBasicTreeView(comptime ST: type) type {
             try self.chunks.clone(opts, &ptr.chunks);
             ptr.allocator = self.allocator;
             ptr._orig_len = self._orig_len;
-            ptr._len = self._len;
+            // Uncommitted writes are dropped (from the source too on transfer), so length = committed.
+            ptr._len = self._orig_len;
+            if (opts.transfer_cache) self._len = self._orig_len;
             return ptr;
         }
 
@@ -86,6 +88,13 @@ pub fn ListBasicTreeView(comptime ST: type) type {
             try self.updateListLength();
             try self.chunks.commit();
             self._orig_len = self._len;
+        }
+
+        /// Grows the list; new positions read as zero. Shrinking must go through sliceTo —
+        /// a bare length cut would leave stale chunk data in the merkleized root.
+        pub fn growTo(self: *Self, new_length: usize) !void {
+            std.debug.assert(new_length >= self._len);
+            self._len = new_length;
         }
 
         pub fn clearCache(self: *Self) void {
@@ -111,10 +120,6 @@ pub fn ListBasicTreeView(comptime ST: type) type {
         pub fn toValue(self: *Self, allocator: Allocator, out: *ST.Type) !void {
             try self.commit();
             try ST.tree.toValue(allocator, self.chunks.state.root, self.chunks.state.pool, out);
-        }
-
-        pub fn setLength(self: *Self, new_length: usize) !void {
-            self._len = new_length;
         }
 
         /// Read-only iterator over committed elements. Pending `set`/`push`
@@ -809,6 +814,54 @@ test "TreeView list basic clone(true) transfers cache and clears source" {
     try std.testing.expect(cloned.chunks.state.children_nodes.count() > 0);
 }
 
+test "TreeView list basic clone(transfer_cache) on a dirty view leaves no orphan pool nodes" {
+    const allocator = std.testing.allocator;
+    var pool = try Node.Pool.init(.{ .page_allocator = allocator, .allocator = allocator, .pool_size = 64 });
+    defer pool.deinit();
+
+    const ListType = FixedListType(UintType(32), 16, .{});
+    var list: ListType.Type = .empty;
+    defer list.deinit(allocator);
+    for (0..4) |i| try list.append(allocator, @as(u32, @intCast(i + 1)));
+
+    const baseline = pool.getNodesInUse();
+    {
+        const root = try ListType.tree.fromValue(&pool, &list);
+        var view = try ListType.TreeView.init(allocator, &pool, root);
+        try view.set(0, @as(u32, 42));
+        var cloned = try view.clone(.{});
+        cloned.deinit();
+        view.deinit();
+    }
+    try std.testing.expectEqual(baseline, pool.getNodesInUse());
+}
+
+test "TreeView list basic clone(transfer_cache) drops an uncommitted push without _len skew" {
+    const allocator = std.testing.allocator;
+    var pool = try Node.Pool.init(.{ .page_allocator = allocator, .allocator = allocator, .pool_size = 256 });
+    defer pool.deinit();
+
+    const ListType = FixedListType(UintType(32), 16, .{});
+    var list: ListType.Type = .empty;
+    defer list.deinit(allocator);
+    for (0..4) |i| try list.append(allocator, @as(u32, @intCast(i + 1)));
+
+    const root = try ListType.tree.fromValue(&pool, &list);
+    var view = try ListType.TreeView.init(allocator, &pool, root);
+    defer view.deinit();
+
+    try view.push(@as(u32, 99));
+
+    var cloned = try view.clone(.{});
+    defer cloned.deinit();
+    try cloned.commit();
+
+    var roundtrip: ListType.Type = .empty;
+    defer roundtrip.deinit(allocator);
+    try ListType.tree.toValue(allocator, cloned.getRoot(), &pool, &roundtrip);
+    try std.testing.expectEqual(@as(usize, 4), roundtrip.items.len);
+}
+
 // Refer to https://github.com/ChainSafe/ssz/blob/7f5580c2ea69f9307300ddb6010a8bc7ce2fc471/packages/ssz/test/unit/byType/listBasic/tree.test.ts#L180-L203
 test "TreeView basic list getAll reflects pushes" {
     const allocator = std.testing.allocator;
@@ -1308,6 +1361,45 @@ test "ListBasicTreeView chunked_leaf: push keeps ChunkedLeaf.len in sync" {
             try std.testing.expectEqualSlices(u8, &zero_chunk, &chunks[c]);
         }
     }
+}
+
+test "ListBasicTreeView chunked_leaf: u8 element width round-trips" {
+    const allocator = std.testing.allocator;
+    var pool = try Node.Pool.init(.{ .page_allocator = allocator, .allocator = allocator, .pool_size = 4096 });
+    defer pool.deinit();
+
+    const ListT = FixedListType(UintType(8), 1 << 20, .{ .chunked_leaf = true });
+    const K: usize = ChunkedLeafType.K;
+    const items_per_chunk: usize = 32;
+    const cl_depth: Depth = ListT.chunk_depth + 1 - ChunkedLeafType.k_log2;
+
+    const item_count: usize = K * items_per_chunk + 2 * items_per_chunk + 5;
+
+    var src: ListT.Type = .empty;
+    defer src.deinit(allocator);
+    const root0 = try ListT.tree.fromValue(&pool, &src);
+    var view = try ListT.TreeView.init(allocator, &pool, root0);
+    defer view.deinit();
+
+    for (0..item_count) |i| try view.push(@as(u8, @intCast(i % 256)));
+    try view.commit();
+
+    const total_chunks = (item_count + items_per_chunk - 1) / items_per_chunk;
+    const chunked_leaf_count = (total_chunks + K - 1) / K;
+    const zero_chunk = [_]u8{0} ** 32;
+    for (0..chunked_leaf_count) |cl_idx| {
+        const cl = try view.chunks.state.root.getNodeAtDepth(&pool, cl_depth, cl_idx);
+        const expected_len: usize = @min(K, total_chunks - cl_idx * K);
+        try std.testing.expectEqual(@as(u16, @intCast(expected_len)), try cl.getChunkedLeafLen(&pool));
+        const chunks = try cl.getChunkedLeafChunks(&pool);
+        for (expected_len..K) |c| try std.testing.expectEqualSlices(u8, &zero_chunk, &chunks[c]);
+    }
+
+    var roundtrip: ListT.Type = .empty;
+    defer roundtrip.deinit(allocator);
+    try ListT.tree.toValue(allocator, view.getRoot(), &pool, &roundtrip);
+    try std.testing.expectEqual(item_count, roundtrip.items.len);
+    for (0..item_count) |i| try std.testing.expectEqual(@as(u8, @intCast(i % 256)), roundtrip.items[i]);
 }
 
 test "ListBasicTreeView chunked_leaf: iteratorReadonly with start_index mid-chunked_leaf" {

--- a/src/ssz/tree_view/list_composite.zig
+++ b/src/ssz/tree_view/list_composite.zig
@@ -68,7 +68,9 @@ pub fn ListCompositeTreeView(comptime ST: type) type {
             try self.chunks.clone(opts, &ptr.chunks);
             ptr.allocator = self.allocator;
             ptr._orig_len = self._orig_len;
-            ptr._len = self._len;
+            // Uncommitted writes are dropped (from the source too on transfer), so length = committed.
+            ptr._len = self._orig_len;
+            if (opts.transfer_cache) self._len = self._orig_len;
             return ptr;
         }
 
@@ -108,7 +110,10 @@ pub fn ListCompositeTreeView(comptime ST: type) type {
             try ST.tree.toValue(allocator, self.chunks.state.root, self.chunks.state.pool, out);
         }
 
-        pub fn setLength(self: *Self, new_length: usize) !void {
+        /// Grows the list; new positions read as zero. Shrinking must go through sliceTo —
+        /// a bare length cut would leave stale chunk data in the merkleized root.
+        pub fn growTo(self: *Self, new_length: usize) !void {
+            std.debug.assert(new_length >= self._len);
             self._len = new_length;
         }
 
@@ -156,8 +161,8 @@ pub fn ListCompositeTreeView(comptime ST: type) type {
         }
 
         /// On success takes ownership of `value` and deinits the element cached for `index`, so any
-        /// earlier get()/getReadonly() of it is now invalid. On error.IndexOutOfBounds the caller
-        /// keeps `value` (ownership only transfers once it reaches the backing chunks).
+        /// earlier get()/getReadonly() of it is now invalid. On any error (IndexOutOfBounds or a
+        /// backing-store OOM) the caller keeps `value` and must free it.
         pub fn set(self: *Self, index: usize, value: Element) !void {
             const list_length = try self.length();
             if (index >= list_length) return error.IndexOutOfBounds;
@@ -176,9 +181,9 @@ pub fn ListCompositeTreeView(comptime ST: type) type {
 
         /// Appends an element to the end of the list.
         ///
-        /// Ownership of the `value` TreeView is transferred to the list view.
-        /// The caller must not deinitialize or otherwise use `value` after calling this method,
-        /// as it is now owned by the list.
+        /// Ownership of the `value` TreeView transfers to the list view on success. After a
+        /// successful call the caller must not deinit or use `value`; on any error the caller keeps
+        /// `value` and must free it.
         pub fn push(self: *Self, value: Element) !void {
             const list_length = try self.length();
             if (list_length >= ST.limit) {
@@ -193,8 +198,6 @@ pub fn ListCompositeTreeView(comptime ST: type) type {
 
         /// Push an SSZ value type, creating a TreeView internally.
         pub fn pushValue(self: *Self, value: *const ST.Element.Type) !void {
-            // Check the limit first. After this, push always takes the view (set frees it on its
-            // own OOM), so adding a cleanup errdefer here would double-free.
             if ((try self.length()) >= ST.limit) return error.LengthOverLimit;
 
             const root = try ST.Element.tree.fromValue(self.chunks.state.pool, value);
@@ -202,6 +205,7 @@ pub fn ListCompositeTreeView(comptime ST: type) type {
                 self.chunks.state.pool.unref(root);
                 return err;
             };
+            errdefer child_view.deinit();
             try self.push(child_view);
         }
 
@@ -384,6 +388,7 @@ pub fn ListCompositeTreeView(comptime ST: type) type {
 
 const FixedContainerType = @import("../type/container.zig").FixedContainerType;
 const VariableContainerType = @import("../type/container.zig").VariableContainerType;
+const StructContainerType = @import("../type/container.zig").StructContainerType;
 const UintType = @import("../type/uint.zig").UintType;
 const ByteVectorType = @import("../type/byte_vector.zig").ByteVectorType;
 const ByteListType = @import("../type/byte_list.zig").ByteListType;
@@ -395,6 +400,37 @@ const Checkpoint = FixedContainerType(struct {
     epoch: UintType(64),
     root: ByteVectorType(32),
 });
+
+test "TreeView composite list iteratorReadonly nextValuePtr walks struct elements" {
+    const allocator = std.testing.allocator;
+    var pool = try Node.Pool.init(.{ .page_allocator = allocator, .allocator = allocator, .pool_size = 512 });
+    defer pool.deinit();
+
+    const StructCheckpoint = StructContainerType(struct {
+        epoch: UintType(64),
+        root: ByteVectorType(32),
+    });
+    const ListType = FixedListType(StructCheckpoint, 16, .{});
+
+    var list: ListType.Type = .empty;
+    defer list.deinit(allocator);
+    for (0..5) |i| try list.append(allocator, .{ .epoch = @intCast(i + 1), .root = [_]u8{@intCast(i)} ** 32 });
+
+    const root = try ListType.tree.fromValue(&pool, &list);
+    var view = try ListType.TreeView.init(allocator, &pool, root);
+    defer view.deinit();
+
+    var it = view.iteratorReadonly(0);
+    for (0..5) |i| {
+        const ptr = try it.nextValuePtr();
+        try std.testing.expectEqual(@as(u64, @intCast(i + 1)), ptr.epoch);
+        try std.testing.expectEqual(@as(u8, @intCast(i)), ptr.root[0]);
+    }
+
+    var it_offset = view.iteratorReadonly(3);
+    try std.testing.expectEqual(@as(u64, 4), (try it_offset.nextValuePtr()).epoch);
+    try std.testing.expectEqual(@as(u64, 5), (try it_offset.nextValuePtr()).epoch);
+}
 
 test "TreeView composite list sliceTo truncates elements" {
     const allocator = std.testing.allocator;
@@ -458,7 +494,7 @@ test "TreeView composite list sliceTo does not leak pool nodes" {
 
 const DoubleFreeDetectAllocator = @import("testing_allocators").DoubleFreeDetectAllocator;
 
-// set takes ownership of the view, so setValue must not deinit it too. Sweep every OOM point.
+// set takes ownership only on success; setValue/push errdefer the view for the OOM path.
 test "TreeView composite list setValue - OOM does not double-free the element view" {
     const ListType = FixedListType(Checkpoint, 16, .{});
 
@@ -514,6 +550,45 @@ test "TreeView composite list push - OOM does not double-free" {
         defer view.deinit();
 
         view.pushValue(&newval) catch {};
+        try std.testing.expect(!oom.double_free);
+    }
+}
+
+test "TreeView composite list set(index, ownedView) - failed set leaves the element view to the caller" {
+    const ListType = FixedListType(Checkpoint, 16, .{});
+
+    var list: ListType.Type = .empty;
+    defer list.deinit(std.testing.allocator);
+    for (0..3) |i| try list.append(std.testing.allocator, .{ .epoch = @intCast(i), .root = [_]u8{@intCast(i)} ** 32 });
+    const newval: Checkpoint.Type = .{ .epoch = 99, .root = [_]u8{0xee} ** 32 };
+
+    var fail_at: usize = 0;
+    while (fail_at < 200) : (fail_at += 1) {
+        var oom = DoubleFreeDetectAllocator.init(std.testing.allocator, fail_at);
+        defer oom.deinit();
+        const alloc = oom.allocator();
+
+        var pool = Node.Pool.init(.{ .page_allocator = alloc, .allocator = alloc, .pool_size = 0 }) catch continue;
+        defer pool.deinit();
+
+        const root = ListType.tree.fromValue(&pool, &list) catch continue;
+        var view = ListType.TreeView.init(alloc, &pool, root) catch {
+            pool.unref(root);
+            continue;
+        };
+        defer view.deinit();
+
+        const elem_node = Checkpoint.tree.fromValue(&pool, &newval) catch continue;
+        var elem_view = Checkpoint.TreeView.init(alloc, &pool, elem_node) catch {
+            pool.unref(elem_node);
+            continue;
+        };
+        const elem_addr = @intFromPtr(elem_view);
+
+        if (view.set(0, elem_view)) |_| {} else |_| {
+            try std.testing.expect(oom.live.contains(elem_addr));
+            elem_view.deinit();
+        }
         try std.testing.expect(!oom.double_free);
     }
 }

--- a/src/ssz/tree_view/utils/tree_view_state.zig
+++ b/src/ssz/tree_view/utils/tree_view_state.zig
@@ -131,7 +131,10 @@ pub const TreeViewState = struct {
         out.children_nodes = self.children_nodes;
 
         for (self.changed.keys()) |gindex| {
-            _ = out.children_nodes.remove(gindex);
+            if (out.children_nodes.fetchRemove(gindex)) |entry| {
+                const state = entry.value.getState(self.pool);
+                if (!state.isFree() and state.refCount() == 0) self.pool.unref(entry.value);
+            }
         }
 
         self.children_nodes = .empty;

--- a/src/ssz/type/list.zig
+++ b/src/ssz/type/list.zig
@@ -591,8 +591,8 @@ pub fn FixedListType(comptime ST: type, comptime _limit: comptime_int, comptime 
                 const content_root = try node.getLeft(pool);
                 const chunked_leaf_count = (chunk_count + ChunkedLeaf.K - 1) / ChunkedLeaf.K;
 
-                const chunked_leaf_ids_buf = try pool.page_allocator.alloc(Node.Id, chunked_leaf_count);
-                defer pool.page_allocator.free(chunked_leaf_ids_buf);
+                const chunked_leaf_ids_buf = try pool.allocator.alloc(Node.Id, chunked_leaf_count);
+                defer pool.allocator.free(chunked_leaf_ids_buf);
                 try content_root.getNodesAtDepth(pool, chunked_leaf_depth, 0, chunked_leaf_ids_buf);
 
                 const state_col = pool.nodes.items(.state);

--- a/src/state_transition/load_state.zig
+++ b/src/state_transition/load_state.zig
@@ -644,27 +644,23 @@ test "loadState scenarios" {
                     break :blk try state_ptr.serialize(allocator);
                 },
                 .trim_struct => |m| {
-                    var validators = try state_ptr.validators();
-                    try validators.setLength(m.new_len);
+                    var trimmed = types.electra.BeaconState.default_value;
+                    try types.electra.BeaconState.deserializeFromBytes(allocator, seed_bytes, &trimmed);
+                    defer types.electra.BeaconState.deinit(allocator, &trimmed);
 
-                    var balances = try state_ptr.balances();
-                    try balances.setLength(m.new_len);
-
-                    var scores = try state_ptr.inactivityScores();
-                    try scores.setLength(m.new_len);
-
-                    var previous_epoch_participation = try state_ptr.previousEpochParticipation();
-                    try previous_epoch_participation.setLength(m.new_len);
-
-                    var current_epoch_participation = try state_ptr.currentEpochParticipation();
-                    try current_epoch_participation.setLength(m.new_len);
-
+                    trimmed.validators.shrinkRetainingCapacity(m.new_len);
+                    trimmed.balances.shrinkRetainingCapacity(m.new_len);
+                    trimmed.inactivity_scores.shrinkRetainingCapacity(m.new_len);
+                    trimmed.previous_epoch_participation.shrinkRetainingCapacity(m.new_len);
+                    trimmed.current_epoch_participation.shrinkRetainingCapacity(m.new_len);
                     if (m.new_len == 0) {
-                        var eth1_data = try state_ptr.eth1Data();
-                        try eth1_data.set("deposit_count", 0);
-                        try state_ptr.setEth1DepositIndex(0);
+                        trimmed.eth1_data.deposit_count = 0;
+                        trimmed.eth1_deposit_index = 0;
                     }
-                    break :blk try state_ptr.serialize(allocator);
+
+                    const out_bytes = try allocator.alloc(u8, types.electra.BeaconState.serializedSize(&trimmed));
+                    _ = types.electra.BeaconState.serializeIntoBytes(&trimmed, out_bytes);
+                    break :blk out_bytes;
                 },
             }
         };

--- a/src/state_transition/slot/upgrade_state_to_altair.zig
+++ b/src/state_transition/slot/upgrade_state_to_altair.zig
@@ -31,13 +31,13 @@ pub fn upgradeStateToAltair(
 
     const validators_count = try altair_state.validatorsCount();
     var previous_epoch_participations = try altair_state.previousEpochParticipation();
-    try previous_epoch_participations.setLength(validators_count);
+    try previous_epoch_participations.growTo(validators_count);
 
     var current_epoch_participations = try altair_state.currentEpochParticipation();
-    try current_epoch_participations.setLength(validators_count);
+    try current_epoch_participations.growTo(validators_count);
 
     var inactivity_scores = try altair_state.inactivityScores();
-    try inactivity_scores.setLength(validators_count);
+    try inactivity_scores.growTo(validators_count);
 
     const active_indices = epoch_cache.next_shuffling.get().active_indices;
 

--- a/src/state_transition/sync_committees_witness.zig
+++ b/src/state_transition/sync_committees_witness.zig
@@ -143,36 +143,27 @@ const ProofFixture = struct {
     current_sync_committee: ct.altair.SyncCommittee.Type,
     next_sync_committee: ct.altair.SyncCommittee.Type,
 
-    fn init(fork: ForkSeq) !ProofFixture {
+    fn init(self: *ProofFixture, fork: ForkSeq) !void {
         const allocator = std.testing.allocator;
-        var pool = try Node.Pool.init(.{ .page_allocator = allocator, .allocator = allocator, .pool_size = 500_000 });
-        errdefer pool.deinit();
+        self.pool = try Node.Pool.init(.{ .page_allocator = allocator, .allocator = allocator, .pool_size = 500_000 });
+        errdefer self.pool.deinit();
 
-        var state = switch (fork) {
-            .altair => try AnyBeaconState.fromValue(allocator, &pool, .altair, &ct.altair.BeaconState.default_value),
-            .electra => try AnyBeaconState.fromValue(allocator, &pool, .electra, &ct.electra.BeaconState.default_value),
+        self.state = switch (fork) {
+            .altair => try AnyBeaconState.fromValue(allocator, &self.pool, .altair, &ct.altair.BeaconState.default_value),
+            .electra => try AnyBeaconState.fromValue(allocator, &self.pool, .electra, &ct.electra.BeaconState.default_value),
             else => return error.UnsupportedFork,
         };
-        errdefer state.deinit();
+        errdefer self.state.deinit();
 
-        const current_sync_committee = fillSyncCommittee(0xbb);
-        const next_sync_committee = fillSyncCommittee(0xcc);
-        try state.setCurrentSyncCommittee(&current_sync_committee);
-        try state.setNextSyncCommittee(&next_sync_committee);
+        self.current_sync_committee = fillSyncCommittee(0xbb);
+        self.next_sync_committee = fillSyncCommittee(0xcc);
+        try self.state.setCurrentSyncCommittee(&self.current_sync_committee);
+        try self.state.setNextSyncCommittee(&self.next_sync_committee);
 
-        try state.commit();
-        const state_root = (try state.hashTreeRoot()).*;
-        const root_node = switch (state) {
+        try self.state.commit();
+        self.state_root = (try self.state.hashTreeRoot()).*;
+        self.root_node = switch (self.state) {
             inline else => |view| view.root,
-        };
-
-        return .{
-            .pool = pool,
-            .state = state,
-            .state_root = state_root,
-            .root_node = root_node,
-            .current_sync_committee = current_sync_committee,
-            .next_sync_committee = next_sync_committee,
         };
     }
 
@@ -203,7 +194,8 @@ test "getSyncCommitteesWitness: SyncCommittees proof" {
     };
 
     for (test_cases) |tc| {
-        var fixture = try ProofFixture.init(tc.fork_seq);
+        var fixture: ProofFixture = undefined;
+        try fixture.init(tc.fork_seq);
         defer fixture.deinit();
 
         var witness_data: SyncCommitteeWitness = undefined;
@@ -241,7 +233,8 @@ test "getSyncCommitteesWitness: currentSyncCommittee proof" {
     };
 
     inline for (test_cases) |tc| {
-        var fixture = try ProofFixture.init(tc.fork_seq);
+        var fixture: ProofFixture = undefined;
+        try fixture.init(tc.fork_seq);
         defer fixture.deinit();
 
         var witness_data: SyncCommitteeWitness = undefined;
@@ -284,7 +277,8 @@ test "getSyncCommitteesWitness: nextSyncCommittee proof" {
     };
 
     inline for (test_cases) |tc| {
-        var fixture = try ProofFixture.init(tc.fork_seq);
+        var fixture: ProofFixture = undefined;
+        try fixture.init(tc.fork_seq);
         defer fixture.deinit();
 
         var witness_data: SyncCommitteeWitness = undefined;

--- a/src/state_transition/utils/target_unslashed_balance.zig
+++ b/src/state_transition/utils/target_unslashed_balance.zig
@@ -1,3 +1,4 @@
+const std = @import("std");
 const types = @import("consensus_types");
 const Validator = types.phase0.Validator.Type;
 const Epoch = types.primitive.Epoch.Type;
@@ -8,6 +9,7 @@ const isActiveValidator = @import("./validator.zig").isActiveValidator;
 const TIMELY_TARGET = 1 << c.TIMELY_TARGET_FLAG_INDEX;
 
 pub fn sumTargetUnslashedBalanceIncrements(participations: []const u8, epoch: Epoch, validators: []const *const Validator) u64 {
+    std.debug.assert(participations.len == validators.len);
     var total: u64 = 0;
     for (participations, 0..) |participation, i| {
         if ((participation & TIMELY_TARGET) == TIMELY_TARGET) {


### PR DESCRIPTION
## Motivation

A review of the chunked-leaf packing and zero-copy tree-view paths surfaced a handful of memory-safety issues. 

## Description

- **Composite `set`/`push`/`setValue` ownership.** Make them caller-retains-on-failure (the std/Ghostty model): `chunks.set` no longer deinits the passed view on its own reservation OOM, and `setValue`/`pushValue` carry an `errdefer` over the view they build. Fixes a double-free in `load_state` (`applyModifiedValidators` / `appendNewValidators`), where the caller's `errdefer` and `set`'s self-free both ran on the `ensureUnusedCapacity` OOM path.
- **ChunkedLeaf root recompute.** `getRoot`'s `.chunked_leaf` arm uses a reused Pool scratch field + `computeRoot` instead of `computeRootAllocating`, removing the only `@panic("OOM")` in `src/` (aborted the Node.js host on OOM) and the per-recompute malloc/free on the hashTreeRoot path. A Pool field rather than a stack buffer because `getRoot` recurses to tree depth (~47 on a mainnet validators path), and chunked_leaf is a recursion leaf so one shared scratch is always safe.
- **`sumTargetUnslashedBalanceIncrements`.** Assert `participations.len == validators.len`; the zero-copy validator pointer slice turns a cross-list length mismatch into a garbage-pointer dereference.
- **`ContainerTreeView.deserialize`.** Add the `errdefer pool.unref(root)` its two siblings already carry, so an `init` OOM no longer strands the deserialized subtree.
- **Delete dead `fillToLength` / `fillToDepth`.** Pool-corrupting on first use, zero callers, superseded by `fillWithContents`.
- **`ChunkedLeaf.computeRoot` trailing-zero assert.** Assert chunks past `len` are zero — a violated invariant would silently hash stale data into a wrong (consensus-divergent) root.
- **`getChunkedLeafPtr` exclusive-ownership assert.** Assert `refCount() == 0` before handing out a mutable blob pointer; in-place mutation of a shared node corrupts every tree referencing it.
- **List `setLength` → `growTo`, grow-only.** New positions read as zero (the data subtree is already the virtual zero subtree), so growing is O(1) and correct by construction; a bare length *cut* only rewrites the length mix-in, leaving stale chunk data in the merkleized root — a silent wrong hashTreeRoot. Now asserted (`new_length >= _len`) and documented: shrinking must go through `sliceTo`. All production callers grow (upgrade-to-altair); the one shrink user (the loadState trim test generator) now truncates a value-level state, keeping the test fixture independent of `sliceTo`, which loadState itself uses to trim.
- **`ContainerTreeView.getFieldRoot` per-call pool-node leak.** On a dirty basic field it built a temporary node from the cached value and never unref'd it — one orphaned pool slot per call, invisible to leak detectors (`Pool.deinit` frees every in-use slot on teardown). Mirrors the fix its `StructContainerTreeView` sibling already carries: copy the hash into a per-field backing store, unref the node, return a pointer into the store. Pinned by a `getNodesInUse`-baseline test (10 calls leaked 10 slots before; baseline-stable after).
- **Cloning a dirty tree view — two latent bugs.** A transfer-clone deliberately *drops* uncommitted writes (the rc-0 staged nodes are exclusively owned and can't be shared in the refcount model). The composite path handles this correctly; the basic-list path had two gaps. (1) **Leak:** `TreeViewState.clone` dropped the staged `children_nodes` entries *without* `unref`, orphaning a pool slot (and any chunked_leaf blob) per dropped write — invisible to leak detectors because `Pool.deinit` frees every in-use slot on teardown; now caught by a `getNodesInUse` baseline. (2) **`_len` skew:** the clone kept the uncommitted `_len`, so a dropped push left length N+1 over an N-element tree → wrong root on commit; the clone now reflects the committed length. Both latent (callers commit before cloning).
- **`StructContainerTreeView.clone` semantics.** It committed the source first, so uncommitted writes survived into both views and `clone()` mutated the source's root — the opposite of every other view's drop semantics. It now clones the committed state and drops uncommitted writes (from the source too on transfer).
- **`ProofFixture` dangling Pool (sync-committee witness tests).** The fixture returned its `Pool` by value after handing `&pool` to the views, leaving them pointing at a dead stack frame; the tests passed only by stack-layout luck. The fixture now initializes in place.
- **Allocator-lane routing.** Two transient buffers (the chunked-leaf serialize Id scratch, the compact-multiproof arena) allocated from the page-allocator lane reserved for the pool's node columns; they now use the general allocator lane.