### PR TITLE
fix: various fixes around config

### DIFF
--- a/bindings/napi/config.zig
+++ b/bindings/napi/config.zig
@@ -5,14 +5,19 @@ const active_preset = @import("preset").active_preset;
 const c = @import("config");
 const BeaconConfig = @import("config").BeaconConfig;
 const ChainConfig = @import("config").ChainConfig;
+const Preset = @import("preset").Preset;
 
-/// Allocator for internal allocations.
-/// Creating ChainConfigs allocate memory for certain fields.
-const allocator = std.heap.page_allocator;
+const max_blob_schedule_entries = 16;
 
 pub const State = struct {
     config: BeaconConfig = undefined,
     initialized: bool = false,
+    config_name: [64]u8 = undefined,
+    blob_schedule: [max_blob_schedule_entries]ChainConfig.BlobScheduleEntry =
+        [_]ChainConfig.BlobScheduleEntry{.{
+            .EPOCH = 0,
+            .MAX_BLOBS_PER_BLOCK = 0,
+        }} ** max_blob_schedule_entries,
 
     pub fn init(self: *State) void {
         if (self.initialized) return;
@@ -22,19 +27,11 @@ pub const State = struct {
             .minimal => self.config = c.minimal.config,
             .gnosis => self.config = c.chiado.config,
         }
+        self.initialized = true;
     }
 
     pub fn deinit(self: *State) void {
         if (!self.initialized) return;
-
-        // Free any allocated fields in config here
-        inline for (std.meta.fields(ChainConfig)) |field| {
-            switch (field.type) {
-                []const u8 => allocator.free(@field(self.config.chain, field.name)),
-                []ChainConfig.BlobScheduleEntry => allocator.free(@field(self.config.chain, field.name)),
-                else => {},
-            }
-        }
 
         self.initialized = false;
     }
@@ -42,13 +39,23 @@ pub const State = struct {
 
 pub var state: State = .{};
 
+fn valueToU64(value: napi.Value) !u64 {
+    const num = try value.getValueDouble();
+    if (std.math.isPositiveInf(num)) {
+        return std.math.maxInt(u64);
+    }
+    if (!std.math.isFinite(num) or num < 0 or num > @as(f64, @floatFromInt(std.math.maxInt(u64)))) {
+        return error.InvalidChainConfigFieldValue;
+    }
+    return @intFromFloat(num);
+}
+
 /// JS: config.set(chainConfigObj, genesisValidatorsRoot)
 pub fn set(object: js.Value, genesis_root: js.Uint8Array) !void {
     if (!state.initialized) {
         return error.ConfigNotInitialized;
     }
 
-    // Drop to low-level for the complex object parsing.
     const chain_config = try chainConfigFromObject(js.env(), try object.toValue().coerceToObject());
 
     const root_slice = try genesis_root.toSlice();
@@ -66,80 +73,94 @@ pub fn set(object: js.Value, genesis_root: js.Uint8Array) !void {
 
 pub fn chainConfigFromObject(env: napi.Env, obj: napi.Value) !ChainConfig {
     var chain_config: ChainConfig = undefined;
+
     inline for (std.meta.fields(ChainConfig)) |field| {
-        const field_value = obj.getNamedProperty(field.name) catch |err| {
+        const field_value: napi.Value = obj.getNamedProperty(field.name) catch |err| {
             try env.throwError(@errorName(err), "Missing field " ++ field.name);
             return error.PendingException;
         };
-        switch (field.type) {
-            u64 => {
-                const num = try field_value.getValueInt64();
-                // TODO check for infinity
-                @field(chain_config, field.name) = num;
-            },
-            u256 => {
-                var sign_bit: u1 = 0;
-                var words_buf: [4]u64 = undefined;
-                const words = try field_value.getValueBigintWords(&sign_bit, &words_buf);
-                if (sign_bit != 0) {
-                    return error.InvalidChainConfigFieldValue;
-                }
-                var num_u256: u256 = 0;
-                for (0..4) |i| {
-                    num_u256 |= u256(words[i]) << (@as(u256, i) * 64);
-                }
-                @field(chain_config, field.name) = num_u256;
-            },
-            [4]u8 => {
-                const typedarray_info = try field_value.getTypedarrayInfo();
-                if (typedarray_info.data.len != 4) {
-                    return error.InvalidVersionLength;
-                }
-                var version: [4]u8 = undefined;
-                @memcpy(&version, typedarray_info.data);
-                @field(chain_config, field.name) = version;
-            },
-            [20]u8 => {
-                const typedarray_info = try field_value.getTypedarrayInfo();
-                if (typedarray_info.data.len != 20) {
-                    return error.InvalidAddressLength;
-                }
-                var address: [20]u8 = undefined;
-                @memcpy(&address, typedarray_info.data);
-                @field(chain_config, field.name) = address;
-            },
-            [32]u8 => {
-                const typedarray_info = try field_value.getTypedarrayInfo();
-                if (typedarray_info.data.len != 32) {
-                    return error.InvalidRootLength;
-                }
-                var root: [32]u8 = undefined;
-                @memcpy(&root, typedarray_info.data);
-                @field(chain_config, field.name) = root;
-            },
-            []const u8 => {
-                var str_buf: [64]u8 = undefined;
-                const str = try field_value.getValueStringUtf8(&str_buf);
-                @field(chain_config, field.name) = try allocator.dupe(u8, str);
-            },
-            []ChainConfig.BlobScheduleEntry => {
-                const array_length = try field_value.getArrayLength();
-                const blob_schedule = try allocator.alloc(c.BlobScheduleEntry, array_length);
-                errdefer allocator.free(blob_schedule);
 
-                for (0..array_length) |i| {
-                    const entry_value = try field_value.getElement(i);
-                    const epoch_value = try entry_value.getNamedProperty("EPOCH");
-                    const max_blobs_value = try entry_value.getNamedProperty("MAX_BLOBS_PER_BLOCK");
-
-                    blob_schedule[i] = c.BlobScheduleEntry{
-                        .EPOCH = try epoch_value.getValueUint64(),
-                        .MAX_BLOBS_PER_BLOCK = try max_blobs_value.getValueUint64(),
+        if (try field_value.typeof() == .undefined) {
+            std.log.warn("missing field value for: {s}, skipping\n", .{field.name});
+        } else {
+            switch (field.type) {
+                Preset => {
+                    var str_buf: [16]u8 = undefined;
+                    const preset_str = try field_value.getValueStringUtf8(&str_buf);
+                    @field(chain_config, field.name) =
+                        if (std.mem.eql(u8, preset_str, "mainnet"))
+                            .mainnet
+                        else if (std.mem.eql(u8, preset_str, "minimal"))
+                            .minimal
+                        else if (std.mem.eql(u8, preset_str, "gnosis"))
+                            .gnosis
+                        else
+                            return error.InvalidPreset;
+                },
+                u64 => @field(chain_config, field.name) = try valueToU64(field_value),
+                u256 => {
+                    var str_buf: [128]u8 = undefined;
+                    const str = try (try field_value.coerceToString()).getValueStringUtf8(&str_buf);
+                    @field(chain_config, field.name) = std.fmt.parseInt(u256, str, 10) catch {
+                        return error.InvalidChainConfigFieldValue;
                     };
-                }
-                @field(chain_config, field.name) = blob_schedule;
-            },
-            else => return error.UnsupportedChainConfigFieldType,
+                },
+                [4]u8 => {
+                    const typedarray_info = try field_value.getTypedarrayInfo();
+                    if (typedarray_info.data.len != 4) {
+                        return error.InvalidVersionLength;
+                    }
+                    var version: [4]u8 = undefined;
+                    @memcpy(&version, typedarray_info.data);
+                    @field(chain_config, field.name) = version;
+                },
+                [20]u8 => {
+                    const typedarray_info = try field_value.getTypedarrayInfo();
+                    if (typedarray_info.data.len != 20) {
+                        return error.InvalidAddressLength;
+                    }
+                    var address: [20]u8 = undefined;
+                    @memcpy(&address, typedarray_info.data);
+                    @field(chain_config, field.name) = address;
+                },
+                [32]u8 => {
+                    const typedarray_info = try field_value.getTypedarrayInfo();
+                    if (typedarray_info.data.len != 32) {
+                        return error.InvalidRootLength;
+                    }
+                    var root: [32]u8 = undefined;
+                    @memcpy(&root, typedarray_info.data);
+                    @field(chain_config, field.name) = root;
+                },
+                []const u8 => {
+                    _ = try field_value.getValueStringUtf8(&state.config_name);
+                    if (comptime std.mem.eql(u8, field.name, "CONFIG_NAME")) {
+                        @field(chain_config, field.name) = &state.config_name;
+                    } else {
+                        @compileError("unsupported field: " ++ field.name);
+                    }
+                },
+                []const ChainConfig.BlobScheduleEntry => {
+                    const array_length: usize = @intCast(try field_value.getArrayLength());
+                    if (array_length > max_blob_schedule_entries) {
+                        return error.BlobScheduleTooLong;
+                    }
+
+                    for (0..array_length) |i| {
+                        const entry_value = try field_value.getElement(@intCast(i));
+                        const epoch_value = try entry_value.getNamedProperty("EPOCH");
+                        const max_blobs_value = try entry_value.getNamedProperty("MAX_BLOBS_PER_BLOCK");
+
+                        const blob_schedule_entry = ChainConfig.BlobScheduleEntry{
+                            .EPOCH = try valueToU64(epoch_value),
+                            .MAX_BLOBS_PER_BLOCK = try valueToU64(max_blobs_value),
+                        };
+                        state.blob_schedule[i] = blob_schedule_entry;
+                    }
+                    @field(chain_config, field.name) = state.blob_schedule[0..array_length];
+                },
+                else => return error.UnsupportedChainConfigFieldType,
+            }
         }
     }
     return chain_config;

--- a/bindings/test/config.test.ts
+++ b/bindings/test/config.test.ts
@@ -1,0 +1,16 @@
+import {createChainForkConfig} from "@lodestar/config";
+import {mainnetChainConfig} from "@lodestar/config/configs";
+import {networksChainConfig} from "@lodestar/config/networks";
+import {describe, expect, it} from "vitest";
+import bindings from "../src/index.js";
+
+describe("config parses JS object config into zig native config", () => {
+  for (const [name, chainConfig] of Object.entries(networksChainConfig)) {
+    if (chainConfig.PRESET_BASE !== mainnetChainConfig.PRESET_BASE) continue;
+
+    it(`sets ${name}`, () => {
+      const config = createChainForkConfig(chainConfig);
+      expect(() => bindings.config.set(config, new Uint8Array(32))).not.toThrow();
+    });
+  }
+});


### PR DESCRIPTION
`config.zig` was broken in various places:

- `getValueUint64()` is a non-existent API, this shouldn't even have
  been merged (i was the reviewer so it's my bad)
- we were unnecessarily using an allocator when we could've just had
  fixed sized buffers for `config_name` and `blob_schedule`, both of
  which probably won't change that frequently anyway