### PR TITLE
chore(scripts): build bindings with preset

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,9 @@
     }
   },
   "scripts": {
-    "prepare": "zig build build-lib:bindings -Doptimize=ReleaseSafe",
+    "prepare": "pnpm run prepare-${LODESTAR_PRESET:-mainnet}",
+    "prepare-mainnet": "zig build build-lib:bindings -Doptimize=ReleaseSafe -Dpreset=mainnet",
+    "prepare-minimal": "zig build build-lib:bindings -Doptimize=ReleaseSafe -Dpreset=minimal",
     "lint": "biome check",
     "test": "NODE_OPTIONS='--expose-gc' vitest run bindings/test/*.test.ts"
   },


### PR DESCRIPTION
we use the upstream `LODESTAR_PRESET` to build bindings based on the preset.

This is necessary for spec tests within the CI.