### PR TITLE
fix(bindings): log level for missing fields

### DIFF
--- a/bindings/napi/config.zig
+++ b/bindings/napi/config.zig
@@ -81,7 +81,7 @@ pub fn chainConfigFromObject(env: napi.Env, obj: napi.Value) !ChainConfig {
         };
 
         if (try field_value.typeof() == .undefined) {
-            std.log.warn("missing field value for: {s}, skipping\n", .{field.name});
+            std.log.debug("missing field value for: {s}, skipping\n", .{field.name});
         } else {
             switch (field.type) {
                 Preset => {


### PR DESCRIPTION
it's on the wrong level so it's noisy even in release builds