### PR TITLE
 fix: do not set start index for deposit request pre fulu

### DIFF
--- a/src/state_transition/block/process_deposit_request.zig
+++ b/src/state_transition/block/process_deposit_request.zig
@@ -6,9 +6,11 @@ const PendingDeposit = types.electra.PendingDeposit.Type;
 const c = @import("constants");
 
 pub fn processDepositRequest(comptime fork: ForkSeq, state: *BeaconState(fork), deposit_request: *const DepositRequest) !void {
-    const deposit_requests_start_index = try state.depositRequestsStartIndex();
-    if (deposit_requests_start_index == c.UNSET_DEPOSIT_REQUESTS_START_INDEX) {
-        try state.setDepositRequestsStartIndex(deposit_request.index);
+    if (comptime fork == .electra) {
+        const deposit_requests_start_index = try state.depositRequestsStartIndex();
+        if (deposit_requests_start_index == c.UNSET_DEPOSIT_REQUESTS_START_INDEX) {
+            try state.setDepositRequestsStartIndex(deposit_request.index);
+        }
     }
 
     const pending_deposit = PendingDeposit{


### PR DESCRIPTION
This was causing a spec test failure, reproducible with `zig build test:spec_tests -Dpreset=minimal -Dspec_tests.filters="fulu transition transition_with_deposit_request_right_after_fork"` after #441 is merged

See: https://github.com/ChainSafe/lodestar/blob/f6b2af6879db8092cdaf0dad41b3a098ff391a4a/packages/state-transition/src/block/processDepositRequest.ts#L133