### PR TITLE
feat(bindings): expose more APIs for STF

### DIFF
--- a/bindings/napi/BeaconStateView.zig
+++ b/bindings/napi/BeaconStateView.zig
@@ -1351,6 +1351,13 @@ pub fn getNextShuffling(self: *const BeaconStateView) !js.Value {
     return js_types.wrap(js.Value, try shufflingToNapi(shuffling));
 }
 
+pub fn getBeaconCommitteeCountPerSlot(self: *const BeaconStateView, epoch_arg: js.Number) !js.Number {
+    const cached_state = try self.requireState();
+    const epoch_: u64 = @intCast(try epoch_arg.toI64());
+
+    return js.Number.from(try cached_state.epoch_cache.getCommitteeCountPerSlot(epoch_));
+}
+
 pub fn getShufflingAtEpoch(self: *const BeaconStateView, epoch_arg: js.Number) !js.Value {
     const cached_state = try self.requireState();
     const epoch_value: u64 = @intCast(try epoch_arg.toI64());

--- a/bindings/napi/BeaconStateView.zig
+++ b/bindings/napi/BeaconStateView.zig
@@ -1351,6 +1351,16 @@ pub fn getNextShuffling(self: *const BeaconStateView) !js.Value {
     return js_types.wrap(js.Value, try shufflingToNapi(shuffling));
 }
 
+pub fn getBeaconCommittee(self: *const BeaconStateView, slot_arg: js.Number, index: js.Number) !js.Array {
+    const env = js.env();
+    const cached_state = try self.requireState();
+    const slot_: u64 = @intCast(try slot_arg.toI64());
+    const index_: u64 = @intCast(try index.toI64());
+
+    const committee = try cached_state.epoch_cache.getBeaconCommittee(slot_, index_);
+    return .{ .val = try numberSliceToNapiValue(env, u64, committee, .{}) };
+}
+
 pub fn getBeaconCommitteeCountPerSlot(self: *const BeaconStateView, epoch_arg: js.Number) !js.Number {
     const cached_state = try self.requireState();
     const epoch_: u64 = @intCast(try epoch_arg.toI64());

--- a/bindings/src/index.d.ts
+++ b/bindings/src/index.d.ts
@@ -250,6 +250,7 @@ export declare class BeaconStateView {
   getPreviousShuffling(): EpochShuffling;
   getCurrentShuffling(): EpochShuffling;
   getNextShuffling(): EpochShuffling;
+  getBeaconCommittee(): number[];
   getBeaconCommitteeCountPerSlot(): number;
   previousDecisionRoot: string;
   currentDecisionRoot: string;

--- a/bindings/src/index.d.ts
+++ b/bindings/src/index.d.ts
@@ -250,6 +250,7 @@ export declare class BeaconStateView {
   getPreviousShuffling(): EpochShuffling;
   getCurrentShuffling(): EpochShuffling;
   getNextShuffling(): EpochShuffling;
+  getBeaconCommitteeCountPerSlot(): number;
   previousDecisionRoot: string;
   currentDecisionRoot: string;
   nextDecisionRoot: string;


### PR DESCRIPTION
these two missing APIs are required for fast confirmation rule spec tests on `lodestar`, see chainsafe/lodestar#9516 spec tests failures