### PR TITLE
fix(epoch_cache): populate decision roots in afterProcessEpoch

### DIFF
--- a/src/state_transition/cache/epoch_cache.zig
+++ b/src/state_transition/cache/epoch_cache.zig
@@ -580,8 +580,13 @@ pub const EpochCache = struct {
 
         self.previous_shuffling.unref();
         self.previous_shuffling = self.current_shuffling;
+        self.previous_decision_root = self.current_decision_root;
+
         self.current_shuffling = self.next_shuffling;
+        self.current_decision_root = self.next_decision_root;
+
         self.next_shuffling = next_shuffling_rc;
+        self.next_decision_root = try calculateShufflingDecisionRoot(state, epoch_after_upcoming);
 
         self.churn_limit = getChurnLimit(self.config, self.current_shuffling.get().active_indices.len);
         self.activation_churn_limit = getActivationChurnLimit(self.config, self.config.forkSeq(slot), self.current_shuffling.get().active_indices.len);


### PR DESCRIPTION
We were missing these.

Most likely the cause of this bug when deployed:

```
verbose: Batch process error id=Finalized-150, startEpoch=104717, startSlot=3350944, count=32, status=Processing, blocksReq=startSlot=3350948,count=28
columnsReq=startSlot=3350944,count=32,cols=[28, 30, 38, 64, 94, 104], downloadAttempts=0, processingAttempts=0, blockCount=29, blockSlots=[3350944-3350947, 3350949-3350952, 3350954-3350955, 3350957-3350975], 
peers=16...oYC9Sz,16...JDQxv8, code=BLOCK_ERROR_BEACON_CHAIN_ERROR, error=SHUFFLING_CACHE_ERROR_NO_SHUFFLING_FOUND
```