### PR TITLE
fix: slashing never committing child state tree

### DIFF
--- a/src/state_transition/block/slash_validator.zig
+++ b/src/state_transition/block/slash_validator.zig
@@ -1,3 +1,4 @@
+const std = @import("std");
 const BeaconConfig = @import("config").BeaconConfig;
 const ForkSeq = @import("config").ForkSeq;
 const types = @import("consensus_types");
@@ -31,10 +32,9 @@ pub fn slashValidator(
     var validators = try state.validators();
     var validator = try validators.get(@intCast(slashed_index));
 
-    // TODO: Bellatrix initiateValidatorExit validators.update() with the one below
     try initiateValidatorExit(fork, config, epoch_cache, state, validator);
-
     try validator.set("slashed", true);
+
     var latest_block_header = try state.latestBlockHeader();
     const latest_block_slot = try latest_block_header.get("slot");
     try slashings_cache.recordValidatorSlashing(latest_block_slot, slashed_index);
@@ -45,6 +45,9 @@ pub fn slashValidator(
     );
 
     const effective_balance = try validator.get("effective_balance");
+    try validator.commit();
+    try validators.commit();
+    try state.commit();
 
     // state.slashings is initially a Gwei (BigInt) vector, however since Nov 2023 it's converted to UintNum64 (number) vector in the state transition because:
     //  - state.slashings[nextEpoch % EPOCHS_PER_SLASHINGS_VECTOR] is reset per epoch in processSlashingsReset()
@@ -107,4 +110,68 @@ pub fn slashValidator(
             epoch_cache.current_target_unslashed_balance_increments -= slashed_effective_balance_increments;
         }
     }
+}
+
+test "slashValidator keeps current target unslashed balance consistent" {
+    const test_utils = @import("../test_utils/root.zig");
+    const TestCachedBeaconState = test_utils.TestCachedBeaconState;
+    const Node = @import("persistent_merkle_tree").Node;
+    const EpochTransitionCache = @import("../cache/epoch_transition_cache.zig").EpochTransitionCache;
+
+    const allocator = std.testing.allocator;
+    const num_validators: usize = 256;
+    const pool_size = num_validators * 5;
+    var pool = try Node.Pool.init(.{ .page_allocator = allocator, .allocator = allocator, .pool_size = pool_size });
+    defer pool.deinit();
+
+    var test_state = try TestCachedBeaconState.init(allocator, &pool, num_validators);
+    defer test_state.deinit();
+
+    try @import("../cache/slashings_cache.zig").buildFromStateIfNeeded(
+        allocator,
+        test_state.cached_state.state.castToFork(.electra),
+        &test_state.cached_state.slashings_cache,
+    );
+
+    var current_epoch_participation = try test_state.cached_state.state.currentEpochParticipation();
+    try current_epoch_participation.set(0, 0b111);
+    try current_epoch_participation.commit();
+    try test_state.cached_state.state.commit();
+
+    // Slash validator at index 0
+    try slashValidator(
+        .electra,
+        test_state.config,
+        test_state.cached_state.epoch_cache,
+        test_state.cached_state.state.castToFork(.electra),
+        &test_state.cached_state.slashings_cache,
+        0,
+        null,
+    );
+
+    // First validator should be slashed
+    var validators = try test_state.cached_state.state.validators();
+    var validator = try validators.getReadonly(0);
+    try std.testing.expect(try validator.get("slashed"));
+    var validators_it = validators.iteratorReadonly(0);
+    const validator_from_iterator = try validators_it.nextValuePtr();
+    try std.testing.expect(validator_from_iterator.slashed);
+    try std.testing.expectEqual(
+        @as(u64, (num_validators - 1) * test_utils.EFFECTIVE_BALANCE_INCREMENT),
+        test_state.cached_state.epoch_cache.current_target_unslashed_balance_increments,
+    );
+
+    var epoch_transition_cache = try EpochTransitionCache.init(
+        allocator,
+        std.testing.io,
+        test_state.cached_state.config,
+        test_state.cached_state.epoch_cache,
+        test_state.cached_state.state,
+    );
+    // Assert transition cache consistency
+    try std.testing.expectEqual(
+        test_state.cached_state.epoch_cache.current_target_unslashed_balance_increments,
+        epoch_transition_cache.curr_epoch_unslashed_target_stake_by_increment,
+    );
+    epoch_transition_cache.deinit(allocator);
 }

--- a/src/state_transition/test_utils/generate_state.zig
+++ b/src/state_transition/test_utils/generate_state.zig
@@ -24,7 +24,6 @@ const EffectiveBalanceIncrements = state_transition.EffectiveBalanceIncrements;
 const getNextSyncCommitteeIndices = state_transition.getNextSyncCommitteeIndices;
 const syncPubkeys = state_transition.syncPubkeys;
 const interopPubkeysCached = @import("./interop_pubkeys.zig").interopPubkeysCached;
-const EFFECTIVE_BALANCE_INCREMENT = 32;
 const EFFECTIVE_BALANCE = 32 * 1e9;
 const active_chain_config = if (active_preset == .mainnet) mainnet_chain_config else minimal_chain_config;
 
@@ -43,14 +42,16 @@ pub fn generateElectraState(allocator: Allocator, pool: *Node.Pool, chain_config
     electra_state.genesis_time = 1596546008;
     electra_state.genesis_validators_root = try hex.hexToRoot("0x8a8b3f1f1e2d3c4b5a697887766554433221100ffeeddccbbaa9988776655443");
     // set the slot to be ready for the next epoch transition
-    electra_state.slot = chain_config.ELECTRA_FORK_EPOCH * preset.SLOTS_PER_EPOCH + 2025 * preset.SLOTS_PER_EPOCH - 1;
+    const electra_fork_epoch = if (chain_config.ELECTRA_FORK_EPOCH > std.math.maxInt(Epoch) - 2025) 0 else chain_config.ELECTRA_FORK_EPOCH;
+    const test_epoch = electra_fork_epoch + 2025;
+    electra_state.slot = test_epoch * preset.SLOTS_PER_EPOCH - 1;
     const current_epoch = @divFloor(electra_state.slot, preset.SLOTS_PER_EPOCH);
     var version: [4]u8 = undefined;
     _ = try hex.hexToBytes(&version, "0x00000001");
     electra_state.fork = .{
         .previous_version = version,
         .current_version = version,
-        .epoch = chain_config.ELECTRA_FORK_EPOCH,
+        .epoch = electra_fork_epoch,
     };
     electra_state.latest_block_header = .{
         .slot = electra_state.slot - 1,
@@ -80,8 +81,8 @@ pub fn generateElectraState(allocator: Allocator, pool: *Node.Pool, chain_config
         try electra_state.validators.append(allocator, validator);
         try electra_state.balances.append(allocator, EFFECTIVE_BALANCE);
         try electra_state.inactivity_scores.append(allocator, 0);
-        try electra_state.previous_epoch_participation.append(allocator, 0b11111111);
-        try electra_state.current_epoch_participation.append(allocator, 0b11111111);
+        try electra_state.previous_epoch_participation.append(allocator, 0b111);
+        try electra_state.current_epoch_participation.append(allocator, 0b111);
     }
 
     electra_state.eth1_data = .{
@@ -97,7 +98,7 @@ pub fn generateElectraState(allocator: Allocator, pool: *Node.Pool, chain_config
     defer effective_balance_increments.deinit(allocator);
     for (0..validator_count) |i| {
         try active_validator_indices.append(allocator, @intCast(i));
-        try effective_balance_increments.append(allocator, EFFECTIVE_BALANCE_INCREMENT);
+        try effective_balance_increments.append(allocator, @import("./root.zig").EFFECTIVE_BALANCE_INCREMENT);
     }
 
     // no need to populate eth1_data_votes

--- a/src/state_transition/test_utils/root.zig
+++ b/src/state_transition/test_utils/root.zig
@@ -6,6 +6,9 @@ pub const TestCachedBeaconState = @import("./generate_state.zig").TestCachedBeac
 pub const generateElectraBlock = @import("./generate_block.zig").generateElectraBlock;
 pub const interopSign = @import("./interop_pubkeys.zig").interopSign;
 
+/// Normally set in preset. Mock a small value for testing.
+pub const EFFECTIVE_BALANCE_INCREMENT = 32;
+
 test {
     testing.refAllDecls(@This());
 }


### PR DESCRIPTION
We slash the validator in the child view, but never end up committing
the slashing, resulting in inconsistent state view when later
reconstructing the epoch transition cache