### PR TITLE
feat: split nextValue fn

### DIFF
--- a/src/ssz/tree_view/list_composite.zig
+++ b/src/ssz/tree_view/list_composite.zig
@@ -253,24 +253,36 @@ pub fn ListCompositeTreeView(comptime ST: type) type {
             }
 
             /// Get the next element as an SSZ value type.
-            pub fn nextValue(self: *ReadonlyIterator, allocator: Allocator) !ST.Element.Type {
+            /// Picks between the non-allocating version for fixed types or
+            /// the allocating version for variable-length types.
+            pub const nextValue = if (isFixedType(ST.Element))
+                nextValueFixed
+            else
+                nextValueAlloc;
+
+            /// Inner function to get the next element as an SSZ value type.
+            fn nextValueFixed(self: *ReadonlyIterator) !ST.Element.Type {
                 const node = try self.depth_iterator.next();
-                if (comptime isFixedType(ST.Element)) {
-                    var value: ST.Element.Type = undefined;
-                    try ST.Element.tree.toValue(node, self.tree_view.chunks.state.pool, &value);
-                    self.elem_index += 1;
-                    return value;
-                } else {
-                    // Variable-size elements: toValue reads `out` (it resizes embedded ArrayLists),
-                    // so initialize it before the call.
-                    var value: ST.Element.Type = if (comptime @hasDecl(ST.Element, "default_value"))
-                        ST.Element.default_value
-                    else
-                        std.mem.zeroes(ST.Element.Type);
-                    try ST.Element.tree.toValue(allocator, node, self.tree_view.chunks.state.pool, &value);
-                    self.elem_index += 1;
-                    return value;
-                }
+                var value: ST.Element.Type = undefined;
+                try ST.Element.tree.toValue(node, self.tree_view.chunks.state.pool, &value);
+                self.elem_index += 1;
+                return value;
+            }
+
+            /// Inner function to get the next element as an SSZ value type.
+            ///
+            /// Requires an allocator for `toValue`.
+            fn nextValueAlloc(self: *ReadonlyIterator, allocator: Allocator) !ST.Element.Type {
+                const node = try self.depth_iterator.next();
+                // Variable-size elements: toValue reads `out` (it resizes embedded ArrayLists),
+                // so initialize it before the call.
+                var value: ST.Element.Type = if (comptime @hasDecl(ST.Element, "default_value"))
+                    ST.Element.default_value
+                else
+                    std.mem.zeroes(ST.Element.Type);
+                try ST.Element.tree.toValue(allocator, node, self.tree_view.chunks.state.pool, &value);
+                self.elem_index += 1;
+                return value;
             }
 
             /// Read-only pointer to the next element's value without copying.

--- a/src/state_transition/block/process_withdrawals.zig
+++ b/src/state_transition/block/process_withdrawals.zig
@@ -115,7 +115,7 @@ pub fn getExpectedWithdrawals(
         const pending_partial_withdrawals_len = try pending_partial_withdrawals.length();
 
         for (0..pending_partial_withdrawals_len) |_| {
-            const withdrawal = try pending_partial_withdrawals_it.nextValue(undefined);
+            const withdrawal = try pending_partial_withdrawals_it.nextValue();
             if (withdrawal.withdrawable_epoch > epoch or withdrawals_result.withdrawals.items.len == preset.MAX_PENDING_PARTIALS_PER_WITHDRAWALS_SWEEP) {
                 break;
             }

--- a/src/state_transition/epoch/process_pending_consolidations.zig
+++ b/src/state_transition/epoch/process_pending_consolidations.zig
@@ -21,7 +21,7 @@ pub fn processPendingConsolidations(
     var pending_consolidations_it = pending_consolidations.iteratorReadonly(0);
     const pending_consolidations_length = try pending_consolidations.length();
     for (0..pending_consolidations_length) |_| {
-        const pending_consolidation = try pending_consolidations_it.nextValue(undefined);
+        const pending_consolidation = try pending_consolidations_it.nextValue();
         const source_index = pending_consolidation.source_index;
         const target_index = pending_consolidation.target_index;
         var source_validator = try validators.get(source_index);

--- a/src/state_transition/epoch/process_pending_deposits.zig
+++ b/src/state_transition/epoch/process_pending_deposits.zig
@@ -44,7 +44,7 @@ pub fn processPendingDeposits(
     const pending_deposits_len = try pending_deposits.length();
 
     for (0..pending_deposits_len) |_| {
-        const deposit = try pending_deposits_it.nextValue(undefined);
+        const deposit = try pending_deposits_it.nextValue();
         // Pre-fulu: do not process deposit requests if Eth1 bridge deposits are not yet applied.
         // Fulu removes this guard along with the former (Eth1 bridge) deposit mechanism.
         if (comptime fork.lt(.fulu)) {


### PR DESCRIPTION
`nextValue` always required an `allocator` as a param but it was not used if the `ST.Element` was a fixed type element. This goes against zig's ideal of being as explicit as possible.

Since we already know if the `Element` contained with the composite list is a fixed type or not, so we use that fact to delegate the fn to non public functions `nextValueFixed` or `nextValueAlloc` depending on the inner type.

Also gets rid of the ugly `undefined` usage in consumers.