### PR TITLE
fix(ssz): drop redundant default-init pass in fixed-list decode

### DIFF
--- a/src/ssz/type/list.zig
+++ b/src/ssz/type/list.zig
@@ -166,7 +166,6 @@ pub fn FixedListType(comptime ST: type, comptime _limit: comptime_int, comptime 
                 @memcpy(std.mem.sliceAsBytes(out.items[0..len]), data);
                 return;
             }
-            @memset(out.items[0..len], Element.default_value);
             for (0..len) |i| {
                 try Element.deserializeFromBytes(
                     data[i * Element.fixed_size .. (i + 1) * Element.fixed_size],


### PR DESCRIPTION
## What

`FixedListType.deserializeFromBytes` pre-filled the entire output slice with `default_value` before the element loop overwrote every element — a full extra write pass over the output (128 MB for a 1M-validator `validators` list).

## Why it is safe to remove

- `FixedListType` elements are comptime-enforced fixed-size, and all fixed-size SSZ types are plain data with no allocator-owned memory.
- The decode loop writes every element completely; there is no skip path.
- On a mid-loop error, the caller's unconditional `deinit` only frees the list buffer — it never reads element contents — so undefined trailing elements are never observed.
- `VariableListType` keeps its init pass: its element `deinit` does read element contents, so every slot must stay valid across a mid-loop failure.

`vector.zig`'s decode path already follows this pattern (no init pass, same reasoning).

## Measured

Full-state decode, libssz differential fixture (phase0 `BeaconState`), ReleaseFast:

| machine | cold | warm (reused capacity) |
|---|---|---|
| AMD EPYC 7763 (Linux) | 40.8 ms → 17.5 ms (−56%) | 28.8 ms → 8.7 ms (−69%) |
| Apple M5 (macOS) | 8.4 ms → 7.1 ms (−16%) | 8.6 ms → 6.8 ms (−21%) |

encode and hashTreeRoot unchanged (control).