### PR TITLE
fix: populate cache balances during rewards/penalties processing

### DIFF
--- a/src/state_transition/epoch/process_rewards_and_penalties.zig
+++ b/src/state_transition/epoch/process_rewards_and_penalties.zig
@@ -42,8 +42,9 @@ pub fn processRewardsAndPenalties(
         }
     }
 
-    // Populate cache.balances for reuse by processEffectiveBalanceUpdates() and the
-    // validator monitor. Prevents recomputation.
+    // Populate cache.balances for reuse by the validator monitor and
+    // more importantly processEffectiveBalanceUpdates() doesn't need to
+    // get from tree view state which has to commit.
     cache.balances = .fromOwnedSlice(try allocator.dupe(u64, balances));
 
     var balances_arraylist: std.ArrayListUnmanaged(u64) = .fromOwnedSlice(balances);

--- a/src/state_transition/epoch/process_rewards_and_penalties.zig
+++ b/src/state_transition/epoch/process_rewards_and_penalties.zig
@@ -16,7 +16,7 @@ pub fn processRewardsAndPenalties(
     config: *const BeaconConfig,
     epoch_cache: *const EpochCache,
     state: *BeaconState(fork),
-    cache: *const EpochTransitionCache,
+    cache: *EpochTransitionCache,
     slashing_penalties: ?[]const u64,
 ) !void {
     // No rewards are applied at the end of `GENESIS_EPOCH` because rewards are for work done in the previous epoch
@@ -41,6 +41,10 @@ pub fn processRewardsAndPenalties(
             balance.* = (try std.math.add(u64, balance.*, reward)) -| penalty;
         }
     }
+
+    // Populate cache.balances for reuse by processEffectiveBalanceUpdates() and the
+    // validator monitor. Prevents recomputation.
+    cache.balances = .fromOwnedSlice(try allocator.dupe(u64, balances));
 
     var balances_arraylist: std.ArrayListUnmanaged(u64) = .fromOwnedSlice(balances);
     try state.setBalances(&balances_arraylist);


### PR DESCRIPTION
We weren't doing this previously. This is required for:
- ~optimal path during `processEffectiveBalances`~ this isn't entirely accurate, but we still avoid grabbing from the tree view this way and saving on a commit, and
- validator monitor takes the balances from the cache

See: https://github.com/ChainSafe/lodestar/blob/fadf0fbb1f0f8d97947d1f1540207def8d6db788/packages/state-transition/src/epoch/processRewardsAndPenalties.ts#L44-L46