### PR TITLE
chore(release): v0.1.2-rc.10

### DIFF
--- a/bindings/napi/pubkeys.zig
+++ b/bindings/napi/pubkeys.zig
@@ -32,6 +32,13 @@ pub const State = struct {
         self.index2pubkey.deinit(allocator);
         self.initialized = false;
     }
+
+    pub fn reset(self: *State) !void {
+        if (!self.initialized) return;
+
+        self.pubkey2index.clearRetainingCapacity();
+        self.index2pubkey.shrinkRetainingCapacity(0);
+    }
 };
 
 pub var state: State = .{};
@@ -150,6 +157,11 @@ pub fn load(file_path: js.String) !void {
     try file_reader.interface.readSliceAll(std.mem.sliceAsBytes(state.index2pubkey.items));
 
     state.initialized = true;
+}
+
+/// JS: pubkeys.reset()
+pub fn reset() !void {
+    try state.reset();
 }
 
 /// JS: pubkeys.getIndex(pubkeyBytes) → number | null

--- a/bindings/src/pubkeys.d.ts
+++ b/bindings/src/pubkeys.d.ts
@@ -15,6 +15,8 @@ export interface PubkeyCache {
   readonly size: number;
   /** Load cache from a PKIX file (clears JS-level cache) */
   load(filepath: string): void;
+  /** Clear native and JS-level cache contents */
+  reset(): void;
   /** Save cache to a PKIX file */
   save(filepath: string): void;
   /** Pre-allocate native capacity */

--- a/bindings/src/pubkeys.js
+++ b/bindings/src/pubkeys.js
@@ -49,6 +49,11 @@ export const pubkeyCache = {
     native.load(filepath);
   },
 
+  reset() {
+    pkCache.clear();
+    native.reset();
+  },
+
   save(filepath) {
     native.save(filepath);
   },

--- a/bindings/test/pubkeys.test.ts
+++ b/bindings/test/pubkeys.test.ts
@@ -90,4 +90,16 @@ describe("pubkeys", () => {
     const after = pubkeyCache.get(0);
     expect(before).not.toBe(after);
   });
+
+  it("reset clears native and JS-level cache", () => {
+    const before = pubkeyCache.get(0);
+    expect(before).toBeDefined();
+    expect(pubkeyCache.getIndex(keypairs[0].pubkeyBytes)).toBeDefined();
+
+    pubkeyCache.reset();
+
+    expect(pubkeyCache.size).toBe(0);
+    expect(pubkeyCache.get(0)).toBeUndefined();
+    expect(pubkeyCache.getIndex(keypairs[0].pubkeyBytes)).toBeNull();
+  });
 });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chainsafe/lodestar-z",
-  "version": "0.1.2-rc.9",
+  "version": "0.1.2-rc.10",
   "description": "Lodestar-z NAPI bindings",
   "files": [
     "bindings/src/",


### PR DESCRIPTION
adds reset API to release for consumption, unblocks chainsafe/lodestar#8900