### PR TITLE
feat: grow pubkey cache by a calculated headroom

### DIFF
--- a/bindings/napi/pubkeys.zig
+++ b/bindings/napi/pubkeys.zig
@@ -4,6 +4,7 @@ const bls = @import("bls");
 const blst_bindings = @import("./blst.zig");
 const PubkeyIndexMap = @import("state_transition").PubkeyIndexMap;
 const Index2PubkeyCache = @import("state_transition").Index2PubkeyCache;
+const pubkey_cache_headroom = @import("state_transition").pubkey_cache_headroom;
 const napi_io = @import("./io.zig");
 
 /// Uses page allocator for internal allocations.
@@ -240,7 +241,7 @@ pub fn set(index: js.Number, pubkey: js.Uint8Array) !void {
 
     // Ensure capacity if needed
     if (idx >= state.index2pubkey.capacity) {
-        const new_cap: u32 = @intCast(@max(idx + 1, state.index2pubkey.capacity * 2));
+        const new_cap: u32 = @intCast(@max(idx + 1, state.index2pubkey.capacity + pubkey_cache_headroom));
         try state.pubkey2index.ensureTotalCapacity(new_cap);
         try state.index2pubkey.ensureTotalCapacity(allocator, new_cap);
     }

--- a/src/state_transition/cache/pubkey_cache.zig
+++ b/src/state_transition/cache/pubkey_cache.zig
@@ -12,7 +12,7 @@ pub const Index2PubkeyCache = std.ArrayList(bls.PublicKey);
 
 const headroom_epochs = (90 * 24 * 60 * 60) / (preset.SECONDS_PER_SLOT * preset.SLOTS_PER_EPOCH);
 
-// Reserve headroom so the native cache does not realloc on growth. Reallocs are unsafe
+/// Reserve headroom so the native cache does not realloc on growth. Reallocs are unsafe
 /// while the historical state worker reads the cache, until lodestar-z adds locking.
 /// Registry growth is capped at MAX_PENDING_DEPOSITS_PER_EPOCH new validators per epoch,
 /// reserve 3 months of worst-case growth, over a year at organic rates

--- a/src/state_transition/cache/pubkey_cache.zig
+++ b/src/state_transition/cache/pubkey_cache.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
 const bls = @import("bls");
+const preset = @import("preset");
 const types = @import("consensus_types");
 const Validator = types.phase0.Validator.Type;
 
@@ -8,6 +9,14 @@ pub const PubkeyIndexMap = std.AutoHashMap([48]u8, u64);
 
 /// Map from validator index to pubkey
 pub const Index2PubkeyCache = std.ArrayList(bls.PublicKey);
+
+const headroom_epochs = (90 * 24 * 60 * 60) / (preset.SECONDS_PER_SLOT * preset.SLOTS_PER_EPOCH);
+
+// Reserve headroom so the native cache does not realloc on growth. Reallocs are unsafe
+/// while the historical state worker reads the cache, until lodestar-z adds locking.
+/// Registry growth is capped at MAX_PENDING_DEPOSITS_PER_EPOCH new validators per epoch,
+/// reserve 3 months of worst-case growth, over a year at organic rates
+pub const pubkey_cache_headroom = preset.MAX_PENDING_DEPOSITS_PER_EPOCH * headroom_epochs;
 
 /// Populate `pubkey_to_index` and `index_to_pubkey` caches from validators list.
 ///

--- a/src/state_transition/cache/pubkey_cache.zig
+++ b/src/state_transition/cache/pubkey_cache.zig
@@ -1,6 +1,6 @@
 const std = @import("std");
 const bls = @import("bls");
-const preset = @import("preset");
+const preset = @import("preset").preset;
 const types = @import("consensus_types");
 const Validator = types.phase0.Validator.Type;
 

--- a/src/state_transition/root.zig
+++ b/src/state_transition/root.zig
@@ -24,6 +24,7 @@ pub const PubkeyIndexMap = @import("./cache/pubkey_cache.zig").PubkeyIndexMap;
 pub const Index2PubkeyCache = @import("./cache/pubkey_cache.zig").Index2PubkeyCache;
 pub const syncPubkeys = @import("./cache/pubkey_cache.zig").syncPubkeys;
 pub const syncPubkeysParallel = @import("./cache/pubkey_cache.zig").syncPubkeysParallel;
+pub const pubkey_cache_headroom = @import("./cache/pubkey_cache.zig").pubkey_cache_headroom;
 
 pub const EpochTransitionCache = @import("./cache/epoch_transition_cache.zig").EpochTransitionCache;
 pub const processEpoch = @import("./epoch/process_epoch.zig").processEpoch;


### PR DESCRIPTION
Registry growth is capped at `MAX_PENDING_DEPOSITS_PER_EPOCH` new validators per epoch, so we reserve 3 months of worst-case growth, over a year at organic rates.