### PR TITLE
chore: silence debug log when used in release builds

### DIFF
--- a/bindings/napi/root.zig
+++ b/bindings/napi/root.zig
@@ -25,7 +25,7 @@ fn init(old_ref_count: u32) !void {
         var cpu_count: u64 = options.thread_count;
         if (options.thread_count == 0) {
             cpu_count = @max(try detectCpuCount(), 2) - 1;
-            std.debug.print(
+            std.log.debug(
                 "Note: no -Dthread-count set, using cgroup-aware CPU count minus 1: {}\n",
                 .{cpu_count},
             );
@@ -44,7 +44,7 @@ fn init(old_ref_count: u32) !void {
 /// count (what `std.Thread.getCpuCount()` reports).
 fn detectCpuCount() !usize {
     return @import("cpu_count").getNumCpus(allocator, napi_io.get()) catch |err| {
-        std.debug.print(
+        std.log.debug(
             "Warning: cgroup CPU detection failed ({s}), using affinity count\n",
             .{@errorName(err)},
         );


### PR DESCRIPTION
```console
➜ ./lodestar --help
Note: no -Dthread-count set, using cgroup-aware CPU count minus 1: 11
```

`debug.print` prints no matter what so even in upstream lodestar we get this message printed, but this should really be using `std.log` scoped behind proper optimize modes