### PR TITLE
fix(bindings): roll back partial N-API initialization

### DIFF
--- a/bindings/napi/root.zig
+++ b/bindings/napi/root.zig
@@ -32,9 +32,19 @@ fn init(old_ref_count: u32) !void {
         }
 
         const n_workers = @min(cpu_count, @import("bls").ThreadPool.MAX_WORKERS);
+
         try blst.initThreadPool(@intCast(n_workers));
+        errdefer blst.deinitThreadPool();
+
         try pool.state.init();
+        errdefer pool.state.deinit();
+
         try pubkeys.state.init();
+
+        // All remaining initialization must stay infallible because the earlier errdefers no
+        // longer cover every initialized global.
+        errdefer comptime unreachable;
+
         config.state.init();
     }
 }


### PR DESCRIPTION
## Summary

- tear down the BLS thread pool if a later N-API pool initialization step fails
- tear down the N-API object pool if pubkey cache initialization fails
- add a compile-time error-path barrier after the final fallible step so future fallible initialization cannot silently bypass the rollback design

## Motivation

The addon initializes several process-global resources in sequence. If a later step fails, the previous implementation only released the N-API I/O context. That can leave an active BLS thread pool referencing a deinitialized I/O backend and prevent a later addon load from recovering because the global pool still exists.
