### PR TITLE
fix(bindings): check signature infinity by default

### DIFF
--- a/bindings/napi/blst.zig
+++ b/bindings/napi/blst.zig
@@ -204,7 +204,7 @@ pub const Signature = struct {
 
         var sig = NativeSignature.deserialize(bytes) catch return error.DeserializationFailed;
         if (try boolOrDefault(sig_validate, false)) {
-            try sig.validate(try boolOrDefault(sig_infcheck, false));
+            try sig.validate(try boolOrDefault(sig_infcheck, true));
         }
         return .{ .raw = sig };
     }

--- a/bindings/test/blst.test.ts
+++ b/bindings/test/blst.test.ts
@@ -88,6 +88,18 @@ describe("blst", () => {
       });
     });
 
+    describe("fromHex()", () => {
+      const G2_POINT_AT_INFINITY = `c0${"00".repeat(95)}`;
+
+      it("should check infinity by default", () => {
+        expect(() => Signature.fromHex(G2_POINT_AT_INFINITY, true)).toThrow("PkIsInfinity");
+      });
+
+      it("should skip the infinity check when explicitly disabled", () => {
+        expect(Signature.fromHex(G2_POINT_AT_INFINITY, true, false)).toBeInstanceOf(Signature);
+      });
+    });
+
     it("should serialize to bytes", () => {
       const sig = Signature.fromBytes(fromHex(TEST_VECTORS.signature.compressed));
       const bytes = sig.toBytes();


### PR DESCRIPTION
Replaces #488 with the same change on top of the latest `main`, using a GitHub-verified signed commit.

## Summary

- Default `Signature.fromHex` `sigInfcheck` to `true` when signature validation is enabled.
- Keep the explicit `sigInfcheck = false` opt-out behavior.
- Add regression coverage using the compressed G2 point at infinity.