### PR TITLE
(don't merge) fix(bindings): make pubkey cache set error-atomic

### DIFF
--- a/bindings/napi/pubkeys.zig
+++ b/bindings/napi/pubkeys.zig
@@ -249,21 +249,23 @@ pub fn set(index: js.Number, pubkey: js.Uint8Array) !void {
     if (pubkey_slice.len != 48) return error.InvalidPubkeyLength;
 
     const pubkey_bytes = pubkey_slice[0..48];
+    // Decode before resize; otherwise a failure would leave the append-only cache half-updated.
     const native_pubkey = try bls.PublicKey.uncompress(pubkey_bytes);
 
-    // Ensure capacity if needed
     if (idx >= state.index2pubkey.capacity) {
         const new_cap: u32 = @intCast(@max(idx + 1, state.index2pubkey.capacity + growth_step));
         try state.pubkey2index.ensureTotalCapacity(new_cap);
         try state.index2pubkey.ensureTotalCapacityPrecise(allocator, new_cap);
     }
+    // Reserve the map before resize so the reverse-index write cannot fail afterward.
     state.pubkey2index.ensureUnusedCapacity(1) catch
         return error.PubkeyIndexInsertFailed;
 
-    // Extend length if needed
     if (idx >= state.index2pubkey.items.len) {
         try state.index2pubkey.resize(allocator, idx + 1);
     }
+    // After resize, both cache writes must remain infallible.
+    errdefer comptime unreachable;
 
     state.index2pubkey.items[@intCast(idx)] = native_pubkey;
     state.pubkey2index.putAssumeCapacity(pubkey_bytes.*, @intCast(idx));

--- a/bindings/napi/pubkeys.zig
+++ b/bindings/napi/pubkeys.zig
@@ -249,6 +249,7 @@ pub fn set(index: js.Number, pubkey: js.Uint8Array) !void {
     if (pubkey_slice.len != 48) return error.InvalidPubkeyLength;
 
     const pubkey_bytes = pubkey_slice[0..48];
+    const native_pubkey = try bls.PublicKey.uncompress(pubkey_bytes);
 
     // Ensure capacity if needed
     if (idx >= state.index2pubkey.capacity) {
@@ -256,17 +257,16 @@ pub fn set(index: js.Number, pubkey: js.Uint8Array) !void {
         try state.pubkey2index.ensureTotalCapacity(new_cap);
         try state.index2pubkey.ensureTotalCapacityPrecise(allocator, new_cap);
     }
+    state.pubkey2index.ensureUnusedCapacity(1) catch
+        return error.PubkeyIndexInsertFailed;
 
     // Extend length if needed
     if (idx >= state.index2pubkey.items.len) {
         try state.index2pubkey.resize(allocator, idx + 1);
     }
 
-    // Set pubkey2index
-    state.pubkey2index.put(pubkey_bytes.*, @intCast(idx)) catch return error.PubkeyIndexInsertFailed;
-
-    // Deserialize and set index2pubkey
-    state.index2pubkey.items[@intCast(idx)] = try bls.PublicKey.uncompress(pubkey_bytes);
+    state.index2pubkey.items[@intCast(idx)] = native_pubkey;
+    state.pubkey2index.putAssumeCapacity(pubkey_bytes.*, @intCast(idx));
 }
 
 /// JS: pubkeys.size() → number

--- a/bindings/test/pubkeys.test.ts
+++ b/bindings/test/pubkeys.test.ts
@@ -103,6 +103,20 @@ describe("pubkeys", () => {
     expect(pubkeyCache.getIndex(keypairs[0].pubkeyBytes)).toBeNull();
   });
 
+  it("set leaves the cache unchanged when pubkey decoding fails", () => {
+    pubkeyCache.reset();
+    const invalidPubkey = new Uint8Array(48);
+
+    expect(() => pubkeyCache.set(0, invalidPubkey)).toThrow("BadEncoding");
+    expect(pubkeyCache.size).toBe(0);
+    expect(pubkeyCache.get(0)).toBeUndefined();
+    expect(pubkeyCache.getIndex(invalidPubkey)).toBeNull();
+
+    pubkeyCache.set(0, keypairs[0].pubkeyBytes);
+    expect(pubkeyCache.size).toBe(1);
+    expect(pubkeyCache.getIndex(keypairs[0].pubkeyBytes)).toBe(0);
+  });
+
   it("exposes native capacity", () => {
     expect(pubkeyCache.capacity).toBeGreaterThanOrEqual(1_000);
   });


### PR DESCRIPTION
## Summary

- decode the BLS public key before mutating either cache direction
- reserve hash map capacity before extending the index cache, so the commit path cannot fail halfway
- mark the post-resize commit point with `errdefer comptime unreachable` to reject future fallible work
- add a regression test proving a failed set leaves the cache unchanged and a valid retry succeeds