### PR TITLE
fix(bindings): validate secret key hex length

### DIFF
--- a/bindings/napi/blst.zig
+++ b/bindings/napi/blst.zig
@@ -278,8 +278,18 @@ pub const SecretKey = struct {
 
     /// Creates a `SecretKey` from a hex string.
     pub fn fromHex(hex_string: js.String) !SecretKey {
+        switch (try hex_string.len()) {
+            NativeSecretKey.serialize_size * 2,
+            NativeSecretKey.serialize_size * 2 + 2,
+            => {},
+            else => return error.InvalidSecretKeyLength,
+        }
+
         var hex_buf: [NativeSecretKey.serialize_size * 2 + 3]u8 = undefined;
         const hex = try hexFromString(hex_string, &hex_buf);
+        if (hex.len != NativeSecretKey.serialize_size * 2) {
+            return error.InvalidSecretKeyLength;
+        }
 
         var bytes_buf: [NativeSecretKey.serialize_size]u8 = undefined;
         const bytes = try std.fmt.hexToBytes(&bytes_buf, hex);

--- a/bindings/test/blst.test.ts
+++ b/bindings/test/blst.test.ts
@@ -167,6 +167,30 @@ describe("blst", () => {
         }
       });
     });
+    describe("SecretKey.fromHex", () => {
+      for (const prefix of ["", "0x"]) {
+        it(`should round-trip a valid key with prefix '${prefix}'`, () => {
+          const hex = `${prefix}${Buffer.from(SECRET_KEY_BYTES).toString("hex")}`;
+          expectEqualHex(SecretKey.fromHex(hex).toBytes(), SECRET_KEY_BYTES);
+        });
+      }
+
+      for (const byteLength of [0, 1, 31, 33]) {
+        for (const prefix of ["", "0x"]) {
+          it(`should throw on ${byteLength}-byte input with prefix '${prefix}'`, () => {
+            expect(() => SecretKey.fromHex(`${prefix}${"00".repeat(byteLength)}`)).toThrow("InvalidSecretKeyLength");
+          });
+        }
+      }
+
+      it("should throw on an odd number of hex characters", () => {
+        expect(() => SecretKey.fromHex("0".repeat(63))).toThrow("InvalidSecretKeyLength");
+      });
+
+      it("should throw on non-hex UTF-8 input without aborting", () => {
+        expect(() => SecretKey.fromHex("é".repeat(32))).toThrow();
+      });
+    });
     describe("instance methods", () => {
       let key: SecretKey;
       describe("toBytes", () => {


### PR DESCRIPTION
## Summary

- validate `SecretKey.fromHex` input length before copying into its fixed-size buffer
- require exactly 32 decoded bytes after stripping an optional `0x` prefix
- cover prefixed and unprefixed valid keys, short and long inputs, odd-length hex, and non-ASCII input

## Why

Short hex strings previously reached a 32-byte slice operation without a length check, causing a ReleaseSafe bounds panic that aborted the Node process instead of throwing a JavaScript error. Checking the UTF-8 byte length before copying also prevents overlong strings from being silently truncated by N-API.

Supersedes #487, which contains unsigned commits.