### PR TITLE
build(bls): migrate deprecated @cImport to addTranslateC

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -3,5 +3,15 @@ const zbuild = @import("zbuild");
 
 pub fn build(b: *std.Build) !void {
     @setEvalBranchQuota(200_000);
-    _ = try zbuild.configureBuild(b, @import("build.zig.zon"), .{});
+    const zbuild_result = try zbuild.configureBuild(b, @import("build.zig.zon"), .{});
+
+    const bls_module = zbuild_result.module("bls").?;
+    const blst_artifact = zbuild_result.dependency("blst").?.artifact("blst");
+    const translate_blst = b.addTranslateC(.{
+        .root_source_file = b.path("src/bls/blst_c.h"),
+        .target = bls_module.resolved_target.?,
+        .optimize = bls_module.optimize.?,
+    });
+    translate_blst.addIncludePath(blst_artifact.getEmittedIncludeTree());
+    bls_module.addImport("blst_c", translate_blst.createModule());
 }

--- a/src/bls/blst_c.h
+++ b/src/bls/blst_c.h
@@ -1,0 +1,1 @@
+#include <blst.h>

--- a/src/bls/root.zig
+++ b/src/bls/root.zig
@@ -2,9 +2,7 @@ const std = @import("std");
 const testing = std.testing;
 
 /// Expose c types for lodestar-bun bindings
-pub const c = @cImport({
-    @cInclude("blst.h");
-});
+pub const c = @import("blst_c");
 
 // blst Zig native types
 pub const Pairing = @import("Pairing.zig");


### PR DESCRIPTION
Wire blst.h translation through an addTranslateC step after zbuild.configureBuild, replacing the now-deprecated @cImport  closes #530.