### PR TITLE
fix: bound beacon runtime and sync work

### DIFF
--- a/src/node/p2p_runtime.zig
+++ b/src/node/p2p_runtime.zig
@@ -28,6 +28,26 @@ const ReqRespContext = networking.ReqRespContext;
 const ConnectionDirection = networking.ConnectionDirection;
 const GoodbyeReason = networking.GoodbyeReason;
 const PeerAction = networking.PeerAction;
+test "data column subnet subscriptions use actual custody columns" {
+    const custody_columns = [_]u64{ 3, 46, 70, 81 };
+    const subnets = try dataColumnSubnetsForCustodyColumns(std.testing.allocator, &custody_columns);
+    defer std.testing.allocator.free(subnets);
+    try std.testing.expectEqualSlices(u8, &[_]u8{ 3, 46, 70, 81 }, subnets);
+}
+
+fn dataColumnSubnetsForCustodyColumns(allocator: std.mem.Allocator, custody_columns: []const u64) ![]u8 {
+    const subnet_count = networking.gossip_topics.MAX_DATA_COLUMN_SIDECAR_SUBNET_ID;
+    var selected = std.StaticBitSet(subnet_count).initEmpty();
+    for (custody_columns) |column_index| selected.set(@intCast(column_index % subnet_count));
+    const subnets = try allocator.alloc(u8, selected.count());
+    var out_i: usize = 0;
+    for (0..subnet_count) |subnet_id| {
+        if (!selected.isSet(subnet_id)) continue;
+        subnets[out_i] = @intCast(subnet_id);
+        out_i += 1;
+    }
+    return subnets;
+}
 const peer_scoring = networking.peer_scoring;
 const StatusMessage = networking.messages.StatusMessage;
 const StatusMessageV2 = networking.messages.StatusMessageV2;
@@ -146,6 +166,48 @@ const OutboundDialEvent = union(enum) {
     dial: OutboundDialAttemptResult,
     timeout: TimeoutWaitResult,
 };
+
+const ReqRespOpenAttemptResult = union(enum) {
+    success: networking.QuicStream,
+    failure: anyerror,
+    canceled,
+};
+const ReqRespOpenEvent = union(enum) {
+    dial: ReqRespOpenAttemptResult,
+    timeout: TimeoutWaitResult,
+};
+const ResponseReadAttemptResult = union(enum) {
+    success: ?networking.req_resp_encoding.DecodedResponseChunk,
+    failure: anyerror,
+    canceled,
+};
+const ResponseReadEvent = union(enum) {
+    read: ResponseReadAttemptResult,
+    timeout: TimeoutWaitResult,
+};
+
+fn freeReqRespOpenEvent(io: std.Io, event: ReqRespOpenEvent) void {
+    switch (event) {
+        .dial => |result| switch (result) {
+            .success => |stream| {
+                var owned_stream = stream;
+                closeOwnedQuicStream(io, &owned_stream);
+            },
+            .failure, .canceled => {},
+        },
+        .timeout => {},
+    }
+}
+
+fn freeResponseReadEvent(allocator: std.mem.Allocator, event: ResponseReadEvent) void {
+    switch (event) {
+        .read => |result| switch (result) {
+            .success => |maybe_chunk| if (maybe_chunk) |chunk| allocator.free(chunk.ssz_bytes),
+            .failure, .canceled => {},
+        },
+        .timeout => {},
+    }
+}
 
 fn freeOutboundDialEvent(allocator: std.mem.Allocator, event: OutboundDialEvent) void {
     switch (event) {
@@ -557,6 +619,84 @@ test "outbound dial helper times out hung dial attempts" {
             .{ std.testing.io, 50 },
         ),
     );
+}
+
+test "req/resp protocol open timeout is shorter than connection dial timeout" {
+    try std.testing.expect(reqresp_open_timeout_ms < outbound_dial_timeout_ms);
+    try std.testing.expectEqual(optional_reqresp_timeout_ms, reqresp_open_timeout_ms);
+}
+
+test "goodbye req/resp open timeout is shorter than regular req/resp open timeout" {
+    try std.testing.expect(goodbye_reqresp_open_timeout_ms < reqresp_open_timeout_ms);
+}
+
+fn sleepingResponseReadAttemptTask(io: std.Io, delay_ms: u64) ResponseReadAttemptResult {
+    const sleep_timeout: std.Io.Timeout = .{ .duration = .{
+        .raw = std.Io.Duration.fromMilliseconds(@intCast(delay_ms)),
+        .clock = .awake,
+    } };
+    sleep_timeout.sleep(io) catch |err| switch (err) {
+        error.Canceled => return .canceled,
+    };
+    return .{ .failure = error.TestUnexpectedResult };
+}
+
+fn delayedResponseChunkReadAttemptTask(
+    allocator: std.mem.Allocator,
+    io: std.Io,
+    delay_ms: u64,
+) ResponseReadAttemptResult {
+    const sleep_timeout: std.Io.Timeout = .{ .duration = .{
+        .raw = std.Io.Duration.fromMilliseconds(@intCast(delay_ms)),
+        .clock = .awake,
+    } };
+    sleep_timeout.sleep(io) catch |err| switch (err) {
+        error.Canceled => return .canceled,
+    };
+    const ssz_bytes = allocator.dupe(u8, "chunk") catch |err| return .{ .failure = err };
+    return .{ .success = .{
+        .result = .success,
+        .context_bytes = null,
+        .ssz_bytes = ssz_bytes,
+        .bytes_consumed = ssz_bytes.len,
+    } };
+}
+
+test "req/resp response deadline bounds complete multi-chunk transfer" {
+    const deadline = reqRespResponseDeadline(std.testing.io, 100);
+
+    const first = (try awaitResponseReadWithDeadline(
+        std.testing.allocator,
+        std.testing.io,
+        deadline,
+        delayedResponseChunkReadAttemptTask,
+        .{ std.testing.allocator, std.testing.io, 60 },
+    )).?;
+    defer std.testing.allocator.free(first.ssz_bytes);
+    try std.testing.expectEqualStrings("chunk", first.ssz_bytes);
+
+    try std.testing.expectError(error.Timeout, awaitResponseReadWithDeadline(
+        std.testing.allocator,
+        std.testing.io,
+        deadline,
+        delayedResponseChunkReadAttemptTask,
+        .{ std.testing.allocator, std.testing.io, 60 },
+    ));
+}
+
+test "req/resp response read helper times out hung response streams" {
+    try std.testing.expectError(error.Timeout, awaitResponseReadWithTimeout(
+        std.testing.allocator,
+        std.testing.io,
+        5,
+        sleepingResponseReadAttemptTask,
+        .{ std.testing.io, 50 },
+    ));
+}
+
+test "req/resp response timeout matches Lodestar response transfer timeout" {
+    try std.testing.expect(reqresp_response_timeout_ms > reqresp_open_timeout_ms);
+    try std.testing.expectEqual(@as(u64, 10_000), reqresp_response_timeout_ms);
 }
 
 test "peerNeedsMetadata distinguishes unknown metadata from seq zero" {
@@ -993,17 +1133,18 @@ fn subscribeInitialSubnets(self: *BeaconNode, io: std.Io, svc: *networking.P2pSe
         log.info("Attestation subnet gossip subscriptions will follow validator subnet demand", .{});
     }
 
-    const custody_group_count = @min(
-        self.chain_runtime.custody_columns.len,
-        @as(usize, gossip_topics.MAX_DATA_COLUMN_SIDECAR_SUBNET_ID),
-    );
-    var data_column_subnet: u8 = 0;
-    while (@as(usize, data_column_subnet) < custody_group_count) : (data_column_subnet += 1) {
+    const data_column_subnets = dataColumnSubnetsForCustodyColumns(self.allocator, self.chain_runtime.custody_columns) catch |err| {
+        log.warn("Failed to compute local data column custody subnets: {}", .{err});
+        return;
+    };
+    defer self.allocator.free(data_column_subnets);
+
+    for (data_column_subnets) |data_column_subnet| {
         svc.subscribeSubnet(io, .data_column_sidecar, data_column_subnet) catch |err| {
             log.warn("Failed to subscribe to data column subnet {d}: {}", .{ data_column_subnet, err });
         };
     }
-    log.info("Subscribed to {d} data column subnets (local custody groups)", .{custody_group_count});
+    log.info("Subscribed to {d} data column subnets (local custody columns)", .{data_column_subnets.len});
 }
 
 fn setInitialSubnetSubscriptionsEnabled(
@@ -1029,12 +1170,13 @@ fn setInitialSubnetSubscriptionsEnabled(
         }
     }
 
-    const custody_group_count = @min(
-        self.chain_runtime.custody_columns.len,
-        @as(usize, gossip_topics.MAX_DATA_COLUMN_SIDECAR_SUBNET_ID),
-    );
-    var data_column_subnet: u8 = 0;
-    while (@as(usize, data_column_subnet) < custody_group_count) : (data_column_subnet += 1) {
+    const data_column_subnets = dataColumnSubnetsForCustodyColumns(self.allocator, self.chain_runtime.custody_columns) catch |err| {
+        log.warn("Failed to compute local data column custody subnets: {}", .{err});
+        return;
+    };
+    defer self.allocator.free(data_column_subnets);
+
+    for (data_column_subnets) |data_column_subnet| {
         if (enabled) {
             svc.subscribeSubnet(io, .data_column_sidecar, data_column_subnet) catch |err| {
                 log.warn("Failed to subscribe to data column subnet {d}: {}", .{ data_column_subnet, err });
@@ -1109,6 +1251,7 @@ const OpenedReqRespRequest = struct {
     request_payload_bytes: u64 = 0,
     response_payload_bytes: u64 = 0,
     response_chunks: u64 = 0,
+    response_deadline: ?std.Io.Clock.Timestamp = null,
     finished: bool = false,
 
     fn noteRequestPayload(self: *OpenedReqRespRequest, payload_bytes: usize) void {
@@ -1118,6 +1261,13 @@ const OpenedReqRespRequest = struct {
     fn noteResponseChunk(self: *OpenedReqRespRequest, payload_bytes: usize) void {
         self.response_chunks +|= 1;
         self.response_payload_bytes +|= @as(u64, @intCast(payload_bytes));
+    }
+
+    fn responseDeadline(self: *OpenedReqRespRequest, io: std.Io) std.Io.Clock.Timestamp {
+        if (self.response_deadline == null) {
+            self.response_deadline = reqRespResponseDeadline(io, reqresp_response_timeout_ms);
+        }
+        return self.response_deadline.?;
     }
 
     fn finish(self: *OpenedReqRespRequest, io: std.Io, outcome: networking.ReqRespRequestOutcome) void {
@@ -1156,13 +1306,14 @@ fn responseCodeOutcome(code: networking.ResponseCode) networking.ReqRespRequestO
     return networking.ReqRespRequestOutcome.fromResponseCode(code);
 }
 
-fn openReqRespRequest(
+fn openReqRespRequestWithTimeout(
     self: *BeaconNode,
     io: std.Io,
     svc: *networking.P2pService,
     peer_id: []const u8,
     method: networking.rate_limiter.SelfRateLimitMethod,
     protocol_id: []const u8,
+    timeout_ms: u64,
 ) !OpenedReqRespRequest {
     const started_ns = std.Io.Clock.awake.now(io).nanoseconds;
     const req_resp_method = reqRespMethodFromSelfLimitMethod(method);
@@ -1187,7 +1338,7 @@ fn openReqRespRequest(
         protocol_id,
     });
 
-    const stream = svc.dialProtocol(io, peer_id, protocol_id) catch |err| {
+    const stream = dialReqRespProtocolWithTimeout(io, svc, peer_id, protocol_id, timeout_ms) catch |err| {
         if (self.metrics) |metrics| {
             metrics.observeReqRespOutbound(req_resp_method, .transport_error, reqRespElapsedSeconds(io, started_ns), 0, 0, 0);
         }
@@ -1200,6 +1351,17 @@ fn openReqRespRequest(
         .method = req_resp_method,
         .started_ns = started_ns,
     };
+}
+
+fn openReqRespRequest(
+    self: *BeaconNode,
+    io: std.Io,
+    svc: *networking.P2pService,
+    peer_id: []const u8,
+    method: networking.rate_limiter.SelfRateLimitMethod,
+    protocol_id: []const u8,
+) !OpenedReqRespRequest {
+    return openReqRespRequestWithTimeout(self, io, svc, peer_id, method, protocol_id, reqresp_open_timeout_ms);
 }
 
 fn bootstrapBootnodes(self: *BeaconNode, io: std.Io, svc: *networking.P2pService) void {
@@ -1253,6 +1415,9 @@ const direct_peer_redial_max_backoff_ms: u64 = 30_000;
 // paths have the same bounded behavior.
 const outbound_dial_timeout_ms: u64 = 30_000;
 const optional_reqresp_timeout_ms: u64 = 3_000;
+const reqresp_open_timeout_ms: u64 = optional_reqresp_timeout_ms;
+const goodbye_reqresp_open_timeout_ms: u64 = 1_000;
+const reqresp_response_timeout_ms: u64 = 10_000;
 
 const TimeoutWaitResult = enum {
     fired,
@@ -3128,6 +3293,155 @@ fn outboundDialAttemptTask(
     return .{ .success = peer_id };
 }
 
+fn awaitReqRespOpenWithTimeout(
+    io: std.Io,
+    timeout_ms: u64,
+    comptime AttemptTask: anytype,
+    attempt_args: anytype,
+) !networking.QuicStream {
+    var events_buf: [2]ReqRespOpenEvent = undefined;
+    var select = std.Io.Select(ReqRespOpenEvent).init(io, &events_buf);
+    errdefer while (select.cancel()) |event| freeReqRespOpenEvent(io, event);
+
+    try select.concurrent(.dial, AttemptTask, attempt_args);
+    select.async(.timeout, waitTimeout, .{ io, .{ .duration = .{
+        .raw = std.Io.Duration.fromMilliseconds(@intCast(timeout_ms)),
+        .clock = .awake,
+    } } });
+
+    while (true) {
+        const event = try select.await();
+        switch (event) {
+            .dial => |result| {
+                while (select.cancel()) |pending| freeReqRespOpenEvent(io, pending);
+                return switch (result) {
+                    .success => |stream| stream,
+                    .failure => |err| err,
+                    .canceled => error.Canceled,
+                };
+            },
+            .timeout => |result| switch (result) {
+                .fired => {
+                    while (select.cancel()) |pending| freeReqRespOpenEvent(io, pending);
+                    return error.Timeout;
+                },
+                .canceled => {},
+            },
+        }
+    }
+}
+
+fn reqRespResponseDeadline(io: std.Io, timeout_ms: u64) std.Io.Clock.Timestamp {
+    return .{
+        .raw = std.Io.Clock.awake.now(io).addDuration(std.Io.Duration.fromMilliseconds(@intCast(timeout_ms))),
+        .clock = .awake,
+    };
+}
+
+fn awaitResponseReadWithDeadline(
+    allocator: std.mem.Allocator,
+    io: std.Io,
+    deadline: std.Io.Clock.Timestamp,
+    comptime AttemptTask: anytype,
+    attempt_args: anytype,
+) !?networking.req_resp_encoding.DecodedResponseChunk {
+    var events_buf: [2]ResponseReadEvent = undefined;
+    var select = std.Io.Select(ResponseReadEvent).init(io, &events_buf);
+    errdefer while (select.cancel()) |event| freeResponseReadEvent(allocator, event);
+
+    try select.concurrent(.read, AttemptTask, attempt_args);
+    select.async(.timeout, waitTimeout, .{ io, .{ .deadline = deadline } });
+
+    while (true) {
+        const event = try select.await();
+        switch (event) {
+            .read => |result| {
+                while (select.cancel()) |pending| freeResponseReadEvent(allocator, pending);
+                return switch (result) {
+                    .success => |maybe_chunk| maybe_chunk,
+                    .failure => |err| err,
+                    .canceled => error.Canceled,
+                };
+            },
+            .timeout => |result| switch (result) {
+                .fired => {
+                    while (select.cancel()) |pending| freeResponseReadEvent(allocator, pending);
+                    return error.Timeout;
+                },
+                .canceled => {},
+            },
+        }
+    }
+}
+
+fn awaitResponseReadWithTimeout(
+    allocator: std.mem.Allocator,
+    io: std.Io,
+    timeout_ms: u64,
+    comptime AttemptTask: anytype,
+    attempt_args: anytype,
+) !?networking.req_resp_encoding.DecodedResponseChunk {
+    return awaitResponseReadWithDeadline(
+        allocator,
+        io,
+        reqRespResponseDeadline(io, timeout_ms),
+        AttemptTask,
+        attempt_args,
+    );
+}
+
+fn responseChunkReadAttemptTask(
+    io: std.Io,
+    reader: *networking.req_resp_encoding.ResponseChunkStreamReader,
+    stream: *networking.QuicStream,
+) ResponseReadAttemptResult {
+    const maybe_chunk = reader.next(io, stream) catch |err| switch (err) {
+        error.Canceled => return .canceled,
+        else => return .{ .failure = err },
+    };
+    return .{ .success = maybe_chunk };
+}
+
+fn nextResponseChunkWithTimeout(
+    self: *BeaconNode,
+    io: std.Io,
+    reader: *networking.req_resp_encoding.ResponseChunkStreamReader,
+    outbound: *OpenedReqRespRequest,
+) !?networking.req_resp_encoding.DecodedResponseChunk {
+    return awaitResponseReadWithDeadline(
+        self.allocator,
+        io,
+        outbound.responseDeadline(io),
+        responseChunkReadAttemptTask,
+        .{ io, reader, &outbound.stream },
+    );
+}
+
+fn reqRespOpenAttemptTask(
+    io: std.Io,
+    svc: *networking.P2pService,
+    peer_id: []const u8,
+    protocol_id: []const u8,
+) ReqRespOpenAttemptResult {
+    const stream = svc.dialProtocol(io, peer_id, protocol_id) catch |err| return .{ .failure = err };
+    return .{ .success = stream };
+}
+
+fn dialReqRespProtocolWithTimeout(
+    io: std.Io,
+    svc: *networking.P2pService,
+    peer_id: []const u8,
+    protocol_id: []const u8,
+    timeout_ms: u64,
+) !networking.QuicStream {
+    return awaitReqRespOpenWithTimeout(
+        io,
+        timeout_ms,
+        reqRespOpenAttemptTask,
+        .{ io, svc, peer_id, protocol_id },
+    );
+}
+
 fn awaitOutboundDialAttemptWithTimeout(
     allocator: std.mem.Allocator,
     io: std.Io,
@@ -4113,7 +4427,7 @@ fn fetchBlobSidecarsByRangeForMetas(
     };
     defer reader.deinit();
 
-    while (try reader.next(io, &outbound.stream)) |decoded| {
+    while (try nextResponseChunkWithTimeout(self, io, &reader, &outbound)) |decoded| {
         outbound.noteResponseChunk(decoded.ssz_bytes.len);
         if (decoded.result != .success) {
             self.allocator.free(decoded.ssz_bytes);
@@ -4249,7 +4563,7 @@ fn fetchBlobSidecarsByRootForMeta(
     };
     defer reader.deinit();
 
-    while (try reader.next(io, &outbound.stream)) |decoded| {
+    while (try nextResponseChunkWithTimeout(self, io, &reader, &outbound)) |decoded| {
         outbound.noteResponseChunk(decoded.ssz_bytes.len);
         if (decoded.result != .success) {
             self.allocator.free(decoded.ssz_bytes);
@@ -4428,7 +4742,7 @@ fn fetchDataColumnsByRangeOnce(
     };
     defer reader.deinit();
 
-    while (try reader.next(io, &outbound.stream)) |decoded| {
+    while (try nextResponseChunkWithTimeout(self, io, &reader, &outbound)) |decoded| {
         outbound.noteResponseChunk(decoded.ssz_bytes.len);
         if (decoded.result != .success) {
             self.allocator.free(decoded.ssz_bytes);
@@ -4702,7 +5016,7 @@ fn fetchDataColumnsByRootOnceForMetas(
     };
     defer reader.deinit();
 
-    while (try reader.next(io, &outbound.stream)) |decoded| {
+    while (try nextResponseChunkWithTimeout(self, io, &reader, &outbound)) |decoded| {
         outbound.noteResponseChunk(decoded.ssz_bytes.len);
         if (decoded.result != .success) {
             self.allocator.free(decoded.ssz_bytes);
@@ -4812,7 +5126,7 @@ fn fetchDataColumnsByRootOnce(
 
     const blob_commitments = try meta.any_signed.beaconBlock().beaconBlockBody().blobKzgCommitments();
 
-    while (try reader.next(io, &outbound.stream)) |decoded| {
+    while (try nextResponseChunkWithTimeout(self, io, &reader, &outbound)) |decoded| {
         outbound.noteResponseChunk(decoded.ssz_bytes.len);
         if (decoded.result != .success) {
             self.allocator.free(decoded.ssz_bytes);
@@ -5094,7 +5408,7 @@ fn fetchBlockByRoot(
     };
     defer reader.deinit();
 
-    const decoded = (try reader.next(io, &outbound.stream)) orelse return error.NoBlockReturned;
+    const decoded = (try nextResponseChunkWithTimeout(self, io, &reader, &outbound)) orelse return error.NoBlockReturned;
     outbound.noteResponseChunk(decoded.ssz_bytes.len);
     if (decoded.result != .success) {
         self.allocator.free(decoded.ssz_bytes);
@@ -5149,7 +5463,7 @@ fn fetchRawBlocksByRange(
     var previous_chunk: ?ValidatedBlockRangeChunk = null;
 
     while (blocks_received < count) {
-        const decoded = reader.next(io, &outbound.stream) catch |err| {
+        const decoded = nextResponseChunkWithTimeout(self, io, &reader, &outbound) catch |err| {
             if (err == error.UnexpectedEof and result.items.len > 0) {
                 log.debug("blocks-by-range from {s}: salvaging {d} block(s) after unexpected EOF", .{
                     peer_id,
@@ -5180,7 +5494,7 @@ fn fetchRawBlocksByRange(
     }
 
     if (blocks_received == count) {
-        const extra = reader.next(io, &outbound.stream) catch |err| {
+        const extra = nextResponseChunkWithTimeout(self, io, &reader, &outbound) catch |err| {
             if (err == error.UnexpectedEof) return error.MalformedBlockBytes;
             return err;
         };
@@ -5304,7 +5618,7 @@ fn sendStatus(
     };
     defer reader.deinit();
 
-    const decoded = (try reader.next(io, &outbound.stream)) orelse {
+    const decoded = (try nextResponseChunkWithTimeout(self, io, &reader, &outbound)) orelse {
         log.debug("Status: peer sent empty response", .{});
         return error.EmptyResponse;
     };
@@ -5403,7 +5717,7 @@ fn requestPeerPing(
     };
     defer reader.deinit();
 
-    const decoded = (try reader.next(io, &outbound.stream)) orelse return error.EmptyResponse;
+    const decoded = (try nextResponseChunkWithTimeout(self, io, &reader, &outbound)) orelse return error.EmptyResponse;
     outbound.noteResponseChunk(decoded.ssz_bytes.len);
     defer self.allocator.free(decoded.ssz_bytes);
 
@@ -5523,7 +5837,7 @@ fn requestPeerMetadataAttempt(
     };
     defer reader.deinit();
 
-    const decoded = (reader.next(io, &outbound.stream) catch |err| {
+    const decoded = (nextResponseChunkWithTimeout(self, io, &reader, &outbound) catch |err| {
         log.debug(
             "Metadata reader failed for {s}: {} buffered={d} eof={}",
             .{
@@ -5753,7 +6067,15 @@ fn sendGoodbye(
     const goodbye_protocol_id = "/eth2/beacon_chain/req/goodbye/1/ssz_snappy";
     const req_resp_encoding = networking.req_resp_encoding;
 
-    var outbound = try openReqRespRequest(self, io, svc, peer_id, .goodbye, goodbye_protocol_id);
+    var outbound = try openReqRespRequestWithTimeout(
+        self,
+        io,
+        svc,
+        peer_id,
+        .goodbye,
+        goodbye_protocol_id,
+        goodbye_reqresp_open_timeout_ms,
+    );
     defer outbound.deinit(io);
     var request_outcome: networking.ReqRespRequestOutcome = .transport_error;
     defer outbound.finish(io, request_outcome);

--- a/src/processor/work_queues.zig
+++ b/src/processor/work_queues.zig
@@ -677,10 +677,12 @@ pub const WorkQueues = struct {
         if (self.api_request_p0.pop()) |w| return .{ .api_request_p0 = w };
 
         // Priority 15-18: recovered unknown-root fast lanes.
-        if (self.recovered_unknown_block_aggregate.len > 0 and self.recoveredUnknownBlockAggregateBatchReady(now_ns)) {
+        // These paths perform gossip BLS verification too, so they must obey
+        // the same dispatch gate as ordinary aggregate/attestation batches.
+        if (self.aggregate_dispatch_enabled and self.recovered_unknown_block_aggregate.len > 0 and self.recoveredUnknownBlockAggregateBatchReady(now_ns)) {
             return self.formRecoveredUnknownBlockAggregateBatch();
         }
-        if (self.recovered_unknown_block_attestation.len > 0 and self.recoveredUnknownBlockAttestationBatchReady(now_ns)) {
+        if (self.attestation_dispatch_enabled and self.recovered_unknown_block_attestation.len > 0 and self.recoveredUnknownBlockAttestationBatchReady(now_ns)) {
             return self.formRecoveredUnknownBlockAttestationBatch();
         }
 
@@ -1315,6 +1317,9 @@ test "WorkQueues: gossip bls dispatch gate defers attestation and aggregate work
 
     wq.setGossipBlsBatchDispatchEnabled(false);
     wq.routeToQueue(.{ .attestation = testAttestationWork(1, 0, 1_000) });
+    wq.routeToQueue(.{ .aggregate = testAggregateWork(2, 1_100) });
+    wq.routeToQueue(.{ .recovered_unknown_block_attestation = testAttestationWork(3, 0, 1_200) });
+    wq.routeToQueue(.{ .recovered_unknown_block_aggregate = testAggregateWork(4, 1_300) });
     wq.routeToQueue(.{ .status = .{
         .peer_id = testPeerId(1),
         .request = testOpaqueHandle(2),
@@ -1325,6 +1330,9 @@ test "WorkQueues: gossip bls dispatch gate defers attestation and aggregate work
     try testing.expectEqual(WorkType.status, first.workType());
     try testing.expect(wq.popHighestPriorityAt(10_000) == null);
     try testing.expectEqual(@as(u32, 1), wq.attestation.len);
+    try testing.expectEqual(@as(u32, 1), wq.aggregate.len);
+    try testing.expectEqual(@as(u32, 1), wq.recovered_unknown_block_attestation.len);
+    try testing.expectEqual(@as(u32, 1), wq.recovered_unknown_block_aggregate.len);
 }
 
 test "WorkQueues: sync message batching holds briefly for a fuller batch" {

--- a/src/sync/batch.zig
+++ b/src/sync/batch.zig
@@ -53,8 +53,10 @@ pub const Batch = struct {
     processing_started_ns: i128,
     /// Generation counter — incremented on each download attempt.
     generation: u32,
-    /// Peer currently downloading this batch (valid when status == downloading).
-    download_peer: ?[]const u8,
+    /// Owned copy of the peer currently downloading this batch (valid when
+    /// status == downloading). This remains valid even if the peer leaves the
+    /// sync peer map while the request is in flight.
+    download_peer: ?[]u8,
     /// Last peer whose download failed. Used as a soft exclusion on retry.
     last_failed_peer: ?[]u8,
     /// Owned copy of the peer that supplied the currently retained batch data.
@@ -123,6 +125,7 @@ pub const Batch = struct {
     /// Release all owned resources.
     pub fn deinit(self: *Batch) void {
         self.freeBlocks();
+        self.clearPeerMemory(&self.download_peer);
         self.clearPeerMemory(&self.last_failed_peer);
         self.clearPeerMemory(&self.current_attempt_peer);
         self.clearDeferredPeers();
@@ -246,10 +249,12 @@ pub const Batch = struct {
         return self.blocks;
     }
 
-    /// Transition to downloading state — assigns a peer and bumps generation.
-    pub fn startDownload(self: *Batch, peer_id: []const u8) void {
+    /// Transition to downloading state after successfully owning the peer ID.
+    pub fn startDownload(self: *Batch, peer_id: []const u8) std.mem.Allocator.Error!void {
+        const owned_peer = try self.allocator.dupe(u8, peer_id);
+        self.clearPeerMemory(&self.download_peer);
+        self.download_peer = owned_peer;
         self.status = .downloading;
-        self.download_peer = peer_id;
         self.download_started_ns = nowNs(self.io);
         self.generation +%= 1;
     }
@@ -262,6 +267,7 @@ pub const Batch = struct {
 
         if (!self.rememberDownloadedBlocks(blocks)) return false;
         self.rememberCurrentAttemptPeer();
+        self.clearPeerMemory(&self.download_peer);
         self.clearPeerMemory(&self.last_failed_peer);
         self.clearDeferredPeers();
         self.status = .awaiting_processing;
@@ -275,7 +281,7 @@ pub const Batch = struct {
         if (self.status != .downloading) return false;
         self.download_failures += 1;
         self.rememberPeer(&self.last_failed_peer);
-        self.download_peer = null;
+        self.clearPeerMemory(&self.download_peer);
         self.status = .awaiting_download;
         return true;
     }
@@ -290,7 +296,7 @@ pub const Batch = struct {
 
         self.clearPeerMemory(&self.last_failed_peer);
         self.rememberDeferredPeer();
-        self.download_peer = null;
+        self.clearPeerMemory(&self.download_peer);
         self.status = .awaiting_download;
         return true;
     }
@@ -316,7 +322,7 @@ pub const Batch = struct {
         self.rememberFailedProcessingPeer();
         self.freeBlocks();
         self.status = .awaiting_download;
-        self.download_peer = null;
+        self.clearPeerMemory(&self.download_peer);
     }
 
     /// Called when a later batch shows this processed batch must be retried.
@@ -387,7 +393,7 @@ test "Batch: lifecycle" {
     try std.testing.expectEqual(@as(u64, 163), b.endSlot());
 
     // Start download — generation bumps to 1.
-    b.startDownload("peer_a");
+    try b.startDownload("peer_a");
     try std.testing.expectEqual(BatchStatus.downloading, b.status);
     try std.testing.expectEqual(@as(u32, 1), b.generation);
 
@@ -411,18 +417,33 @@ test "Batch: lifecycle" {
 test "Batch: download error retry" {
     var b = Batch.init(std.testing.io, 1, 0, 32, std.testing.allocator);
     defer b.deinit();
-    b.startDownload("peer_b");
+    try b.startDownload("peer_b");
     const gen = b.generation;
     try std.testing.expect(b.onDownloadError(gen));
     try std.testing.expectEqual(BatchStatus.awaiting_download, b.status);
     try std.testing.expectEqual(@as(u8, 1), b.download_failures);
 }
 
+test "Batch: in-flight download peer survives source peer removal" {
+    var b = Batch.init(std.testing.io, 5, 0, 32, std.testing.allocator);
+    defer b.deinit();
+
+    const transient_peer = try std.testing.allocator.dupe(u8, "peer_removed_before_error");
+    try b.startDownload(transient_peer);
+    const gen = b.generation;
+    std.testing.allocator.free(transient_peer);
+
+    try std.testing.expect(b.onDownloadError(gen));
+    try std.testing.expectEqual(BatchStatus.awaiting_download, b.status);
+    try std.testing.expectEqual(@as(u8, 1), b.download_failures);
+    try std.testing.expectEqualStrings("peer_removed_before_error", b.last_failed_peer.?);
+}
+
 test "Batch: download deferred does not consume retry budget" {
     var b = Batch.init(std.testing.io, 3, 0, 32, std.testing.allocator);
     defer b.deinit();
 
-    b.startDownload("peer_e");
+    try b.startDownload("peer_e");
     const gen = b.generation;
     const blocks = [_]BatchBlock{.{ .slot = 1, .block_bytes = "b1" }};
     try std.testing.expect(b.onDownloadDeferred(gen, &blocks));
@@ -436,11 +457,11 @@ test "Batch: download deferred does not consume retry budget" {
 test "Batch: generation prevents stale error" {
     var b = Batch.init(std.testing.io, 2, 50, 10, std.testing.allocator);
     defer b.deinit();
-    b.startDownload("peer_c");
+    try b.startDownload("peer_c");
     const old_gen = b.generation;
 
     // Re-assign to new peer — new generation.
-    b.startDownload("peer_d");
+    try b.startDownload("peer_d");
     const new_gen = b.generation;
     try std.testing.expect(old_gen != new_gen);
 
@@ -453,7 +474,7 @@ test "Batch: validation error retries processed batch" {
     var b = Batch.init(std.testing.io, 4, 0, 32, std.testing.allocator);
     defer b.deinit();
 
-    b.startDownload("peer_f");
+    try b.startDownload("peer_f");
     const gen = b.generation;
     const blocks = [_]BatchBlock{.{ .slot = 1, .block_bytes = "b1" }};
     try std.testing.expect(b.onDownloadSuccess(gen, &blocks));
@@ -477,14 +498,14 @@ test "Batch: deferred blocks are reused on successful retry" {
         .{ .slot = 65, .block_bytes = "b65" },
     };
 
-    b.startDownload("peer_a");
+    try b.startDownload("peer_a");
     const first_gen = b.generation;
     try std.testing.expect(b.onDownloadDeferred(first_gen, &blocks));
 
     const retained = b.getBlocks();
     const retained_ptr = retained.ptr;
 
-    b.startDownload("peer_b");
+    try b.startDownload("peer_b");
     const second_gen = b.generation;
     try std.testing.expect(b.onDownloadSuccess(second_gen, retained));
     try std.testing.expectEqual(BatchStatus.awaiting_processing, b.status);
@@ -495,7 +516,7 @@ test "Batch: processing error remembers batch producer" {
     var b = Batch.init(std.testing.io, 6, 0, 32, std.testing.allocator);
     defer b.deinit();
 
-    b.startDownload("peer_g");
+    try b.startDownload("peer_g");
     const gen = b.generation;
     const blocks = [_]BatchBlock{.{ .slot = 1, .block_bytes = "b1" }};
     try std.testing.expect(b.onDownloadSuccess(gen, &blocks));

--- a/src/sync/sync_chain.zig
+++ b/src/sync/sync_chain.zig
@@ -527,8 +527,9 @@ pub const SyncChain = struct {
         return active_downloads;
     }
 
-    /// Dispatch download requests for all awaiting_download batches.
+    /// Dispatch awaiting downloads while preserving the active request/processing cap.
     fn dispatchDownloads(self: *SyncChain) void {
+        var active_count = self.activeDispatchCount();
         for (self.batches.items) |*b| {
             if (b.status == .awaiting_download) {
                 if (b.isDownloadExhausted()) {
@@ -536,16 +537,18 @@ pub const SyncChain = struct {
                     b.status = .awaiting_validation;
                     continue;
                 }
+                if (active_count >= sync_types.MAX_PENDING_BATCHES) return;
                 const peer = self.selectPeer(b) orelse continue;
+                b.startDownload(peer) catch continue;
                 scoped_log.debug("SyncChain dispatch: chain={d} batch={d} gen={d} slots={d}..{d} peer={s}", .{
                     self.id,
                     b.id,
-                    b.generation +% 1,
+                    b.generation,
                     b.start_slot,
                     b.endSlot(),
                     peer,
                 });
-                b.startDownload(peer);
+                active_count += 1;
                 self.cumulative_metrics.download_requests_total += 1;
                 self.callbacks.downloadByRange(
                     self.id,
@@ -559,9 +562,26 @@ pub const SyncChain = struct {
         }
     }
 
-    /// Fill the batch window up to MAX_PENDING_BATCHES.
+    fn activeDispatchCount(self: *const SyncChain) usize {
+        var count: usize = 0;
+        for (self.batches.items) |batch| {
+            switch (batch.status) {
+                .downloading, .awaiting_processing, .processing => count += 1,
+                .awaiting_download, .awaiting_validation => {},
+            }
+        }
+        return count;
+    }
+
+    /// Fill the active download/processing window up to MAX_PENDING_BATCHES.
+    ///
+    /// Match Lodestar-TS range sync: batches that are already
+    /// AwaitingValidation must not count against the buffer, otherwise a long
+    /// run of empty/skip-slot batches can fill the whole window and prevent the
+    /// next batch from being downloaded to validate that prefix.
     fn fillBatchWindow(self: *SyncChain) void {
-        while (self.batches.items.len < sync_types.MAX_PENDING_BATCHES and
+        var active_buffered = self.activeBufferedBatchCount();
+        while (active_buffered < sync_types.MAX_PENDING_BATCHES and
             self.next_batch_start <= self.target.slot)
         {
             const remaining = self.target.slot - self.next_batch_start + 1;
@@ -571,8 +591,17 @@ pub const SyncChain = struct {
             self.next_batch_id +%= 1;
 
             self.batches.append(self.allocator, Batch.init(self.io, id, self.next_batch_start, count, self.allocator)) catch return;
+            active_buffered += 1;
             self.next_batch_start += count;
         }
+    }
+
+    fn activeBufferedBatchCount(self: *const SyncChain) usize {
+        var count: usize = 0;
+        for (self.batches.items) |batch| {
+            if (batch.status != .awaiting_validation) count += 1;
+        }
+        return count;
     }
 
     fn nextProcessableBatchIndex(self: *const SyncChain) ?usize {
@@ -972,6 +1001,133 @@ test "SyncChain: pending processing waits for completion callback" {
     const done_after_completion = try chain.tick();
     try std.testing.expect(done_after_completion);
     try std.testing.expectEqual(SyncChainStatus.done, chain.status);
+}
+
+test "SyncChain: awaiting-validation window does not block next download" {
+    const allocator = std.testing.allocator;
+    var tc = TestSyncCallbacks{};
+    var chain = SyncChain.init(
+        allocator,
+        std.testing.io,
+        0,
+        .finalized,
+        0,
+        .{ .slot = sync_types.BATCH_SIZE * (sync_types.MAX_PENDING_BATCHES + 1), .root = [_]u8{0x88} ** 32 },
+        tc.callbacks(),
+    );
+    defer chain.deinit();
+
+    try chain.addPeer("p1", .{ .slot = sync_types.BATCH_SIZE * (sync_types.MAX_PENDING_BATCHES + 1), .root = [_]u8{0x88} ** 32 }, null);
+    chain.startSyncing();
+
+    _ = try chain.tick();
+    try std.testing.expectEqual(@as(usize, sync_types.MAX_PENDING_BATCHES), chain.batches.items.len);
+    const initial_downloads = tc.downloaded_count;
+    try std.testing.expectEqual(@as(u32, sync_types.MAX_PENDING_BATCHES), initial_downloads);
+
+    var batch_ids: [sync_types.MAX_PENDING_BATCHES]BatchId = undefined;
+    var generations: [sync_types.MAX_PENDING_BATCHES]u32 = undefined;
+    for (chain.batches.items, 0..) |batch, index| {
+        batch_ids[index] = batch.id;
+        generations[index] = batch.generation;
+    }
+
+    const no_blocks = [_]BatchBlock{};
+    for (batch_ids, generations) |batch_id, generation| {
+        chain.onBatchResponse(batch_id, generation, &no_blocks);
+    }
+
+    try std.testing.expectEqual(@as(usize, sync_types.MAX_PENDING_BATCHES), chain.batches.items.len);
+    for (chain.batches.items) |batch| {
+        try std.testing.expectEqual(BatchStatus.awaiting_validation, batch.status);
+    }
+
+    _ = try chain.tick();
+    try std.testing.expect(tc.downloaded_count > initial_downloads);
+    try std.testing.expect(chain.batches.items.len > sync_types.MAX_PENDING_BATCHES);
+}
+
+test "SyncChain: rewind does not exceed pending dispatch window" {
+    const allocator = std.testing.allocator;
+    var tc = TestSyncCallbacks{};
+    const target_slot = sync_types.BATCH_SIZE * (sync_types.MAX_PENDING_BATCHES * 2);
+    var chain = SyncChain.init(
+        allocator,
+        std.testing.io,
+        0,
+        .finalized,
+        0,
+        .{ .slot = target_slot, .root = [_]u8{0x99} ** 32 },
+        tc.callbacks(),
+    );
+    defer chain.deinit();
+
+    try chain.addPeer("p1", .{ .slot = target_slot, .root = [_]u8{0x99} ** 32 }, null);
+    chain.startSyncing();
+
+    _ = try chain.tick();
+    var prefix_ids: [sync_types.MAX_PENDING_BATCHES]BatchId = undefined;
+    var prefix_generations: [sync_types.MAX_PENDING_BATCHES]u32 = undefined;
+    for (chain.batches.items, 0..) |batch, index| {
+        prefix_ids[index] = batch.id;
+        prefix_generations[index] = batch.generation;
+    }
+    for (prefix_ids, prefix_generations) |batch_id, generation| {
+        chain.onBatchResponse(batch_id, generation, &.{});
+    }
+
+    _ = try chain.tick();
+    try std.testing.expectEqual(@as(usize, sync_types.MAX_PENDING_BATCHES * 2), chain.batches.items.len);
+
+    const validating_index = sync_types.MAX_PENDING_BATCHES;
+    const validating_batch = chain.batches.items[validating_index];
+    const blocks = [_]BatchBlock{.{ .slot = validating_batch.start_slot, .block_bytes = "invalid" }};
+    tc.should_fail_processing = true;
+    chain.onBatchResponse(validating_batch.id, validating_batch.generation, &blocks);
+    tc.should_fail_processing = false;
+
+    _ = try chain.tick();
+    var active_count: usize = 0;
+    var queued_count: usize = 0;
+    for (chain.batches.items) |batch| {
+        switch (batch.status) {
+            .downloading, .awaiting_processing, .processing => active_count += 1,
+            .awaiting_download => queued_count += 1,
+            .awaiting_validation => {},
+        }
+    }
+    try std.testing.expect(active_count <= sync_types.MAX_PENDING_BATCHES);
+    try std.testing.expect(queued_count > 0);
+}
+
+test "SyncChain: peer ownership failure does not dispatch download" {
+    var failing_allocator_state = std.testing.FailingAllocator.init(std.testing.allocator, .{});
+    const allocator = failing_allocator_state.allocator();
+    var tc = TestSyncCallbacks{};
+    var chain = SyncChain.init(
+        allocator,
+        std.testing.io,
+        0,
+        .finalized,
+        0,
+        .{ .slot = sync_types.BATCH_SIZE - 1, .root = [_]u8{0xA5} ** 32 },
+        tc.callbacks(),
+    );
+    defer chain.deinit();
+
+    chain.startSyncing();
+    _ = try chain.tick();
+    try std.testing.expectEqual(@as(usize, 1), chain.batches.items.len);
+    try chain.addPeer("p1", .{ .slot = sync_types.BATCH_SIZE - 1, .root = [_]u8{0xA5} ** 32 }, null);
+
+    failing_allocator_state.fail_index = failing_allocator_state.alloc_index;
+    _ = try chain.tick();
+
+    try std.testing.expect(failing_allocator_state.has_induced_failure);
+    try std.testing.expectEqual(@as(u32, 0), tc.downloaded_count);
+    try std.testing.expectEqual(BatchStatus.awaiting_download, chain.batches.items[0].status);
+    try std.testing.expectEqual(@as(u32, 0), chain.batches.items[0].generation);
+    try std.testing.expectEqual(@as(?[]u8, null), chain.batches.items[0].download_peer);
 }
 
 test "SyncChain: later batch validates earlier batch" {


### PR DESCRIPTION
## Summary
- subscribe to data-column subnets derived from the node's actual custody columns
- bound req/resp protocol opens and the complete response transfer so slow peers cannot monopolize the P2P loop
- apply BLS dispatch gates to recovered unknown-block gossip work
- preserve peer ownership across in-flight sync downloads and keep validation/rewind paths within the pending batch window
- exclude the temporary QUIC/gossipsub tracing dependency, debug metrics, trace scripts, and investigation-only artifacts

## Review notes
- Response timeouts use one absolute deadline for the complete multi-chunk transfer, matching Lodestar-TS `respTimeoutMs` semantics rather than resetting per chunk.
- Sync retry dispatch remains capped after a long awaiting-validation prefix is rewound.
- `Batch.startDownload` is transactional under allocator failure: no state, generation, metric, or callback changes occur unless peer ownership succeeds.
