### PR TITLE
fix(bls): enforce 32-byte signing roots

### DIFF
--- a/bindings/napi/blst.zig
+++ b/bindings/napi/blst.zig
@@ -117,12 +117,6 @@ fn uint8SliceFromValue(value: js.Value) ![]u8 {
     return info.data;
 }
 
-/// Validates a dynamic N-API byte slice and narrows it to the fixed BLS message type.
-fn signingRootFromBytes(bytes: []const u8) !*const SigningRoot {
-    if (bytes.len != @sizeOf(SigningRoot)) return error.InvalidMessageLength;
-    return bytes[0..@sizeOf(SigningRoot)];
-}
-
 pub const PublicKey = struct {
     pub const js_meta = js.class(.{});
 
@@ -335,8 +329,9 @@ pub const SecretKey = struct {
 
     /// Signs a message with this `SecretKey`, returns a `Signature`.
     pub fn sign(self: *const SecretKey, msg: js.Uint8Array) !Signature {
-        const signing_root = try signingRootFromBytes(try msg.toSlice());
-        return .{ .raw = self.raw.sign(signing_root, DST, null) };
+        const msg_bytes = try msg.toSlice();
+        if (msg_bytes.len != @sizeOf(SigningRoot)) return error.InvalidMessageLength;
+        return .{ .raw = self.raw.sign(msg_bytes[0..@sizeOf(SigningRoot)], DST, null) };
     }
 
     /// Derives the PublicKey from this SecretKey.
@@ -366,11 +361,12 @@ pub const SecretKey = struct {
 /// 4) pk_validate: ?bool
 /// 5) sig_groupcheck: ?bool
 pub fn verify(msg: js.Uint8Array, pk: PublicKey, sig: Signature, pk_validate: ?js.Boolean, sig_groupcheck: ?js.Boolean) !js.Boolean {
-    const signing_root = try signingRootFromBytes(try msg.toSlice());
+    const msg_bytes = try msg.toSlice();
+    if (msg_bytes.len != @sizeOf(SigningRoot)) return error.InvalidMessageLength;
 
     sig.raw.verify(
         try boolOrDefault(sig_groupcheck, false),
-        signing_root,
+        msg_bytes[0..@sizeOf(SigningRoot)],
         DST,
         null,
         &pk.raw,
@@ -402,7 +398,8 @@ pub fn aggregateVerify(msgs: js.Array, pks: js.Array, sig: Signature, pks_valida
     for (0..msgs_len) |i| {
         const msg_value = try msgs.get(@intCast(i));
         const msg_bytes = try uint8SliceFromValue(msg_value);
-        msg_bufs[i] = (try signingRootFromBytes(msg_bytes)).*;
+        if (msg_bytes.len != @sizeOf(SigningRoot)) return error.InvalidMessageLength;
+        msg_bufs[i] = msg_bytes[0..@sizeOf(SigningRoot)].*;
 
         const wrapped_pk = try unwrapClass(PublicKey, try pks.get(@intCast(i)));
         pk_ptrs[i] = &wrapped_pk.raw;
@@ -433,7 +430,8 @@ pub fn aggregateVerify(msgs: js.Array, pks: js.Array, sig: Signature, pks_valida
 /// 3) sig: Signature
 /// 4) sigs_groupcheck: ?bool
 pub fn fastAggregateVerify(msg: js.Uint8Array, pks: js.Array, sig: Signature, sigs_groupcheck: ?js.Boolean) !js.Boolean {
-    const signing_root = try signingRootFromBytes(try msg.toSlice());
+    const msg_bytes = try msg.toSlice();
+    if (msg_bytes.len != @sizeOf(SigningRoot)) return error.InvalidMessageLength;
 
     const pks_len = try pks.length();
     if (pks_len == 0) return js.Boolean.from(false);
@@ -451,7 +449,7 @@ pub fn fastAggregateVerify(msg: js.Uint8Array, pks: js.Array, sig: Signature, si
     const result = sig.raw.fastAggregateVerify(
         try boolOrDefault(sigs_groupcheck, false),
         &pairing_buf,
-        signing_root,
+        msg_bytes[0..@sizeOf(SigningRoot)],
         DST,
         native_pks,
         false,
@@ -517,7 +515,8 @@ pub fn verifyMultipleAggregateSignatures(sets: js.Array, pks_validate: ?js.Boole
 
         const msg_napi = try set.getNamedProperty("msg");
         const msg_bytes = try uint8SliceFromValue(.{ .val = msg_napi });
-        msgs[i] = (try signingRootFromBytes(msg_bytes)).*;
+        if (msg_bytes.len != @sizeOf(SigningRoot)) return error.InvalidMessageLength;
+        msgs[i] = msg_bytes[0..@sizeOf(SigningRoot)].*;
 
         const pk_napi = try set.getNamedProperty("pk");
         const wrapped_pk = try unwrapClass(PublicKey, .{ .val = pk_napi });

--- a/bindings/napi/blst.zig
+++ b/bindings/napi/blst.zig
@@ -19,6 +19,7 @@ const bls = @import("bls");
 const NativePublicKey = bls.PublicKey;
 const NativeSignature = bls.Signature;
 const NativeSecretKey = bls.SecretKey;
+const SigningRoot = bls.SigningRoot;
 const Pairing = bls.Pairing;
 const AggregatePublicKey = bls.AggregatePublicKey;
 const AggregateSignature = bls.AggregateSignature;
@@ -114,6 +115,12 @@ fn uint8SliceFromValue(value: js.Value) ![]u8 {
     const info = try raw.getTypedarrayInfo();
     if (info.array_type != .uint8) return error.TypeMismatch;
     return info.data;
+}
+
+/// Validates a dynamic N-API byte slice and narrows it to the fixed BLS message type.
+fn signingRootFromBytes(bytes: []const u8) !*const SigningRoot {
+    if (bytes.len != @sizeOf(SigningRoot)) return error.InvalidMessageLength;
+    return @ptrCast(bytes.ptr);
 }
 
 pub const PublicKey = struct {
@@ -328,8 +335,8 @@ pub const SecretKey = struct {
 
     /// Signs a message with this `SecretKey`, returns a `Signature`.
     pub fn sign(self: *const SecretKey, msg: js.Uint8Array) !Signature {
-        const slice = try msg.toSlice();
-        return .{ .raw = self.raw.sign(slice, DST, null) };
+        const signing_root = try signingRootFromBytes(try msg.toSlice());
+        return .{ .raw = self.raw.sign(signing_root, DST, null) };
     }
 
     /// Derives the PublicKey from this SecretKey.
@@ -359,11 +366,11 @@ pub const SecretKey = struct {
 /// 4) pk_validate: ?bool
 /// 5) sig_groupcheck: ?bool
 pub fn verify(msg: js.Uint8Array, pk: PublicKey, sig: Signature, pk_validate: ?js.Boolean, sig_groupcheck: ?js.Boolean) !js.Boolean {
-    const msg_slice = try msg.toSlice();
+    const signing_root = try signingRootFromBytes(try msg.toSlice());
 
     sig.raw.verify(
         try boolOrDefault(sig_groupcheck, false),
-        msg_slice,
+        signing_root,
         DST,
         null,
         &pk.raw,
@@ -386,7 +393,7 @@ pub fn aggregateVerify(msgs: js.Array, pks: js.Array, sig: Signature, pks_valida
         return error.InvalidAggregateVerifyInput;
     }
 
-    const msg_bufs = try allocator.alloc([32]u8, msgs_len);
+    const msg_bufs = try allocator.alloc(SigningRoot, msgs_len);
     defer allocator.free(msg_bufs);
 
     const pk_ptrs = try allocator.alloc(*NativePublicKey, pks_len);
@@ -395,8 +402,7 @@ pub fn aggregateVerify(msgs: js.Array, pks: js.Array, sig: Signature, pks_valida
     for (0..msgs_len) |i| {
         const msg_value = try msgs.get(@intCast(i));
         const msg_bytes = try uint8SliceFromValue(msg_value);
-        if (msg_bytes.len != 32) return error.InvalidMessageLength;
-        @memcpy(&msg_bufs[i], msg_bytes[0..32]);
+        msg_bufs[i] = (try signingRootFromBytes(msg_bytes)).*;
 
         const wrapped_pk = try unwrapClass(PublicKey, try pks.get(@intCast(i)));
         pk_ptrs[i] = &wrapped_pk.raw;
@@ -427,8 +433,7 @@ pub fn aggregateVerify(msgs: js.Array, pks: js.Array, sig: Signature, pks_valida
 /// 3) sig: Signature
 /// 4) sigs_groupcheck: ?bool
 pub fn fastAggregateVerify(msg: js.Uint8Array, pks: js.Array, sig: Signature, sigs_groupcheck: ?js.Boolean) !js.Boolean {
-    const msg_slice = try msg.toSlice();
-    if (msg_slice.len != 32) return error.InvalidMessageLength;
+    const signing_root = try signingRootFromBytes(try msg.toSlice());
 
     const pks_len = try pks.length();
     if (pks_len == 0) return js.Boolean.from(false);
@@ -446,7 +451,7 @@ pub fn fastAggregateVerify(msg: js.Uint8Array, pks: js.Array, sig: Signature, si
     const result = sig.raw.fastAggregateVerify(
         try boolOrDefault(sigs_groupcheck, false),
         &pairing_buf,
-        msg_slice[0..32],
+        signing_root,
         DST,
         native_pks,
         false,
@@ -466,12 +471,12 @@ pub fn verifyMultipleAggregateSignatures(sets: js.Array, pks_validate: ?js.Boole
     const n_elems = try sets.length();
     if (n_elems == 0) return js.Boolean.from(false);
 
-    var msgs_stack: [BATCH_VERIFY_SIZE][]const u8 = undefined;
+    var msgs_stack: [BATCH_VERIFY_SIZE]SigningRoot = undefined;
     var pks_stack: [BATCH_VERIFY_SIZE]*NativePublicKey = undefined;
     var sigs_stack: [BATCH_VERIFY_SIZE]*NativeSignature = undefined;
     var rands_stack: [BATCH_VERIFY_SIZE][32]u8 = undefined;
 
-    var msgs_heap: ?[][]const u8 = null;
+    var msgs_heap: ?[]SigningRoot = null;
     defer if (msgs_heap) |buf| allocator.free(buf);
     var pks_heap: ?[]*NativePublicKey = null;
     defer if (pks_heap) |buf| allocator.free(buf);
@@ -481,7 +486,7 @@ pub fn verifyMultipleAggregateSignatures(sets: js.Array, pks_validate: ?js.Boole
     defer if (rands_heap) |buf| allocator.free(buf);
 
     const msgs = if (n_elems <= BATCH_VERIFY_SIZE) msgs_stack[0..n_elems] else blk: {
-        const buf = try allocator.alloc([]const u8, n_elems);
+        const buf = try allocator.alloc(SigningRoot, n_elems);
         msgs_heap = buf;
         break :blk buf;
     };
@@ -512,8 +517,7 @@ pub fn verifyMultipleAggregateSignatures(sets: js.Array, pks_validate: ?js.Boole
 
         const msg_napi = try set.getNamedProperty("msg");
         const msg_bytes = try uint8SliceFromValue(.{ .val = msg_napi });
-        if (msg_bytes.len != 32) return error.InvalidMessageLength;
-        msgs[i] = msg_bytes;
+        msgs[i] = (try signingRootFromBytes(msg_bytes)).*;
 
         const pk_napi = try set.getNamedProperty("pk");
         const wrapped_pk = try unwrapClass(PublicKey, .{ .val = pk_napi });

--- a/bindings/napi/blst.zig
+++ b/bindings/napi/blst.zig
@@ -120,7 +120,7 @@ fn uint8SliceFromValue(value: js.Value) ![]u8 {
 /// Validates a dynamic N-API byte slice and narrows it to the fixed BLS message type.
 fn signingRootFromBytes(bytes: []const u8) !*const SigningRoot {
     if (bytes.len != @sizeOf(SigningRoot)) return error.InvalidMessageLength;
-    return @ptrCast(bytes.ptr);
+    return bytes[0..@sizeOf(SigningRoot)];
 }
 
 pub const PublicKey = struct {

--- a/bindings/src/blst.d.ts
+++ b/bindings/src/blst.d.ts
@@ -34,6 +34,7 @@ export class SecretKey {
   static fromBytes(bytes: Uint8Array): SecretKey;
   static fromHex(hex: string): SecretKey;
   static fromKeygen(ikm: Uint8Array, keyInfo?: Uint8Array): SecretKey;
+  /** Sign an exact 32-byte Ethereum consensus signing root. */
   sign(msg: Uint8Array): Signature;
   toPublicKey(): PublicKey;
   toBytes(): Uint8Array;
@@ -85,6 +86,7 @@ export class Signature {
 }
 
 export interface SignatureSet {
+  /** Exact 32-byte Ethereum consensus signing root. */
   msg: Uint8Array;
   pk: PublicKey;
   sig: Signature;
@@ -101,7 +103,7 @@ export interface PkAndSig {
 }
 
 /**
- * Verify a signature against a message and public key.
+ * Verify a signature against an exact 32-byte Ethereum consensus signing root and public key.
  *
  * If `pkValidate` is `true`, the public key will be infinity and group checked.
  *
@@ -116,7 +118,7 @@ export function verify(
 ): boolean;
 
 /**
- * Verify an aggregated signature against multiple messages and multiple public keys.
+ * Verify an aggregated signature against exact 32-byte Ethereum consensus signing roots and multiple public keys.
  *
  * If `pksValidate` is `true`, the public keys will be infinity and group checked.
  *
@@ -131,7 +133,7 @@ export function aggregateVerify(
 ): boolean;
 
 /**
- * Verify an aggregated signature against a single message and multiple public keys.
+ * Verify an aggregated signature against a single exact 32-byte Ethereum consensus signing root and multiple public keys.
  *
  * Proof-of-possession is required for public keys.
  *
@@ -145,7 +147,7 @@ export function fastAggregateVerify(
 ): boolean;
 
 /**
- * Verify multiple aggregated signatures against multiple messages and multiple public keys.
+ * Verify multiple aggregated signatures against exact 32-byte Ethereum consensus signing roots and multiple public keys.
  *
  * If `pksValidate` is `true`, the public keys will be infinity and group checked.
  *

--- a/bindings/test/blst.test.ts
+++ b/bindings/test/blst.test.ts
@@ -234,11 +234,18 @@ describe("blst", () => {
         });
       });
       describe("sign", () => {
-        it("should create a valid Signature", () => {
-          const sig = SecretKey.fromKeygen(KEY_MATERIAL, undefined).sign(Buffer.from("some fancy message"));
+        it("should create a valid Signature for a 32-byte signing root", () => {
+          const sig = SecretKey.fromKeygen(KEY_MATERIAL, undefined).sign(new Uint8Array(32));
           expect(sig).to.be.instanceOf(Signature);
           expect(sig.validate(false)).to.be.undefined;
         });
+
+        for (const length of [31, 33]) {
+          it(`should throw InvalidMessageLength for a ${length}-byte signing root`, () => {
+            const sk = SecretKey.fromKeygen(KEY_MATERIAL, undefined);
+            expect(() => sk.sign(new Uint8Array(length))).toThrow("InvalidMessageLength");
+          });
+        }
       });
     });
   });
@@ -258,6 +265,14 @@ describe("blst", () => {
       const result = verify(wrongMessage, pk, sig, false, false);
       expect(result).toBe(false);
     });
+
+    for (const length of [31, 33]) {
+      it(`should throw InvalidMessageLength for a ${length}-byte signing root`, () => {
+        const pk = PublicKey.fromHex(TEST_VECTORS.publicKey.compressed);
+        const sig = Signature.fromHex(TEST_VECTORS.signature.compressed);
+        expect(() => verify(new Uint8Array(length), pk, sig, false, false)).toThrow("InvalidMessageLength");
+      });
+    }
   });
 
   describe("aggregateVerify", () => {
@@ -278,6 +293,14 @@ describe("blst", () => {
       const sig = Signature.fromHex(TEST_VECTORS.signature.compressed);
       expect(aggregateVerify([TEST_VECTORS.message], [pk], sig)).to.be.true;
     });
+
+    for (const length of [31, 33]) {
+      it(`should throw InvalidMessageLength for a ${length}-byte signing root`, () => {
+        const pk = PublicKey.fromHex(TEST_VECTORS.publicKey.compressed);
+        const sig = Signature.fromHex(TEST_VECTORS.signature.compressed);
+        expect(() => aggregateVerify([new Uint8Array(length)], [pk], sig)).toThrow("InvalidMessageLength");
+      });
+    }
   });
 
   describe("fastAggregateVerify", () => {
@@ -302,11 +325,13 @@ describe("blst", () => {
       expect(result).toBe(false);
     });
 
-    it("should throw on wrong message length", () => {
-      const pk = PublicKey.fromHex(TEST_VECTORS.publicKey.compressed);
-      const sig = Signature.fromHex(TEST_VECTORS.signature.compressed);
-      expect(() => fastAggregateVerify(new Uint8Array(31), [pk], sig, false)).toThrow();
-    });
+    for (const length of [31, 33]) {
+      it(`should throw InvalidMessageLength for a ${length}-byte signing root`, () => {
+        const pk = PublicKey.fromHex(TEST_VECTORS.publicKey.compressed);
+        const sig = Signature.fromHex(TEST_VECTORS.signature.compressed);
+        expect(() => fastAggregateVerify(new Uint8Array(length), [pk], sig, false)).toThrow("InvalidMessageLength");
+      });
+    }
   });
 
   describe("verifyMultipleAggregateSignatures", () => {
@@ -329,6 +354,15 @@ describe("blst", () => {
         verifyMultipleAggregateSignatures([{msg, pk, sig: pk as unknown as Signature}], false, false)
       ).toThrow("TypeMismatch");
     });
+
+    for (const length of [31, 33]) {
+      it(`should throw InvalidMessageLength for a ${length}-byte signing root`, () => {
+        const [set] = getTestSets(1);
+        expect(() => verifyMultipleAggregateSignatures([{...set, msg: new Uint8Array(length)}], false, false)).toThrow(
+          "InvalidMessageLength"
+        );
+      });
+    }
   });
 
   describe("aggregatePublicKeys", () => {

--- a/src/bls/Pairing.zig
+++ b/src/bls/Pairing.zig
@@ -54,7 +54,7 @@ pub fn aggregate(
     pk_validate: bool,
     sig: ?*const Signature,
     sig_groupcheck: bool,
-    msg: []const u8,
+    msg: *const SigningRoot,
     aug: ?[]const u8,
 ) BlstError!void {
     try errorFromInt(
@@ -64,8 +64,8 @@ pub fn aggregate(
             pk_validate,
             if (sig) |s| &s.point else null,
             sig_groupcheck,
-            msg.ptr,
-            msg.len,
+            msg,
+            @sizeOf(SigningRoot),
             if (aug) |a| a.ptr else null,
             if (aug) |a| a.len else 0,
         ),
@@ -83,7 +83,7 @@ pub fn mulAndAggregate(
     sig_groupcheck: bool,
     scalar: []const u8,
     nbits: usize,
-    msg: []const u8,
+    msg: *const SigningRoot,
 ) BlstError!void {
     try errorFromInt(
         c.blst_pairing_chk_n_mul_n_aggr_pk_in_g1(
@@ -94,8 +94,8 @@ pub fn mulAndAggregate(
             sig_groupcheck,
             scalar.ptr,
             nbits,
-            msg.ptr,
-            32,
+            msg,
+            @sizeOf(SigningRoot),
             null,
             0,
         ),
@@ -153,3 +153,4 @@ const errorFromInt = @import("error.zig").errorFromInt;
 const blst = @import("root.zig");
 const PublicKey = blst.PublicKey;
 const Signature = blst.Signature;
+const SigningRoot = blst.SigningRoot;

--- a/src/bls/SecretKey.zig
+++ b/src/bls/SecretKey.zig
@@ -122,13 +122,13 @@ pub fn toPublicKey(self: *const Self) PublicKey {
 }
 
 /// Sign a message with this `SecretKey`. Returns the `Signature` for the message.
-pub fn sign(self: *const Self, msg: []const u8, dst: []const u8, aug: ?[]const u8) Signature {
+pub fn sign(self: *const Self, msg: *const SigningRoot, dst: []const u8, aug: ?[]const u8) Signature {
     var sig = Signature{};
     var q = @import("AggregateSignature.zig"){};
     c.blst_hash_to_g2(
         @ptrCast(&q.point),
-        msg.ptr,
-        msg.len,
+        msg,
+        @sizeOf(SigningRoot),
         dst.ptr,
         dst.len,
         if (aug) |a| a.ptr else null,
@@ -163,6 +163,7 @@ const check = @import("error.zig").check;
 const blst = @import("root.zig");
 const PublicKey = blst.PublicKey;
 const Signature = blst.Signature;
+const SigningRoot = blst.SigningRoot;
 
 const c = @import("root.zig").c;
 

--- a/src/bls/Signature.zig
+++ b/src/bls/Signature.zig
@@ -117,7 +117,7 @@ pub fn fastAggregateVerify(
     return try self.aggregateVerify(
         sig_groupcheck,
         buffer,
-        @as([*]const SigningRoot, @ptrCast(msg))[0..1],
+        @ptrCast(msg),
         dst,
         &[_]PublicKey{pk},
         false,

--- a/src/bls/Signature.zig
+++ b/src/bls/Signature.zig
@@ -27,7 +27,7 @@ pub fn validate(self: *const Self, sig_infcheck: bool) BlstError!void {
 pub fn verify(
     self: *const Self,
     sig_groupcheck: bool,
-    msg: []const u8,
+    msg: *const SigningRoot,
     dst: []const u8,
     aug: ?[]const u8,
     pk: *const PublicKey,
@@ -36,7 +36,7 @@ pub fn verify(
     if (sig_groupcheck) try self.validate(false);
     if (pk_validate) try pk.validate();
 
-    if (msg.len == 0 or dst.len == 0) {
+    if (dst.len == 0) {
         return BlstError.BadEncoding;
     }
 
@@ -44,8 +44,8 @@ pub fn verify(
         @ptrCast(&pk.point),
         &self.point,
         true,
-        msg.ptr,
-        msg.len,
+        msg,
+        @sizeOf(SigningRoot),
         dst.ptr,
         dst.len,
         if (aug) |a| a.ptr else null,
@@ -62,7 +62,7 @@ pub fn aggregateVerify(
     self: *const Self,
     sig_groupcheck: bool,
     buffer: *align(Pairing.buf_align) [Pairing.sizeOf()]u8,
-    msgs: []const [32]u8,
+    msgs: []const SigningRoot,
     dst: []const u8,
     pks: []const PublicKey,
     pks_validate: bool,
@@ -106,7 +106,7 @@ pub fn fastAggregateVerify(
     self: *const Self,
     sig_groupcheck: bool,
     buffer: *align(Pairing.buf_align) [Pairing.sizeOf()]u8,
-    msg: *const [32]u8,
+    msg: *const SigningRoot,
     dst: []const u8,
     pks: []const PublicKey,
     pks_validate: bool,
@@ -117,7 +117,7 @@ pub fn fastAggregateVerify(
     return try self.aggregateVerify(
         sig_groupcheck,
         buffer,
-        @ptrCast(msg),
+        @as([*]const SigningRoot, @ptrCast(msg))[0..1],
         dst,
         &[_]PublicKey{pk},
         false,
@@ -131,7 +131,7 @@ pub fn fastAggregateVerifyPreAggregated(
     self: *const Self,
     sig_groupcheck: bool,
     buffer: *align(Pairing.buf_align) [Pairing.sizeOf()]u8,
-    msg: *const [32]u8,
+    msg: *const SigningRoot,
     dst: []const u8,
     pk: *const PublicKey,
 ) BlstError!bool {
@@ -139,7 +139,7 @@ pub fn fastAggregateVerifyPreAggregated(
     return try self.aggregateVerify(
         sig_groupcheck,
         buffer,
-        @ptrCast(msg),
+        @as([*]const SigningRoot, @ptrCast(msg))[0..1],
         dst,
         pks[0..1],
         false,
@@ -216,6 +216,7 @@ const c = @import("root.zig").c;
 const BlstError = @import("error.zig").BlstError;
 const errorFromInt = @import("error.zig").errorFromInt;
 const PublicKey = @import("root.zig").PublicKey;
+const SigningRoot = @import("root.zig").SigningRoot;
 const AggregatePublicKey = @import("AggregatePublicKey.zig");
 const AggregateSignature = @import("AggregateSignature.zig");
 const Pairing = @import("Pairing.zig");
@@ -231,7 +232,8 @@ const ikm: [32]u8 = [_]u8{
 
 test uncompress {
     const sk = try SecretKey.keyGen(&ikm, null);
-    const sig = sk.sign("hello foo", DST, null);
+    const signing_root = [_]u8{0x42} ** 32;
+    const sig = sk.sign(&signing_root, DST, null);
     const sig_comp = sig.compress();
 
     // Valid compressed bytes round-trip.
@@ -257,13 +259,13 @@ test "test_sign_n_verify" {
     const pk = sk.toPublicKey();
 
     const dst = DST;
-    const msg = "hello foo";
-    const sig = sk.sign(msg, dst, null);
+    const signing_root = [_]u8{0x42} ** 32;
+    const sig = sk.sign(&signing_root, dst, null);
 
     // aug is null
     try sig.verify(
         true,
-        msg,
+        &signing_root,
         dst,
         null,
         &pk,

--- a/src/bls/ThreadPool.zig
+++ b/src/bls/ThreadPool.zig
@@ -17,6 +17,7 @@ const Pairing = @import("Pairing.zig");
 const blst = @import("root.zig");
 const PublicKey = blst.PublicKey;
 const Signature = blst.Signature;
+const SigningRoot = blst.SigningRoot;
 const AggregatePublicKey = blst.AggregatePublicKey;
 const AggregateSignature = blst.AggregateSignature;
 const BlstError = @import("error.zig").BlstError;
@@ -202,7 +203,7 @@ pub fn submitAndWait(pool: *ThreadPool, io: std.Io, items: []*WorkItem) (PoolErr
 const VerifyMultiJob = struct {
     pks: []const *PublicKey,
     sigs: []const *Signature,
-    msgs: []const []const u8,
+    msgs: []const SigningRoot,
     rands: []const [32]u8,
     dst: []const u8,
     pks_validate: bool,
@@ -237,7 +238,7 @@ const VerifyMultiWorkItem = struct {
                 job.sigs_groupcheck,
                 &job.rands[i],
                 RAND_BITS,
-                job.msgs[i],
+                &job.msgs[i],
             ) catch {
                 job.err_flag.store(true, .release);
                 break;
@@ -257,7 +258,7 @@ pub fn verifyMultipleAggregateSignatures(
     pool: *ThreadPool,
     io: std.Io,
     n_elems: usize,
-    msgs: []const []const u8,
+    msgs: []const SigningRoot,
     dst: []const u8,
     pks: []const *PublicKey,
     pks_validate: bool,
@@ -310,7 +311,7 @@ pub fn verifyMultipleAggregateSignatures(
 
 const AggVerifyJob = struct {
     pks: []const *PublicKey,
-    msgs: []const [32]u8,
+    msgs: []const SigningRoot,
     dst: []const u8,
     pks_validate: bool,
     n_elems: usize,
@@ -365,7 +366,7 @@ pub fn aggregateVerify(
     io: std.Io,
     sig: *const Signature,
     sig_groupcheck: bool,
-    msgs: []const [32]u8,
+    msgs: []const SigningRoot,
     dst: []const u8,
     pks: []const *PublicKey,
     pks_validate: bool,
@@ -498,8 +499,7 @@ test "verifyMultipleAggregateSignatures multi-threaded" {
 
     const num_sigs = 16;
 
-    var msgs: [num_sigs][32]u8 = undefined;
-    var msg_refs: [num_sigs][]const u8 = undefined;
+    var msgs: [num_sigs]SigningRoot = undefined;
     var pks: [num_sigs]PublicKey = undefined;
     var sigs: [num_sigs]Signature = undefined;
     var pk_ptrs: [num_sigs]*PublicKey = undefined;
@@ -519,7 +519,6 @@ test "verifyMultipleAggregateSignatures multi-threaded" {
         const sk = try SecretKey.keyGen(&ikm_i, null);
         pks[i] = sk.toPublicKey();
         sigs[i] = sk.sign(&msgs[i], blst.DST, null);
-        msg_refs[i] = &msgs[i];
         pk_ptrs[i] = &pks[i];
         sig_ptrs[i] = &sigs[i];
     }
@@ -530,7 +529,7 @@ test "verifyMultipleAggregateSignatures multi-threaded" {
     const result = try pool.verifyMultipleAggregateSignatures(
         std.testing.io,
         num_sigs,
-        &msg_refs,
+        &msgs,
         blst.DST,
         &pk_ptrs,
         true,

--- a/src/bls/fast_verify.zig
+++ b/src/bls/fast_verify.zig
@@ -12,7 +12,7 @@ const RAND_BITS = 8 * RAND_BYTES;
 pub fn verifyMultipleAggregateSignatures(
     pairing_buf: *align(Pairing.buf_align) [Pairing.sizeOf()]u8,
     n_elems: usize,
-    msgs: []const []const u8,
+    msgs: []const SigningRoot,
     dst: []const u8,
     pks: []const *PublicKey,
     pks_validate: bool,
@@ -38,7 +38,7 @@ pub fn verifyMultipleAggregateSignatures(
             sigs_groupcheck,
             &rands[i],
             RAND_BITS,
-            msgs[i],
+            &msgs[i],
         );
     }
 
@@ -52,3 +52,4 @@ const Pairing = @import("Pairing.zig");
 const blst = @import("root.zig");
 const PublicKey = blst.PublicKey;
 const Signature = blst.Signature;
+const SigningRoot = blst.SigningRoot;

--- a/src/bls/root.zig
+++ b/src/bls/root.zig
@@ -15,6 +15,9 @@ pub const AggregatePublicKey = @import("AggregatePublicKey.zig");
 pub const AggregateSignature = @import("AggregateSignature.zig");
 pub const BlstError = @import("error.zig").BlstError;
 
+/// Ethereum consensus BLS messages are fixed-size signing roots.
+pub const SigningRoot = [32]u8;
+
 pub const verifyMultipleAggregateSignatures = @import("fast_verify.zig").verifyMultipleAggregateSignatures;
 pub const ThreadPool = @import("ThreadPool.zig");
 pub const pippenger = @import("pippenger.zig");

--- a/src/state_transition/test_utils/interop_pubkeys.zig
+++ b/src/state_transition/test_utils/interop_pubkeys.zig
@@ -22,7 +22,7 @@ pub fn interopPubkeysCached(validator_count: usize, out: []BLSPubkey) !void {
     }
 }
 
-pub fn interopSign(validator_index: usize, message: []const u8) !bls.Signature {
+pub fn interopSign(validator_index: usize, message: *const bls.SigningRoot) !bls.Signature {
     var ikm = [_]u8{0} ** 32;
     const u64_slice = std.mem.bytesAsSlice(u64, ikm[0..8]);
     u64_slice[0] = @intCast(validator_index);

--- a/src/state_transition/utils/bls.zig
+++ b/src/state_transition/utils/bls.zig
@@ -16,6 +16,7 @@ const bls = @import("bls");
 const PublicKey = bls.PublicKey;
 const Signature = bls.Signature;
 const SecretKey = bls.SecretKey;
+const SigningRoot = bls.SigningRoot;
 
 const BlsOpts = struct {
     /// Decides whether the signature should be group checked.
@@ -24,13 +25,13 @@ const BlsOpts = struct {
     pk_validate: bool = false,
 };
 
-pub fn sign(sk: SecretKey, msg: []const u8) Signature {
+pub fn sign(sk: SecretKey, msg: *const SigningRoot) Signature {
     return sk.sign(msg, bls.DST, null);
 }
 
 /// Verify a signature against a message and public key.
 pub fn verify(
-    msg: []const u8,
+    msg: *const SigningRoot,
     pk: *const PublicKey,
     sig: *const Signature,
     opts: BlsOpts,
@@ -39,7 +40,7 @@ pub fn verify(
 }
 
 pub fn fastAggregateVerify(
-    msg: []const u8,
+    msg: *const SigningRoot,
     pks: []const PublicKey,
     sig: *const Signature,
     opts: BlsOpts,
@@ -48,7 +49,7 @@ pub fn fastAggregateVerify(
     return sig.fastAggregateVerify(
         opts.sig_groupcheck,
         &pairing_buf,
-        msg[0..32],
+        msg,
         bls.DST,
         pks,
         opts.pk_validate,

--- a/src/state_transition/utils/signature_sets.zig
+++ b/src/state_transition/utils/signature_sets.zig
@@ -3,7 +3,7 @@ const types = @import("consensus_types");
 pub const bls = @import("bls");
 const PublicKey = bls.PublicKey;
 const Signature = bls.Signature;
-const Root = types.primitive.Root.Type;
+const SigningRoot = bls.SigningRoot;
 const BLSSignature = types.primitive.BLSSignature.Type;
 const verify = @import("./bls.zig").verify;
 const fastAggregateVerify = @import("./bls.zig").fastAggregateVerify;
@@ -13,14 +13,14 @@ pub const SignatureSetType = enum { single, aggregate };
 pub const SingleSignatureSet = struct {
     // fromBytes api return PublicKey so it's more convenient to model this as value
     pubkey: PublicKey,
-    signing_root: Root,
+    signing_root: SigningRoot,
     signature: BLSSignature,
 };
 
 pub const AggregatedSignatureSet = struct {
     // fastAggregateVerify also requires []*const PublicKey
     pubkeys: []const PublicKey,
-    signing_root: Root,
+    signing_root: SigningRoot,
     signature: BLSSignature,
 };
 
@@ -42,7 +42,7 @@ pub fn verifyAggregatedSignatureSet(set: *const AggregatedSignatureSet) !bool {
     );
 }
 
-pub fn createSingleSignatureSetFromComponents(pubkey: *const PublicKey, signing_root: Root, signature: BLSSignature) SingleSignatureSet {
+pub fn createSingleSignatureSetFromComponents(pubkey: *const PublicKey, signing_root: SigningRoot, signature: BLSSignature) SingleSignatureSet {
     return .{
         .pubkey = pubkey,
         .signing_root = signing_root,
@@ -50,7 +50,7 @@ pub fn createSingleSignatureSetFromComponents(pubkey: *const PublicKey, signing_
     };
 }
 
-pub fn createAggregateSignatureSetFromComponents(pubkeys: []const PublicKey, signing_root: Root, signature: BLSSignature) AggregatedSignatureSet {
+pub fn createAggregateSignatureSetFromComponents(pubkeys: []const PublicKey, signing_root: SigningRoot, signature: BLSSignature) AggregatedSignatureSet {
     return .{
         .pubkeys = pubkeys,
         .signing_root = signing_root,

--- a/test/spec/bls/test_case.zig
+++ b/test/spec/bls/test_case.zig
@@ -78,7 +78,7 @@ pub fn aggregate_verify(gpa: Allocator, path: std.Io.Dir) !void {
 
         const pubkeys = try allocator.alloc(bls.PublicKey, num_sigs);
         defer allocator.free(pubkeys);
-        const messages = try allocator.alloc([32]u8, num_sigs);
+        const messages = try allocator.alloc(bls.SigningRoot, num_sigs);
         defer allocator.free(messages);
 
         var pk_buf: [bls.PublicKey.COMPRESS_SIZE]u8 = undefined;
@@ -94,10 +94,11 @@ pub fn aggregate_verify(gpa: Allocator, path: std.Io.Dir) !void {
         }
 
         for (aggregate_verify_test_data.input.messages, 0..) |msg_hex_bytes, i| {
-            _ = try std.fmt.hexToBytes(
+            const message = try std.fmt.hexToBytes(
                 messages[i][0..],
                 msg_hex_bytes[2..], // skip "0x" prefix
             );
+            try std.testing.expectEqual(@sizeOf(bls.SigningRoot), message.len);
         }
 
         const sig_bytes = try std.fmt.hexToBytes(
@@ -149,7 +150,7 @@ pub fn fast_aggregate_verify(gpa: Allocator, path: std.Io.Dir) !void {
         const pubkeys = try allocator.alloc(bls.PublicKey, num_sigs);
         defer allocator.free(pubkeys);
 
-        var msg_bytes: [32]u8 = undefined;
+        var msg_bytes: bls.SigningRoot = undefined;
         var pk_buf: [bls.PublicKey.COMPRESS_SIZE]u8 = undefined;
         var sig_buf: [bls.Signature.COMPRESS_SIZE]u8 = undefined;
         var pairing_buf: [bls.Pairing.sizeOf()]u8 align(bls.Pairing.buf_align) = undefined;
@@ -162,10 +163,11 @@ pub fn fast_aggregate_verify(gpa: Allocator, path: std.Io.Dir) !void {
             pubkeys[i] = try bls.PublicKey.deserialize(pk_bytes);
         }
 
-        _ = try std.fmt.hexToBytes(
+        const message = try std.fmt.hexToBytes(
             &msg_bytes,
             fast_aggregate_verify_test_data.input.message[2..], // skip "0x" prefix
         );
+        try std.testing.expectEqual(@sizeOf(bls.SigningRoot), message.len);
 
         const sig_bytes = try std.fmt.hexToBytes(
             &sig_buf,
@@ -213,8 +215,9 @@ pub fn sign(gpa: Allocator, path: std.Io.Dir) !void {
         var privkey: [32]u8 = undefined;
         _ = try std.fmt.hexToBytes(&privkey, sign_test_data.input.privkey[2..]); // skip "0x" prefix
 
-        var msg: [32]u8 = undefined;
-        _ = try std.fmt.hexToBytes(&msg, sign_test_data.input.message[2..]); // skip "0x" prefix
+        var msg: bls.SigningRoot = undefined;
+        const message = try std.fmt.hexToBytes(&msg, sign_test_data.input.message[2..]); // skip "0x" prefix
+        try std.testing.expectEqual(@sizeOf(bls.SigningRoot), message.len);
 
         const sk = bls.SecretKey.deserialize(&privkey) catch {
             // if secret key is invalid, expect signature to be "null"
@@ -256,7 +259,7 @@ pub fn verify(gpa: Allocator, path: std.Io.Dir) !void {
     {
         var pk_buf: [bls.PublicKey.COMPRESS_SIZE]u8 = undefined;
         var sig_buf: [bls.Signature.COMPRESS_SIZE]u8 = undefined;
-        var msg_bytes: [32]u8 = undefined;
+        var msg_bytes: bls.SigningRoot = undefined;
 
         const pk_bytes = try std.fmt.hexToBytes(&pk_buf, verify_test_data.input.pubkey[2..]); // skip "0x" prefix
         const pk = bls.PublicKey.deserialize(pk_bytes) catch {
@@ -265,7 +268,8 @@ pub fn verify(gpa: Allocator, path: std.Io.Dir) !void {
             return;
         };
 
-        _ = try std.fmt.hexToBytes(&msg_bytes, verify_test_data.input.message[2..]); // skip "0x" prefix
+        const message = try std.fmt.hexToBytes(&msg_bytes, verify_test_data.input.message[2..]); // skip "0x" prefix
+        try std.testing.expectEqual(@sizeOf(bls.SigningRoot), message.len);
 
         const sig_bytes = try std.fmt.hexToBytes(&sig_buf, verify_test_data.input.signature[2..]); // skip "0x" prefix
         const signature = bls.Signature.deserialize(sig_bytes) catch {
@@ -371,7 +375,7 @@ pub fn eth_fast_aggregate_verify(gpa: Allocator, path: std.Io.Dir) !void {
         const pubkeys = try allocator.alloc(bls.PublicKey, num_sigs);
         defer allocator.free(pubkeys);
 
-        var msg_bytes: [32]u8 = undefined;
+        var msg_bytes: bls.SigningRoot = undefined;
         var pk_buf: [bls.PublicKey.COMPRESS_SIZE]u8 = undefined;
         var sig_buf: [bls.Signature.COMPRESS_SIZE]u8 = undefined;
         var pairing_buf: [bls.Pairing.sizeOf()]u8 align(bls.Pairing.buf_align) = undefined;
@@ -388,10 +392,11 @@ pub fn eth_fast_aggregate_verify(gpa: Allocator, path: std.Io.Dir) !void {
             };
         }
 
-        _ = try std.fmt.hexToBytes(
+        const message = try std.fmt.hexToBytes(
             &msg_bytes,
             eth_fast_aggregate_verify_test_data.input.message[2..], // skip "0x" prefix
         );
+        try std.testing.expectEqual(@sizeOf(bls.SigningRoot), message.len);
 
         const sig_bytes = try std.fmt.hexToBytes(
             &sig_buf,


### PR DESCRIPTION
## Summary

- define one canonical `bls.SigningRoot = [32]u8` and use it throughout native BLS signing, verification, pairing, randomized batch verification, thread-pool, and state-transition APIs
- validate every dynamic N-API signing-root input with one exact-length helper and copy batch roots into native storage before worker-thread verification
- document the 32-byte TypeScript contract and add 31-/33-byte rejection coverage for every exported N-API signing and verification path
- make the BLS spec harness reject decoded messages that are not exactly one signing root

Closes #523
