### PR TITLE
fix(bls): make batch cardinality structural

### DIFF
--- a/bindings/napi/blst.zig
+++ b/bindings/napi/blst.zig
@@ -23,6 +23,7 @@ const Pairing = bls.Pairing;
 const AggregatePublicKey = bls.AggregatePublicKey;
 const AggregateSignature = bls.AggregateSignature;
 const ThreadPool = bls.ThreadPool;
+const BatchVerifyItem = bls.BatchVerifyItem;
 const DST = bls.DST;
 const MAX_AGGREGATE_PER_JOB = bls.MAX_AGGREGATE_PER_JOB;
 
@@ -466,75 +467,45 @@ pub fn verifyMultipleAggregateSignatures(sets: js.Array, pks_validate: ?js.Boole
     const n_elems = try sets.length();
     if (n_elems == 0) return js.Boolean.from(false);
 
-    var msgs_stack: [BATCH_VERIFY_SIZE][]const u8 = undefined;
-    var pks_stack: [BATCH_VERIFY_SIZE]*NativePublicKey = undefined;
-    var sigs_stack: [BATCH_VERIFY_SIZE]*NativeSignature = undefined;
-    var rands_stack: [BATCH_VERIFY_SIZE][32]u8 = undefined;
+    var items_stack: [BATCH_VERIFY_SIZE]BatchVerifyItem = undefined;
+    var items_heap: ?[]BatchVerifyItem = null;
+    defer if (items_heap) |buf| allocator.free(buf);
 
-    var msgs_heap: ?[][]const u8 = null;
-    defer if (msgs_heap) |buf| allocator.free(buf);
-    var pks_heap: ?[]*NativePublicKey = null;
-    defer if (pks_heap) |buf| allocator.free(buf);
-    var sigs_heap: ?[]*NativeSignature = null;
-    defer if (sigs_heap) |buf| allocator.free(buf);
-    var rands_heap: ?[][32]u8 = null;
-    defer if (rands_heap) |buf| allocator.free(buf);
-
-    const msgs = if (n_elems <= BATCH_VERIFY_SIZE) msgs_stack[0..n_elems] else blk: {
-        const buf = try allocator.alloc([]const u8, n_elems);
-        msgs_heap = buf;
-        break :blk buf;
-    };
-    const pks = if (n_elems <= BATCH_VERIFY_SIZE) pks_stack[0..n_elems] else blk: {
-        const buf = try allocator.alloc(*NativePublicKey, n_elems);
-        pks_heap = buf;
-        break :blk buf;
-    };
-    const sigs = if (n_elems <= BATCH_VERIFY_SIZE) sigs_stack[0..n_elems] else blk: {
-        const buf = try allocator.alloc(*NativeSignature, n_elems);
-        sigs_heap = buf;
-        break :blk buf;
-    };
-    const rands = if (n_elems <= BATCH_VERIFY_SIZE) rands_stack[0..n_elems] else blk: {
-        const buf = try allocator.alloc([32]u8, n_elems);
-        rands_heap = buf;
+    const items = if (n_elems <= BATCH_VERIFY_SIZE) items_stack[0..n_elems] else blk: {
+        const buf = try allocator.alloc(BatchVerifyItem, n_elems);
+        items_heap = buf;
         break :blk buf;
     };
 
     const io = js.io();
-    io.random(std.mem.sliceAsBytes(rands));
-    for (rands) |*randomness| {
-        try ensureNonzeroRandomScalar(io, randomness[0..8]);
-    }
-
     for (0..n_elems) |i| {
         const set = (try sets.get(@intCast(i))).toValue();
 
         const msg_napi = try set.getNamedProperty("msg");
         const msg_bytes = try uint8SliceFromValue(.{ .val = msg_napi });
         if (msg_bytes.len != 32) return error.InvalidMessageLength;
-        msgs[i] = msg_bytes;
-
         const pk_napi = try set.getNamedProperty("pk");
         const wrapped_pk = try unwrapClass(PublicKey, .{ .val = pk_napi });
-        pks[i] = &wrapped_pk.raw;
 
         const sig_napi = try set.getNamedProperty("sig");
         const wrapped_sig = try unwrapClass(Signature, .{ .val = sig_napi });
-        sigs[i] = &wrapped_sig.raw;
+        items[i] = .{
+            .message = msg_bytes,
+            .public_key = &wrapped_pk.raw,
+            .signature = &wrapped_sig.raw,
+            .randomness = undefined,
+        };
+        io.random(&items[i].randomness);
+        try ensureNonzeroRandomScalar(io, items[i].randomness[0..8]);
     }
 
     const pool = state.thread_pool orelse return error.ThreadPoolNotInitialized;
     const result = pool.verifyMultipleAggregateSignatures(
         js.io(),
-        n_elems,
-        msgs,
+        items,
         DST,
-        pks,
         try boolOrDefault(pks_validate, false),
-        sigs,
         try boolOrDefault(sigs_groupcheck, false),
-        rands,
     ) catch return js.Boolean.from(false);
 
     return js.Boolean.from(result);

--- a/src/bls/ThreadPool.zig
+++ b/src/bls/ThreadPool.zig
@@ -21,7 +21,6 @@ const AggregatePublicKey = blst.AggregatePublicKey;
 const AggregateSignature = blst.AggregateSignature;
 const BlstError = @import("error.zig").BlstError;
 const BatchVerifyItem = @import("fast_verify.zig").BatchVerifyItem;
-const fast_verify = @import("fast_verify.zig");
 const SecretKey = @import("SecretKey.zig");
 const pippenger = @import("pippenger.zig");
 
@@ -263,18 +262,6 @@ pub fn verifyMultipleAggregateSignatures(
 ) (BlstError || PoolError || std.Io.Cancelable)!bool {
     const n_elems = items.len;
     if (n_elems == 0) return BlstError.VerifyFail;
-
-    // Avoid queue overhead for small batches or a single-worker pool.
-    if (n_elems <= 2 or pool.n_workers <= 1) {
-        var pairing_buf: PairingBuf = .{};
-        return fast_verify.verifyMultipleAggregateSignatures(
-            &pairing_buf.data,
-            items,
-            dst,
-            pks_validate,
-            sigs_groupcheck,
-        );
-    }
 
     const n_active = @min(pool.n_workers, n_elems);
 

--- a/src/bls/ThreadPool.zig
+++ b/src/bls/ThreadPool.zig
@@ -20,6 +20,8 @@ const Signature = blst.Signature;
 const AggregatePublicKey = blst.AggregatePublicKey;
 const AggregateSignature = blst.AggregateSignature;
 const BlstError = @import("error.zig").BlstError;
+const BatchVerifyItem = @import("fast_verify.zig").BatchVerifyItem;
+const fast_verify = @import("fast_verify.zig");
 const SecretKey = @import("SecretKey.zig");
 const pippenger = @import("pippenger.zig");
 
@@ -200,10 +202,7 @@ pub fn submitAndWait(pool: *ThreadPool, io: std.Io, items: []*WorkItem) (PoolErr
 }
 
 const VerifyMultiJob = struct {
-    pks: []const *PublicKey,
-    sigs: []const *Signature,
-    msgs: []const []const u8,
-    rands: []const [32]u8,
+    items: []const BatchVerifyItem,
     dst: []const u8,
     pks_validate: bool,
     sigs_groupcheck: bool,
@@ -223,21 +222,22 @@ const VerifyMultiWorkItem = struct {
         const job = self.job;
 
         var pairing = Pairing.init(&job.result_bufs[self.worker_id].data, true, job.dst);
-        const n_elems = job.pks.len;
+        const n_elems = job.items.len;
 
         while (true) {
             const i = job.counter.fetchAdd(1, .monotonic);
             if (i >= n_elems) break;
             if (job.err_flag.load(.monotonic)) break;
 
+            const item = &job.items[i];
             pairing.mulAndAggregate(
-                job.pks[i],
+                item.public_key,
                 job.pks_validate,
-                job.sigs[i],
+                item.signature,
                 job.sigs_groupcheck,
-                &job.rands[i],
+                &item.randomness,
                 RAND_BITS,
-                job.msgs[i],
+                item.message,
             ) catch {
                 job.err_flag.store(true, .release);
                 break;
@@ -256,31 +256,32 @@ const VerifyMultiWorkItem = struct {
 pub fn verifyMultipleAggregateSignatures(
     pool: *ThreadPool,
     io: std.Io,
-    n_elems: usize,
-    msgs: []const []const u8,
+    items: []const BatchVerifyItem,
     dst: []const u8,
-    pks: []const *PublicKey,
     pks_validate: bool,
-    sigs: []const *Signature,
     sigs_groupcheck: bool,
-    rands: []const [32]u8,
 ) (BlstError || PoolError || std.Io.Cancelable)!bool {
-    if (n_elems == 0 or
-        pks.len != n_elems or
-        sigs.len != n_elems or
-        msgs.len != n_elems or
-        rands.len != n_elems)
-        return BlstError.VerifyFail;
+    const n_elems = items.len;
+    if (n_elems == 0) return BlstError.VerifyFail;
+
+    // Avoid queue overhead for small batches or a single-worker pool.
+    if (n_elems <= 2 or pool.n_workers <= 1) {
+        var pairing_buf: PairingBuf = .{};
+        return fast_verify.verifyMultipleAggregateSignatures(
+            &pairing_buf.data,
+            items,
+            dst,
+            pks_validate,
+            sigs_groupcheck,
+        );
+    }
 
     const n_active = @min(pool.n_workers, n_elems);
 
     var result_bufs: [MAX_WORKERS]PairingBuf = undefined;
 
     var job = VerifyMultiJob{
-        .pks = pks[0..n_elems],
-        .sigs = sigs[0..n_elems],
-        .msgs = msgs[0..n_elems],
-        .rands = rands[0..n_elems],
+        .items = items,
         .dst = dst,
         .pks_validate = pks_validate,
         .sigs_groupcheck = sigs_groupcheck,
@@ -499,11 +500,9 @@ test "verifyMultipleAggregateSignatures multi-threaded" {
     const num_sigs = 16;
 
     var msgs: [num_sigs][32]u8 = undefined;
-    var msg_refs: [num_sigs][]const u8 = undefined;
     var pks: [num_sigs]PublicKey = undefined;
     var sigs: [num_sigs]Signature = undefined;
-    var pk_ptrs: [num_sigs]*PublicKey = undefined;
-    var sig_ptrs: [num_sigs]*Signature = undefined;
+    var items: [num_sigs]blst.BatchVerifyItem = undefined;
 
     var prng = std.Random.DefaultPrng.init(blk: {
         var seed: u64 = undefined;
@@ -519,24 +518,21 @@ test "verifyMultipleAggregateSignatures multi-threaded" {
         const sk = try SecretKey.keyGen(&ikm_i, null);
         pks[i] = sk.toPublicKey();
         sigs[i] = sk.sign(&msgs[i], blst.DST, null);
-        msg_refs[i] = &msgs[i];
-        pk_ptrs[i] = &pks[i];
-        sig_ptrs[i] = &sigs[i];
+        items[i] = .{
+            .message = &msgs[i],
+            .public_key = &pks[i],
+            .signature = &sigs[i],
+            .randomness = undefined,
+        };
+        std.Random.bytes(rand, &items[i].randomness);
     }
-
-    var rands: [num_sigs][32]u8 = undefined;
-    for (&rands) |*r| std.Random.bytes(rand, r);
 
     const result = try pool.verifyMultipleAggregateSignatures(
         std.testing.io,
-        num_sigs,
-        &msg_refs,
+        &items,
         blst.DST,
-        &pk_ptrs,
         true,
-        &sig_ptrs,
         true,
-        &rands,
     );
 
     try std.testing.expect(result);

--- a/src/bls/fast_verify.zig
+++ b/src/bls/fast_verify.zig
@@ -4,6 +4,14 @@ const RAND_BYTES = 8;
 /// Number of random bits used for verification.
 const RAND_BITS = 8 * RAND_BYTES;
 
+/// One signature set and its random coefficient for batch verification.
+pub const BatchVerifyItem = struct {
+    message: []const u8,
+    public_key: *const PublicKey,
+    signature: *const Signature,
+    randomness: [32]u8,
+};
+
 /// Verify multiple aggregate signatures efficiently using random coefficients.
 ///
 /// Source: https://ethresear.ch/t/fast-verification-of-multiple-bls-signatures/5407
@@ -11,16 +19,12 @@ const RAND_BITS = 8 * RAND_BYTES;
 /// Returns true if verification succeeds, false if verification fails, `BlstError` on error.
 pub fn verifyMultipleAggregateSignatures(
     pairing_buf: *align(Pairing.buf_align) [Pairing.sizeOf()]u8,
-    n_elems: usize,
-    msgs: []const []const u8,
+    items: []const BatchVerifyItem,
     dst: []const u8,
-    pks: []const *PublicKey,
     pks_validate: bool,
-    sigs: []const *Signature,
     sigs_groupcheck: bool,
-    rands: []const [32]u8,
 ) BlstError!bool {
-    if (n_elems == 0) {
+    if (items.len == 0) {
         return BlstError.VerifyFail;
     }
 
@@ -30,15 +34,15 @@ pub fn verifyMultipleAggregateSignatures(
         dst,
     );
 
-    for (0..n_elems) |i| {
+    for (items) |*item| {
         try pairing.mulAndAggregate(
-            pks[i],
+            item.public_key,
             pks_validate,
-            sigs[i],
+            item.signature,
             sigs_groupcheck,
-            &rands[i],
+            &item.randomness,
             RAND_BITS,
-            msgs[i],
+            item.message,
         );
     }
 

--- a/src/bls/root.zig
+++ b/src/bls/root.zig
@@ -15,6 +15,7 @@ pub const AggregatePublicKey = @import("AggregatePublicKey.zig");
 pub const AggregateSignature = @import("AggregateSignature.zig");
 pub const BlstError = @import("error.zig").BlstError;
 
+pub const BatchVerifyItem = @import("fast_verify.zig").BatchVerifyItem;
 pub const verifyMultipleAggregateSignatures = @import("fast_verify.zig").verifyMultipleAggregateSignatures;
 pub const ThreadPool = @import("ThreadPool.zig");
 pub const pippenger = @import("pippenger.zig");


### PR DESCRIPTION
## Summary

- replace the batch verifier's independent count and parallel message/public-key/signature/randomness slices with one `BatchVerifyItem` slice
- use the same item representation in the single-threaded verifier, thread-pool jobs, and N-API adapter
- derive the batch count from the item slice so cardinality mismatches are unrepresentable instead of becoming user-facing verification errors or release-mode out-of-bounds access

## Rationale

The mismatched cardinalities in #543 are programmer invariants, but an assertion alone disappears in unchecked release builds. Grouping each message, public key, signature, and random scalar into one item enforces the relationship structurally and mirrors Lodestar-TS's array-of-signature-sets API.

Empty batches retain the existing verification-failure behavior.

Closes #543
