### PR TITLE
fix(bls): bound randomized aggregation inputs

### DIFF
--- a/src/bls/AggregatePublicKey.zig
+++ b/src/bls/AggregatePublicKey.zig
@@ -4,6 +4,12 @@ const Self = @This();
 /// An aggregate public key that can be used to verify aggregate signatures.
 point: c.blst_p1 = c.blst_p1{},
 
+/// A public key paired with its fixed-width random aggregation coefficient.
+pub const RandomizedPublicKey = struct {
+    public_key: *const PublicKey,
+    randomness: [32]u8,
+};
+
 /// Converts an aggregate public key back to a regular public key.
 /// This converts from projective coordinates back to affine coordinates.
 pub fn toPublicKey(self: *const Self) PublicKey {
@@ -38,43 +44,80 @@ pub fn aggregate(pks: []const PublicKey, pks_validate: bool) BlstError!Self {
 /// enhanced security through the use of randomness.
 ///
 /// Errors if:
-/// - `pk` slice is empty,
+/// - `items` is empty or contains more than `MAX_AGGREGATE_PER_JOB` entries,
 /// - `scratch` space is insufficient, or
 /// - if any public key validation fails.
 ///
 /// Returns the `AggregatePublicKey` on success.
 pub fn aggregateWithRandomness(
-    pks: []*const PublicKey,
-    randomness: []const u8,
+    items: []const RandomizedPublicKey,
     pks_validate: bool,
     scratch: []u64,
 ) BlstError!Self {
-    if (pks.len == 0) return BlstError.AggrTypeMismatch;
+    if (items.len == 0) return BlstError.EmptyAggregate;
+    if (items.len > MAX_AGGREGATE_PER_JOB) return BlstError.TooManyItems;
     const scratch_len = @divExact(
-        c.blst_p1s_mult_pippenger_scratch_sizeof(pks.len),
+        c.blst_p1s_mult_pippenger_scratch_sizeof(items.len),
         @sizeOf(u64),
     );
     if (scratch.len < scratch_len) {
-        return BlstError.AggrTypeMismatch;
+        return BlstError.InsufficientScratchSpace;
     }
-    if (pks_validate) for (pks) |pk| try pk.validate();
+    if (pks_validate) for (items) |item| try item.public_key.validate();
 
     var scalars_refs: [MAX_AGGREGATE_PER_JOB]*const u8 = undefined;
-    for (0..pks.len) |i| scalars_refs[i] = &randomness[i * 32];
+    var pks_refs: [MAX_AGGREGATE_PER_JOB]*const c.blst_p1_affine = undefined;
+    for (items, 0..) |*item, i| {
+        scalars_refs[i] = &item.randomness[0];
+        pks_refs[i] = &item.public_key.point;
+    }
 
     var agg_pk = Self{};
     c.blst_p1s_mult_pippenger(
         &agg_pk.point,
-        @ptrCast(pks[0..pks.len].ptr),
-        pks.len,
-        @ptrCast(scalars_refs[0..pks.len].ptr),
+        pks_refs[0..items.len].ptr,
+        items.len,
+        scalars_refs[0..items.len].ptr,
         64,
         scratch.ptr,
     );
     return agg_pk;
 }
 
-test aggregateWithRandomness {
+test "aggregateWithRandomness rejects empty items" {
+    const items: []const RandomizedPublicKey = &.{};
+    var scratch: [1]u64 = undefined;
+
+    try std.testing.expectError(
+        BlstError.EmptyAggregate,
+        aggregateWithRandomness(items, false, &scratch),
+    );
+}
+
+test "aggregateWithRandomness rejects too many public key items" {
+    const items: [MAX_AGGREGATE_PER_JOB + 1]RandomizedPublicKey = undefined;
+    var scratch: [1]u64 = undefined;
+
+    try std.testing.expectError(
+        BlstError.TooManyItems,
+        aggregateWithRandomness(&items, false, &scratch),
+    );
+}
+
+test "aggregateWithRandomness rejects insufficient public key scratch space" {
+    const public_key: PublicKey = undefined;
+    const items = [_]RandomizedPublicKey{.{
+        .public_key = &public_key,
+        .randomness = [_]u8{1} ** 32,
+    }};
+
+    try std.testing.expectError(
+        BlstError.InsufficientScratchSpace,
+        aggregateWithRandomness(&items, false, &.{}),
+    );
+}
+
+test "aggregateWithRandomness aggregates 128 public keys" {
     const ikm: [32]u8 = [_]u8{
         0x93, 0xad, 0x7e, 0x65, 0xde, 0xad, 0x05, 0x2a, 0x08, 0x3a,
         0x91, 0x0c, 0x8b, 0x72, 0x85, 0x91, 0x46, 0x4c, 0xca, 0x56,
@@ -115,18 +158,18 @@ test aggregateWithRandomness {
         sigs[i] = sig;
     }
     var rands: [32 * MAX_AGGREGATE_PER_JOB]u8 = [_]u8{0} ** (32 * MAX_AGGREGATE_PER_JOB);
-    var scalars_refs: [MAX_AGGREGATE_PER_JOB]*const u8 = undefined;
-    var pks_refs: [MAX_AGGREGATE_PER_JOB]*const PublicKey = undefined;
+    var items: [MAX_AGGREGATE_PER_JOB]RandomizedPublicKey = undefined;
     std.Random.bytes(rand, &rands);
 
     for (0..num_sigs) |i| {
-        scalars_refs[i] = &rands[i * 32];
-        pks_refs[i] = &pks[i];
+        items[i] = .{
+            .public_key = &pks[i],
+            .randomness = rands[i * 32 ..][0..32].*,
+        };
     }
 
     _ = try aggregateWithRandomness(
-        &pks_refs,
-        &rands,
+        &items,
         true,
         scratch[0..],
     );

--- a/src/bls/AggregateSignature.zig
+++ b/src/bls/AggregateSignature.zig
@@ -5,6 +5,12 @@ const Self = @This();
 /// against an aggregate public key.
 point: c.blst_p2 = c.blst_p2{},
 
+/// A signature paired with its fixed-width random aggregation coefficient.
+pub const RandomizedSignature = struct {
+    signature: *const Signature,
+    randomness: [32]u8,
+};
+
 /// Validates that the aggregate signature is in the correct subgroup (G2).
 pub fn validate(self: *const Self) BlstError!void {
     if (!c.blst_p2_in_g2(&self.point)) return BlstError.PointNotInGroup;
@@ -37,41 +43,80 @@ pub fn aggregate(sigs: []const Signature, sigs_groupcheck: bool) BlstError!Self 
 
 /// Aggregates multiple signatures using multi-scalar multiplication with randomness.
 ///
-/// Errors if scratch space is insufficient, or if any signature validation fails.
+/// Errors if `items` is empty, contains more than `MAX_AGGREGATE_PER_JOB`
+/// entries, scratch space is insufficient, or any signature validation fails.
 ///
 /// Returns the `AggregateSignature` on success.
 pub fn aggregateWithRandomness(
-    sigs: []*const Signature,
-    randomness: []const u8,
+    items: []const RandomizedSignature,
     sigs_groupcheck: bool,
     scratch: []u64,
 ) BlstError!Self {
-    if (sigs_groupcheck) for (sigs) |sig| try sig.validate(false);
+    if (items.len == 0) return BlstError.EmptyAggregate;
+    if (items.len > MAX_AGGREGATE_PER_JOB) return BlstError.TooManyItems;
     const scratch_len = @divExact(
-        c.blst_p2s_mult_pippenger_scratch_sizeof(sigs.len),
+        c.blst_p2s_mult_pippenger_scratch_sizeof(items.len),
         @sizeOf(u64),
     );
     if (scratch.len < scratch_len) {
-        return BlstError.AggrTypeMismatch;
+        return BlstError.InsufficientScratchSpace;
     }
+    if (sigs_groupcheck) for (items) |item| try item.signature.validate(false);
 
     var scalars_refs: [MAX_AGGREGATE_PER_JOB]*const u8 = undefined;
-    for (0..sigs.len) |i| scalars_refs[i] = &randomness[i * 32];
+    var sigs_refs: [MAX_AGGREGATE_PER_JOB]*const c.blst_p2_affine = undefined;
+    for (items, 0..) |*item, i| {
+        scalars_refs[i] = &item.randomness[0];
+        sigs_refs[i] = &item.signature.point;
+    }
 
     var agg_sig = Self{};
 
     c.blst_p2s_mult_pippenger(
         &agg_sig.point,
-        @ptrCast(sigs[0..sigs.len].ptr),
-        sigs.len,
-        scalars_refs[0..sigs.len].ptr,
+        sigs_refs[0..items.len].ptr,
+        items.len,
+        scalars_refs[0..items.len].ptr,
         64,
         scratch.ptr,
     );
     return agg_sig;
 }
 
-test aggregateWithRandomness {
+test "aggregateWithRandomness rejects empty signature items" {
+    const items: []const RandomizedSignature = &.{};
+    var scratch: [1]u64 = undefined;
+
+    try std.testing.expectError(
+        BlstError.EmptyAggregate,
+        aggregateWithRandomness(items, false, &scratch),
+    );
+}
+
+test "aggregateWithRandomness rejects too many signature items" {
+    const items: [MAX_AGGREGATE_PER_JOB + 1]RandomizedSignature = undefined;
+    var scratch: [1]u64 = undefined;
+
+    try std.testing.expectError(
+        BlstError.TooManyItems,
+        aggregateWithRandomness(&items, false, &scratch),
+    );
+}
+
+test "aggregateWithRandomness rejects insufficient signature scratch space" {
+    const signature: Signature = undefined;
+    const items = [_]RandomizedSignature{.{
+        .signature = &signature,
+        .randomness = [_]u8{1} ** 32,
+    }};
+
+    try std.testing.expectError(
+        BlstError.InsufficientScratchSpace,
+        aggregateWithRandomness(&items, false, &.{}),
+    );
+}
+
+test "aggregateWithRandomness aggregates 128 signatures" {
     const ikm: [32]u8 = [_]u8{
         0x93, 0xad, 0x7e, 0x65, 0xde, 0xad, 0x05, 0x2a, 0x08, 0x3a,
         0x91, 0x0c, 0x8b, 0x72, 0x85, 0x91, 0x46, 0x4c, 0xca, 0x56,
@@ -125,25 +170,29 @@ test aggregateWithRandomness {
         try sig.verify(true, &msgs[i], dst, null, &pks[i], true);
     }
     var rands: [32 * MAX_AGGREGATE_PER_JOB]u8 = [_]u8{0} ** (32 * MAX_AGGREGATE_PER_JOB);
-    var sigs_refs: [MAX_AGGREGATE_PER_JOB]*const Signature = undefined;
-    var pks_refs: [MAX_AGGREGATE_PER_JOB]*const PublicKey = undefined;
+    var randomized_sigs: [MAX_AGGREGATE_PER_JOB]RandomizedSignature = undefined;
+    var randomized_pks: [MAX_AGGREGATE_PER_JOB]AggregatePublicKey.RandomizedPublicKey = undefined;
     std.Random.bytes(rand, &rands);
 
     for (0..num_sigs) |i| {
-        sigs_refs[i] = &sigs[i];
-        pks_refs[i] = &pks[i];
+        randomized_sigs[i] = .{
+            .signature = &sigs[i],
+            .randomness = rands[i * 32 ..][0..32].*,
+        };
+        randomized_pks[i] = .{
+            .public_key = &pks[i],
+            .randomness = rands[i * 32 ..][0..32].*,
+        };
     }
 
     const agg_pk = try AggregatePublicKey.aggregateWithRandomness(
-        pks_refs[0..],
-        &rands,
+        &randomized_pks,
         true,
         pk_scratch,
     );
     const pk = agg_pk.toPublicKey();
     const agg_sig = try aggregateWithRandomness(
-        &sigs_refs,
-        &rands,
+        &randomized_sigs,
         true,
         sig_scratch,
     );

--- a/src/bls/error.zig
+++ b/src/bls/error.zig
@@ -9,6 +9,9 @@ pub const BlstError = error{
     PkIsInfinity,
     BadScalar,
     MergeError,
+    EmptyAggregate,
+    TooManyItems,
+    InsufficientScratchSpace,
     UnknownError,
 };
 

--- a/test/fuzz/src/fuzz_bls_aggregate_pk.zig
+++ b/test/fuzz/src/fuzz_bls_aggregate_pk.zig
@@ -52,8 +52,7 @@ fn fuzzAggregateWithRandomness(input: []const u8) void {
     if (n == 0) return;
 
     var pks: [MAX_AGGREGATE_PER_JOB]PublicKey = undefined;
-    var pks_refs: [MAX_AGGREGATE_PER_JOB]*const PublicKey = undefined;
-    var randomness: [MAX_AGGREGATE_PER_JOB * rand_size]u8 = undefined;
+    var items: [MAX_AGGREGATE_PER_JOB]AggregatePublicKey.RandomizedPublicKey = undefined;
     var count: usize = 0;
 
     for (0..n) |i| {
@@ -63,8 +62,10 @@ fn fuzzAggregateWithRandomness(input: []const u8) void {
 
         const pk = PublicKey.deserialize(pk_chunk) catch continue;
         pks[count] = pk;
-        pks_refs[count] = &pks[count];
-        @memcpy(randomness[count * rand_size .. (count + 1) * rand_size], rand_chunk);
+        items[count] = .{
+            .public_key = &pks[count],
+            .randomness = rand_chunk[0..rand_size].*,
+        };
         count += 1;
     }
 
@@ -73,13 +74,10 @@ fn fuzzAggregateWithRandomness(input: []const u8) void {
     var scratch: [1 << 14]u64 = undefined;
 
     _ = AggregatePublicKey.aggregateWithRandomness(
-        pks_refs[0..count],
-        randomness[0 .. count * rand_size],
+        items[0..count],
         false,
         &scratch,
-    ) catch |err| {
-        if (err != blstError.AggrTypeMismatch) {
-            @panic("unexpected aggregateWithRandomness public key error");
-        }
+    ) catch {
+        @panic("unexpected aggregateWithRandomness public key error");
     };
 }

--- a/test/fuzz/src/fuzz_bls_aggregate_sig.zig
+++ b/test/fuzz/src/fuzz_bls_aggregate_sig.zig
@@ -50,8 +50,7 @@ fn fuzzAggregateWithRandomness(input: []const u8) void {
     if (n == 0) return;
 
     var sigs: [MAX_AGGREGATE_PER_JOB]Signature = undefined;
-    var sig_refs: [MAX_AGGREGATE_PER_JOB]*const Signature = undefined;
-    var randomness: [MAX_AGGREGATE_PER_JOB * rand_size]u8 = undefined;
+    var items: [MAX_AGGREGATE_PER_JOB]AggregateSignature.RandomizedSignature = undefined;
     var count: usize = 0;
 
     for (0..n) |i| {
@@ -61,8 +60,10 @@ fn fuzzAggregateWithRandomness(input: []const u8) void {
 
         const sig = Signature.deserialize(sig_chunk) catch continue;
         sigs[count] = sig;
-        sig_refs[count] = &sigs[count];
-        @memcpy(randomness[count * rand_size .. (count + 1) * rand_size], rand_chunk);
+        items[count] = .{
+            .signature = &sigs[count],
+            .randomness = rand_chunk[0..rand_size].*,
+        };
         count += 1;
     }
 
@@ -71,13 +72,10 @@ fn fuzzAggregateWithRandomness(input: []const u8) void {
     var scratch: [1 << 16]u64 = undefined;
 
     _ = AggregateSignature.aggregateWithRandomness(
-        sig_refs[0..count],
-        randomness[0 .. count * rand_size],
+        items[0..count],
         false,
         &scratch,
-    ) catch |err| {
-        if (err != BlstError.AggrTypeMismatch) {
-            @panic("unexpected aggregateWithRandomness signature error");
-        }
+    ) catch {
+        @panic("unexpected aggregateWithRandomness signature error");
     };
 }


### PR DESCRIPTION
## Summary

- replace independent randomized-aggregate value and randomness slices with fixed-width per-item inputs
- reject empty and over-capacity native calls with dedicated recoverable errors before entering BLST
- preserve the 128-item boundary while making insufficient randomness unrepresentable
- update native tests and fuzz harnesses for the new public contract

## Rationale

The randomized aggregate helpers are exported native APIs, so empty and over-capacity slices are representable malformed inputs rather than impossible internal states. Assertions are not a stable public contract and disappear in unchecked release builds. Fixed-width per-item randomness removes the parallel-length invariant, while explicit errors protect the remaining runtime bounds.

Closes #542
