### PR TITLE
test(state_transition): harden PKIX load bounds and document trust boundary

### DIFF
--- a/bindings/src/pubkeys.d.ts
+++ b/bindings/src/pubkeys.d.ts
@@ -21,11 +21,17 @@ export interface PubkeyCache {
    * Load a compatible PKIX file from the control environment while no workers are using the cache.
    * The explicit capacity limit bounds both the entry count and native allocation;
    * spare capacity recorded in the file is discarded above this limit.
+   *
+   * The file is application-owned local cache data, in the same trust class as the application's
+   * database files. The caller must keep it under a private cache directory and must scope the path
+   * to one network. PKIX stores no network identifier. The loader checks framing, ABI
+   * compatibility, bounds, and a checksum to detect corruption or an incompatible build.
+   * It does not authenticate the file. Do not pass an operator-supplied or network-sourced path.
    */
   load(filepath: string, maxCapacity: number): void;
   /** Testing-only reset from the control environment while no workers are using the cache. */
   reset(): void;
-  /** Save from the control environment. */
+  /** Save from the control environment. Writes application-owned local cache data. */
   save(filepath: string): void;
   /** Reserve exact native capacity when growing; existing larger capacity is retained. */
   ensureCapacity(capacity: number): void;

--- a/bindings/src/pubkeys.d.ts
+++ b/bindings/src/pubkeys.d.ts
@@ -22,11 +22,8 @@ export interface PubkeyCache {
    * The explicit capacity limit bounds both the entry count and native allocation;
    * spare capacity recorded in the file is discarded above this limit.
    *
-   * The file is application-owned local cache data, in the same trust class as the application's
-   * database files. The caller must keep it under a private cache directory and must scope the path
-   * to one network. PKIX stores no network identifier. The loader checks framing, ABI
-   * compatibility, bounds, and a checksum to detect corruption or an incompatible build.
-   * It does not authenticate the file. Do not pass an operator-supplied or network-sourced path.
+   * The file is application-owned local cache data. See the top-level doc comment in
+   * `src/state_transition/cache/pkix.zig` for the trust assumptions the caller must meet.
    */
   load(filepath: string, maxCapacity: number): void;
   /** Testing-only reset from the control environment while no workers are using the cache. */

--- a/src/state_transition/cache/pkix.zig
+++ b/src/state_transition/cache/pkix.zig
@@ -1,3 +1,34 @@
+//! PKIX is the on-disk snapshot format for `PubkeyCache`.
+//!
+//! # Trust boundary
+//!
+//! A PKIX file is application-owned local cache data. It is in the same trust
+//! class as the application's database files or its persisted ENR. It is not
+//! operator-supplied input, not network input, and not a portable interchange
+//! format.
+//!
+//! The application must guarantee all of the following:
+//!
+//! - The file lives under a private, application-owned cache directory.
+//! - The path is scoped to one network, exactly as other persisted application
+//!   state is scoped. PKIX stores no network identifier and cannot detect a
+//!   file written for a different network.
+//! - Only the application writes the file, through `save`.
+//!
+//! # What load does and does not check
+//!
+//! `load` checks framing, format version, ABI compatibility, capacity bounds,
+//! the exact file size, and a checksum over the whole payload. Those checks
+//! exist to detect accidental corruption, a partial write, and a snapshot
+//! written by an incompatible build. They run before the payload is allocated,
+//! so a crafted header cannot force an unbounded allocation.
+//!
+//! `load` does not authenticate the file and does not semantically validate the
+//! restored affine points. Separate point validation is unnecessary inside the
+//! cache boundary above, because the payload checksum already covers every
+//! restored byte. Do not relax the boundary and rely on these checks: PKIX is
+//! not a substitute for validating untrusted input.
+
 const std = @import("std");
 const builtin = @import("builtin");
 const bls = @import("bls");
@@ -178,7 +209,13 @@ pub fn save(cache: *PubkeyCache, io: std.Io, writer: *std.Io.Writer) !void {
 ///
 /// PKIX checks framing, ABI compatibility, bounds, and checksum, but does not
 /// authenticate or semantically validate entries. Callers must provide an
-/// application-owned file from the intended network.
+/// application-owned file from the intended network. See the module doc comment
+/// for the full trust boundary.
+///
+/// `max_capacity` is the caller's allocation bound. It caps both the restored
+/// entry count and the reserved spare capacity, so a crafted header cannot make
+/// this function allocate more than the caller allows. Every bound is checked
+/// before the first allocation.
 pub fn load(
     allocator: std.mem.Allocator,
     io: std.Io,

--- a/src/state_transition/cache/pkix_test.zig
+++ b/src/state_transition/cache/pkix_test.zig
@@ -65,6 +65,41 @@ fn appendPubkeys(
     }
 }
 
+/// Assert that `pkix.load` rejects `encoded` without allocating.
+///
+/// `fail_index = 0` makes the first allocation attempt fail. The counters then
+/// prove the rejection happened before that attempt, not because of it.
+fn expectLoadRejectedWithoutAllocation(
+    encoded: []const u8,
+    file_size: u64,
+    max_capacity: usize,
+    expected_error: anyerror,
+) !void {
+    var failing = testing.FailingAllocator.init(
+        testing.allocator,
+        .{ .fail_index = 0 },
+    );
+    var reader = std.Io.Reader.fixed(encoded);
+    try testing.expectError(expected_error, pkix.load(
+        failing.allocator(),
+        testing.io,
+        &reader,
+        file_size,
+        max_capacity,
+    ));
+    try testing.expectEqual(@as(usize, 0), failing.allocations);
+    try testing.expect(!failing.has_induced_failure);
+}
+
+/// Assert that `pkix.load` rejects `encoded` with a checksum error.
+fn expectLoadRejectedByChecksum(encoded: []const u8, expected_error: anyerror) !void {
+    var reader = std.Io.Reader.fixed(encoded);
+    try testing.expectError(
+        expected_error,
+        loadPkixForTest(testing.allocator, &reader, encoded.len),
+    );
+}
+
 test "PKIX round trip preserves populated and empty caches" {
     const allocator = testing.allocator;
     var pubkeys: [3]types.primitive.BLSPubkey.Type = undefined;
@@ -345,4 +380,200 @@ test "PKIX enforces the caller capacity limit before allocation" {
     defer empty_loaded.deinit();
     try testing.expectEqual(@as(u32, 0), empty_loaded.count(testing.io));
     try testing.expectEqual(@as(usize, 0), empty_loaded.capacity(testing.io));
+}
+
+test "PKIX crafted headers cannot force an allocation" {
+    const allocator = testing.allocator;
+    var source = PubkeyCache.init(allocator, testing.io);
+    defer source.deinit();
+    const encoded = try encodePkixForTest(allocator, &source);
+    defer allocator.free(encoded);
+    try testing.expectEqual(header_size, encoded.len);
+
+    const Case = struct {
+        entry_count: u32,
+        cache_capacity: u32,
+        max_capacity: usize,
+        expected_error: anyerror,
+    };
+
+    // Every case is a header-only file that claims a payload it does not have.
+    // The largest encodable entry count claims about 618 GiB of entries.
+    const cases = [_]Case{
+        .{
+            .entry_count = std.math.maxInt(u32),
+            .cache_capacity = std.math.maxInt(u32),
+            .max_capacity = std.math.maxInt(usize),
+            .expected_error = error.InvalidPkixHeader,
+        },
+        .{
+            .entry_count = std.math.maxInt(u32),
+            .cache_capacity = std.math.maxInt(u32),
+            .max_capacity = 8,
+            .expected_error = error.PkixCapacityLimitExceeded,
+        },
+        .{
+            .entry_count = 1_000_000,
+            .cache_capacity = std.math.maxInt(u32),
+            .max_capacity = std.math.maxInt(usize),
+            .expected_error = error.InvalidPkixHeader,
+        },
+        .{
+            .entry_count = 1,
+            .cache_capacity = std.math.maxInt(u32),
+            .max_capacity = std.math.maxInt(usize),
+            .expected_error = error.InvalidPkixHeader,
+        },
+        .{
+            .entry_count = 1,
+            .cache_capacity = 0,
+            .max_capacity = std.math.maxInt(usize),
+            .expected_error = error.InvalidPkixHeader,
+        },
+    };
+
+    for (cases) |case| {
+        var header = readHeaderForTest(encoded);
+        header.entry_count = case.entry_count;
+        header.cache_capacity = case.cache_capacity;
+        updateHeaderChecksumForTest(&header);
+        writeHeaderForTest(encoded, header);
+        try expectLoadRejectedWithoutAllocation(
+            encoded,
+            encoded.len,
+            case.max_capacity,
+            case.expected_error,
+        );
+    }
+
+    // A file shorter than the header and an all-zero file must also allocate
+    // nothing.
+    const zeroed = try allocator.alloc(u8, header_size);
+    defer allocator.free(zeroed);
+    @memset(zeroed, 0);
+    try expectLoadRejectedWithoutAllocation(
+        zeroed,
+        zeroed.len,
+        std.math.maxInt(usize),
+        error.InvalidPkixMagic,
+    );
+    try expectLoadRejectedWithoutAllocation(
+        zeroed[0 .. header_size - 1],
+        header_size - 1,
+        std.math.maxInt(usize),
+        error.InvalidPkixHeader,
+    );
+}
+
+test "PKIX clamps crafted spare capacity to the caller limit" {
+    const allocator = testing.allocator;
+    var pubkeys: [2]types.primitive.BLSPubkey.Type = undefined;
+    try interop.interopPubkeysCached(pubkeys.len, &pubkeys);
+
+    var source = try PubkeyCache.initCapacity(allocator, testing.io, pubkeys.len);
+    defer source.deinit();
+    try appendPubkeys(&source, &pubkeys);
+
+    const encoded = try encodePkixForTest(allocator, &source);
+    defer allocator.free(encoded);
+
+    // The header claims spare capacity for about 1 billion entries. The entry
+    // count stays valid, so the load succeeds, but the reserved capacity must
+    // follow the caller limit instead of the file.
+    const caller_limit = 4;
+    var header = readHeaderForTest(encoded);
+    header.cache_capacity = 1 << 30;
+    updateHeaderChecksumForTest(&header);
+    writeHeaderForTest(encoded, header);
+
+    var reader = std.Io.Reader.fixed(encoded);
+    var loaded = try pkix.load(
+        allocator,
+        testing.io,
+        &reader,
+        encoded.len,
+        caller_limit,
+    );
+    defer loaded.deinit();
+    try testing.expectEqual(@as(u32, pubkeys.len), loaded.count(testing.io));
+    try testing.expectEqual(@as(usize, caller_limit), loaded.capacity(testing.io));
+    for (pubkeys, 0..) |pubkey, index| {
+        try testing.expectEqual(
+            @as(u64, @intCast(index)),
+            loaded.get(testing.io, pubkey).?,
+        );
+    }
+}
+
+test "PKIX rejects corruption in every payload and header region" {
+    const allocator = testing.allocator;
+    var pubkeys: [3]types.primitive.BLSPubkey.Type = undefined;
+    try interop.interopPubkeysCached(pubkeys.len, &pubkeys);
+
+    var source = try PubkeyCache.initCapacity(allocator, testing.io, pubkeys.len);
+    defer source.deinit();
+    try appendPubkeys(&source, &pubkeys);
+
+    const encoded = try encodePkixForTest(allocator, &source);
+    defer allocator.free(encoded);
+
+    const key_size = 48;
+    const key_start = header_size;
+    const affine_start = key_start + pubkeys.len * key_size;
+    try testing.expect(affine_start < encoded.len);
+
+    // One flipped bit anywhere in the payload must fail the checksum.
+    const payload_offsets = [_]usize{
+        key_start,
+        key_start + key_size - 1,
+        affine_start - 1,
+        affine_start,
+        encoded.len - 1,
+    };
+    for (payload_offsets) |offset| {
+        encoded[offset] ^= 1;
+        try expectLoadRejectedByChecksum(encoded, error.InvalidPkixChecksum);
+        encoded[offset] ^= 1;
+    }
+
+    // Reordering two entries keeps every byte but changes their order, so the
+    // payload checksum must still reject the file.
+    var swapped_key: [key_size]u8 = undefined;
+    @memcpy(&swapped_key, encoded[key_start..][0..key_size]);
+    @memcpy(
+        encoded[key_start..][0..key_size],
+        encoded[key_start + key_size ..][0..key_size],
+    );
+    @memcpy(encoded[key_start + key_size ..][0..key_size], &swapped_key);
+    try expectLoadRejectedByChecksum(encoded, error.InvalidPkixChecksum);
+    @memcpy(&swapped_key, encoded[key_start..][0..key_size]);
+    @memcpy(
+        encoded[key_start..][0..key_size],
+        encoded[key_start + key_size ..][0..key_size],
+    );
+    @memcpy(encoded[key_start + key_size ..][0..key_size], &swapped_key);
+
+    // The round trip still works after every mutation is reverted.
+    var restored_reader = std.Io.Reader.fixed(encoded);
+    var restored = try loadPkixForTest(allocator, &restored_reader, encoded.len);
+    defer restored.deinit();
+    try testing.expectEqual(@as(u32, pubkeys.len), restored.count(testing.io));
+
+    // A corrupt payload checksum field fails even though the payload is intact.
+    var header = readHeaderForTest(encoded);
+    header.payload_checksum ^= 1;
+    updateHeaderChecksumForTest(&header);
+    writeHeaderForTest(encoded, header);
+    try expectLoadRejectedByChecksum(encoded, error.InvalidPkixChecksum);
+
+    // A corrupt header checksum field is caught before any bound is read.
+    header = readHeaderForTest(encoded);
+    header.header_checksum ^= 1;
+    writeHeaderForTest(encoded, header);
+    try expectLoadRejectedWithoutAllocation(
+        encoded,
+        encoded.len,
+        std.math.maxInt(usize),
+        error.InvalidPkixHeaderChecksum,
+    );
 }


### PR DESCRIPTION
## Motivation

`pkix.load` and `pkix.save` handle an application-owned local cache snapshot, but nothing in the code said so. A reader could reasonably mistake the loader's framing, ABI, bounds, and checksum checks for input validation and pass the file an operator-supplied path. The existing bounds tests asserted only the returned error, so they could not distinguish a header rejected before allocation from one rejected because an allocation failed, which is the property that actually matters for a crafted header.

Closes #539.

## Description

- Document the PKIX trust boundary as application-owned local cache data on the Zig module, the `load` function, and the `bindings/src/pubkeys.d.ts` declarations.
- Add `expectLoadRejectedWithoutAllocation`, which asserts a rejection happened with zero allocation attempts rather than because of a failed one.
- Cover crafted headers that declare oversized entry counts, an all-zero file, and a short file.
- Cover spare capacity clamping, so a header declaring `1 << 30` capacity still honors the caller limit.
- Cover payload and header corruption: bit flips across the key and affine regions, an entry reorder, and both checksum fields.

No behavior change. The loader's existing capacity and file-size bounds are unchanged.

## Verification

- `zig build test:state_transition test:ssz test:bls` (376 passed)
- `zig fmt --check src bindings test bench examples scripts build.zig`
- `pnpm lint`
- `pnpm exec vitest run bindings/test/pubkeys.test.ts` (19 passed)

Spec and ERA suites were not run locally; their download steps are absent in my environment and this change touches no consensus, SSZ, or ERA behavior.

This PR was written by an AI agent (stargazer), supervised by a human.
