### PR TITLE
perf(bls): bypass worker queue for small batches

### DIFF
--- a/src/bls/ThreadPool.zig
+++ b/src/bls/ThreadPool.zig
@@ -20,6 +20,7 @@ const Signature = blst.Signature;
 const AggregatePublicKey = blst.AggregatePublicKey;
 const AggregateSignature = blst.AggregateSignature;
 const BlstError = @import("error.zig").BlstError;
+const fast_verify = @import("fast_verify.zig");
 const SecretKey = @import("SecretKey.zig");
 const pippenger = @import("pippenger.zig");
 
@@ -248,6 +249,17 @@ const VerifyMultiWorkItem = struct {
     }
 };
 
+fn useDirectVerification(n_elems: usize, n_workers: usize) bool {
+    return n_elems <= 2 or n_workers <= 1;
+}
+
+test "small batch verification bypasses the worker queue" {
+    try std.testing.expect(useDirectVerification(1, 4));
+    try std.testing.expect(useDirectVerification(2, 4));
+    try std.testing.expect(!useDirectVerification(3, 4));
+    try std.testing.expect(useDirectVerification(3, 1));
+}
+
 /// Verifies multiple aggregate signatures in parallel using the thread pool.
 ///
 /// This is the multi-threaded version of the same function in `fast_verify.zig`.
@@ -271,6 +283,21 @@ pub fn verifyMultipleAggregateSignatures(
         msgs.len != n_elems or
         rands.len != n_elems)
         return BlstError.VerifyFail;
+
+    if (useDirectVerification(n_elems, pool.n_workers)) {
+        var pairing_buf: PairingBuf = .{};
+        return fast_verify.verifyMultipleAggregateSignatures(
+            &pairing_buf.data,
+            n_elems,
+            msgs,
+            dst,
+            pks,
+            pks_validate,
+            sigs,
+            sigs_groupcheck,
+            rands,
+        );
+    }
 
     const n_active = @min(pool.n_workers, n_elems);
 

--- a/src/bls/ThreadPool.zig
+++ b/src/bls/ThreadPool.zig
@@ -249,17 +249,6 @@ const VerifyMultiWorkItem = struct {
     }
 };
 
-fn useDirectVerification(n_elems: usize, n_workers: usize) bool {
-    return n_elems <= 2 or n_workers <= 1;
-}
-
-test "small batch verification bypasses the worker queue" {
-    try std.testing.expect(useDirectVerification(1, 4));
-    try std.testing.expect(useDirectVerification(2, 4));
-    try std.testing.expect(!useDirectVerification(3, 4));
-    try std.testing.expect(useDirectVerification(3, 1));
-}
-
 /// Verifies multiple aggregate signatures in parallel using the thread pool.
 ///
 /// This is the multi-threaded version of the same function in `fast_verify.zig`.
@@ -276,7 +265,7 @@ pub fn verifyMultipleAggregateSignatures(
     const n_elems = items.len;
     if (n_elems == 0) return BlstError.VerifyFail;
 
-    if (useDirectVerification(n_elems, pool.n_workers)) {
+    if (n_elems <= 2 or pool.n_workers <= 1) {
         var pairing_buf: PairingBuf = .{};
         return fast_verify.verifyMultipleAggregateSignatures(
             &pairing_buf.data,


### PR DESCRIPTION
## Summary

- route batches of one or two signature sets directly through the single-threaded verifier
- use the direct verifier for pools configured with one worker
- keep a call-local pairing buffer so concurrent callers do not share verifier state

## Rationale

This keeps the small-batch optimization removed from #547 in its own focused change, as requested in the review discussion. It avoids queue submission and wake-up overhead when parallel dispatch cannot help.

The branch is based on current `main`. I will refresh the small call-site change onto #547's structural `BatchVerifyItem` API after #547 lands if needed.
