### PR TITLE
build(bls): consume upstream blst module

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -20,8 +20,8 @@
             .hash = "zbuild-0.4.0-XJFav-1nAgDmfVY1nVSIIzbkcbuHZj7yMb7Fv8yvznPO",
         },
         .blst = .{
-            .url = "git+https://github.com/ChainSafe/blst.zig.git#5d9543be8a7a1a9942c62a097644286751f95dc7",
-            .hash = "blst_zig-0.0.0-cnAxzisLAADc_A14MqXu_f_rLBRS6m6ki8zHrUjLXYoo",
+            .url = "git+https://github.com/ChainSafe/blst.zig.git#4b13f897d72fe7c9168f0f0eccf055e3941f56c7",
+            .hash = "blst_zig-0.0.0-cnAxzmIPAADDM1ada7PDap4MdWbHWq-zpVsnJYTWWt3q",
             .args = .{
                 .optimize = .ReleaseFast,
                 .portable = true,
@@ -183,7 +183,7 @@
         },
         .bls = .{
             .root_source_file = "src/bls/root.zig",
-            .link_libraries = .{"blst"},
+            .imports = .{.blst},
         },
         .state_transition = .{
             .root_source_file = "src/state_transition/root.zig",

--- a/src/bls/root.zig
+++ b/src/bls/root.zig
@@ -2,9 +2,7 @@ const std = @import("std");
 const testing = std.testing;
 
 /// Expose c types for lodestar-bun bindings
-pub const c = @cImport({
-    @cInclude("blst.h");
-});
+pub const c = @import("blst");
 
 // blst Zig native types
 pub const Pairing = @import("Pairing.zig");


### PR DESCRIPTION
## Summary

- update `ChainSafe/blst.zig` to main commit `4b13f897d72fe7c9168f0f0eccf055e3941f56c7`
- consume its exported `blst` module from the Lodestar-z BLS module
- replace the local `@cImport` and redundant direct library link

## Why

C header translation and native library linkage are packaging concerns owned by `blst.zig`. Consuming its public module keeps Lodestar-z independent of the dependency's header layout and build internals.

## Impact

There is no intended public API change. The translated C namespace remains available as `bls.c`.

## AI assistance

The implementation and PR description were primarily AI-authored with human direction and review.

Closes #530