### PR TITLE
feat(pubkeys): add getPubkeyBytes binding

### DIFF
--- a/bindings/napi/pubkeys.zig
+++ b/bindings/napi/pubkeys.zig
@@ -132,6 +132,16 @@ pub fn get(index: js.Number) !?blst_bindings.PublicKey {
     return .{ .raw = public_key };
 }
 
+/// JS: pubkeys.getPubkeyBytes(index) → Uint8Array | undefined
+pub fn getPubkeyBytes(index: js.Number) !?js.Uint8Array {
+    if (!state.initialized) return error.PubkeyIndexNotInitialized;
+
+    const idx = try index.toU32();
+    const io = js.io();
+    const pubkey_bytes = state.cache.getPubkeyBytes(io, idx) orelse return null;
+    return try js.Uint8Array.fromExternal(pubkey_bytes[0..]);
+}
+
 /// Aggregate multiple `PublicKey`s by the given
 /// validator `indices` into one.
 ///

--- a/bindings/napi/pubkeys.zig
+++ b/bindings/napi/pubkeys.zig
@@ -139,7 +139,7 @@ pub fn getPubkeyBytes(index: js.Number) !?js.Uint8Array {
     const idx = try index.toU32();
     const io = js.io();
     const pubkey_bytes = state.cache.getPubkeyBytes(io, idx) orelse return null;
-    return try js.Uint8Array.fromExternal(pubkey_bytes[0..]);
+    return js.Uint8Array.from(pubkey_bytes[0..]);
 }
 
 /// Aggregate multiple `PublicKey`s by the given

--- a/bindings/src/pubkeys.d.ts
+++ b/bindings/src/pubkeys.d.ts
@@ -5,6 +5,8 @@ export interface PubkeyCache {
   get(index: number): PublicKey | undefined;
   /** Same as get(), but throws if the index is not in the cache */
   getOrThrow(index: number): PublicKey;
+  /** Get the cached 48-byte compressed pubkey bytes without materializing a PublicKey wrapper. */
+  getPubkeyBytes(index: number): Uint8Array | undefined;
   /** Aggregate cached public keys by validator index */
   aggregate(indices: number[]): PublicKey;
   /** Get validator index by pubkey bytes */

--- a/bindings/src/pubkeys.d.ts
+++ b/bindings/src/pubkeys.d.ts
@@ -7,6 +7,8 @@ export interface PubkeyCache {
   getOrThrow(index: number): PublicKey;
   /** Get the cached 48-byte compressed pubkey bytes without materializing a PublicKey wrapper. */
   getPubkeyBytes(index: number): Uint8Array | undefined;
+  /** Same as getPubkeyBytes(), but throws if the index is not in the cache. */
+  getPubkeyBytesOrThrow(index: number): Uint8Array;
   /** Aggregate cached public keys by validator index */
   aggregate(indices: number[]): PublicKey;
   /** Get validator index by pubkey bytes */

--- a/bindings/src/pubkeys.js
+++ b/bindings/src/pubkeys.js
@@ -29,6 +29,15 @@ export const pubkeyCache = {
     return native.getPubkeyBytes(index);
   },
 
+  getPubkeyBytesOrThrow(index) {
+     const pubkey = native.getPubkeyBytes(index);
+     if (pubkey === undefined) {
+       throw new Error(`pubkeyCache: index ${index} not found`);
+     }
+
+     return pubkey;
+   },
+
   aggregate(indices) {
     if (indices.length === 1) return pubkeyCache.getOrThrow(indices[0]);
     return native.aggregate(indices);

--- a/bindings/src/pubkeys.js
+++ b/bindings/src/pubkeys.js
@@ -25,6 +25,10 @@ export const pubkeyCache = {
     return pk;
   },
 
+  getPubkeyBytes(index) {
+    return native.getPubkeyBytes(index);
+  },
+
   aggregate(indices) {
     if (indices.length === 1) return pubkeyCache.getOrThrow(indices[0]);
     return native.aggregate(indices);

--- a/bindings/test/pubkeys.test.ts
+++ b/bindings/test/pubkeys.test.ts
@@ -105,6 +105,22 @@ describe("pubkeys", () => {
     expect(pubkeyCache.get(0xffffffff)).toBeUndefined();
   });
 
+  it("getPubkeyBytes returns the compressed pubkey bytes", () => {
+    for (const {index, pubkeyBytes} of keypairs) {
+      expect(pubkeyCache.getPubkeyBytes(index)).toEqual(pubkeyBytes);
+    }
+  });
+
+  it("getPubkeyBytes matches getOrThrow().toBytes() and returns copies", () => {
+    const bytes = pubkeyCache.getPubkeyBytes(0);
+    expect(bytes).toEqual(pubkeyCache.getOrThrow(0).toBytes());
+    expect(pubkeyCache.getPubkeyBytes(0)).not.toBe(bytes);
+  });
+
+  it("getPubkeyBytes returns undefined for out-of-range index", () => {
+    expect(pubkeyCache.getPubkeyBytes(0xffffffff)).toBeUndefined();
+  });
+
   it("getIndex returns null for unknown pubkey", () => {
     expect(pubkeyCache.getIndex(new Uint8Array(48))).toBeNull();
   });

--- a/src/state_transition/cache/pubkey_cache.zig
+++ b/src/state_transition/cache/pubkey_cache.zig
@@ -164,6 +164,20 @@ pub const PubkeyCache = struct {
         return self.entries.values()[@intCast(index)];
     }
 
+    /// Get the compressed pubkey bytes for a validator index. A value is
+    /// returned so no pointer into movable map storage escapes the shared
+    /// lock.
+    pub fn getPubkeyBytes(
+        self: *const PubkeyCache,
+        io: std.Io,
+        index: u64,
+    ) ?[48]u8 {
+        self.lockShared(io);
+        defer self.unlockShared(io);
+        if (index >= self.entries.count()) return null;
+        return self.entries.keys()[@intCast(index)];
+    }
+
     /// Copy affine pubkeys for a batch of validator indices while holding one
     /// shared lock. The output is left unchanged when an index is invalid.
     pub fn getPubkeys(


### PR DESCRIPTION
Expose the cached 48-byte compressed pubkey bytes by validator index without materializing a PublicKey wrapper or serializing in JS. The BLS worker job path in Lodestar needs Uint8Array pubkeys, so this avoids the getOrThrow() + toBytes() round trip on the SingleAttestation gossip validation hot path.

Refs https://github.com/ChainSafe/lodestar/pull/9728#issuecomment-5237784361