### PR TITLE
docs(pkix): document load provenance requirement

### DIFF
--- a/src/state_transition/cache/pkix.zig
+++ b/src/state_transition/cache/pkix.zig
@@ -179,6 +179,11 @@ pub fn save(cache: *PubkeyCache, io: std.Io, writer: *std.Io.Writer) !void {
 /// PKIX checks framing, ABI compatibility, bounds, and checksum, but does not
 /// authenticate or semantically validate entries. Callers must provide an
 /// application-owned file from the intended network.
+///
+/// The supported trust assumption is that `load` receives only PKIX files
+/// produced by this module's `save`. Entry-level cache invariants are inherited
+/// from caches built through `append` and `save` and are not revalidated by
+/// `load`.
 pub fn load(
     allocator: std.mem.Allocator,
     io: std.Io,


### PR DESCRIPTION
## Motivation

`pkix.load` relies on entry-level cache invariants without revalidating them. The supported API requires snapshots to come from `pkix.save`, but the load contract did not state that provenance requirement.

Closes #550.

## Description

- Document that `load` supports only files produced by `save`.
- State that `append` and `save` establish the entry-level invariants that `load` trusts.

## Verification

- `zig fmt --check src bindings test bench examples scripts build.zig`
- `zig build test:state_transition --summary all` (120/120 tests passed)
- `pnpm lint` (10 existing warnings, no errors)

This PR was written by an AI agent (stargazer), supervised by a human.
