### PR TITLE
docs: document security threat model

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,10 +12,14 @@
 - **Relative imports:** use the `.js` extension in TypeScript ESM imports.
 - **No `any`:** avoid `any` and `as any`; use proper types or a justified Biome suppression.
 - **Follow existing patterns** before introducing new abstractions.
-- **Security reviews:** read `THREAT_MODEL.md` before reporting a security finding. Identify the
-  attacker, current supported path or identified planned integration path, integration maturity,
-  trusted preconditions, violated security objective, and concrete impact. Classify same-process
-  hardening and operator misuse accurately.
+- **Security reviews:** read `THREAT_MODEL.md` and `docs/security/IMPLEMENTATION_MAP.md` before
+  reporting a security finding. Identify the attacker, current supported path or identified planned
+  integration path, integration maturity, trusted preconditions, violated security objective, and
+  concrete impact. Classify same-process hardening and operator misuse accurately.
+- **Security-model maintenance:** review both security documents when a change adds or alters a
+  trust boundary, native dependency, persistence path or format, shared mutable cache or pool,
+  externally influenced native input, or supported integration. Update the normative threat model
+  only when the security contract changes; otherwise update the implementation map.
 - **Incremental commits:** after review starts, do not force-push unless a maintainer requests it.
 - **Communication style:** do not use em dashes. Keep communication succinct and human-friendly.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,10 +12,11 @@
 - **Relative imports:** use the `.js` extension in TypeScript ESM imports.
 - **No `any`:** avoid `any` and `as any`; use proper types or a justified Biome suppression.
 - **Follow existing patterns** before introducing new abstractions.
-- **Security reviews:** read `THREAT_MODEL.md` and `docs/security/IMPLEMENTATION_MAP.md` before
-  reporting a security finding. Identify the attacker, current supported path or identified planned
-  integration path, integration maturity, trusted preconditions, violated security objective, and
-  concrete impact. Classify same-process hardening and operator misuse accurately.
+- **Security reviews:** first surface candidate security-objective violations, then use
+  `THREAT_MODEL.md` and `docs/security/IMPLEMENTATION_MAP.md` to classify them. The model is not an
+  allowlist. Downgrade a candidate only after verifying the applicable trust assumption against the
+  current or planned call path. If code and documentation conflict, report the code behavior and the
+  documentation gap.
 - **Security-model maintenance:** review both security documents when a change adds or alters a
   trust boundary, native dependency, persistence path or format, shared mutable cache or pool,
   externally influenced native input, or supported integration. Update the normative threat model

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,8 +13,9 @@
 - **No `any`:** avoid `any` and `as any`; use proper types or a justified Biome suppression.
 - **Follow existing patterns** before introducing new abstractions.
 - **Security reviews:** read `THREAT_MODEL.md` before reporting a security finding. Identify the
-  attacker, supported call path, trusted preconditions, violated security objective, and concrete
-  impact. Classify same-process hardening and operator misuse accurately.
+  attacker, current supported path or identified planned integration path, integration maturity,
+  trusted preconditions, violated security objective, and concrete impact. Classify same-process
+  hardening and operator misuse accurately.
 - **Incremental commits:** after review starts, do not force-push unless a maintainer requests it.
 - **Communication style:** do not use em dashes. Keep communication succinct and human-friendly.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,9 @@
 - **Relative imports:** use the `.js` extension in TypeScript ESM imports.
 - **No `any`:** avoid `any` and `as any`; use proper types or a justified Biome suppression.
 - **Follow existing patterns** before introducing new abstractions.
+- **Security reviews:** read `THREAT_MODEL.md` before reporting a security finding. Identify the
+  attacker, supported call path, trusted preconditions, violated security objective, and concrete
+  impact. Classify same-process hardening and operator misuse accurately.
 - **Incremental commits:** after review starts, do not force-push unless a maintainer requests it.
 - **Communication style:** do not use em dashes. Keep communication succinct and human-friendly.
 

--- a/THREAT_MODEL.md
+++ b/THREAT_MODEL.md
@@ -73,10 +73,13 @@ Lodestar-z aims to preserve the following properties in supported builds and dep
 3. **Memory safety.** Malformed externally sourced bytes, points, indices, offsets, and collection
    lengths do not cause out-of-bounds access, use-after-free, double free, uninitialized-memory use,
    or allocator mismatch.
-4. **Process availability.** A single malformed or protocol-bounded remote input fails with an error
-   rather than a panic, deadlock, infinite loop, or unreasonable amplification of CPU or memory.
+4. **Process availability.** Attacker-controlled inputs and bounded sequences of inputs fail safely
+   and do not cause panics, deadlocks, infinite loops, cumulative leaks, or unbounded queue or cache
+   growth. CPU and memory amplification remain within explicit protocol, transport, and application
+   bounds.
 5. **State integrity.** Rejected candidate blocks do not partially modify the trusted pre-state,
-   publish derived epoch-cache entries, enter fork choice, or corrupt process-wide caches.
+   publish branch-specific epoch-cache entries, enter fork choice, or violate the documented
+   process-wide pubkey-cache invariant.
 6. **Lifecycle safety.** Supported Node.js worker creation, concurrent cache access, environment
    teardown, and finalization do not race or access freed global state.
 7. **Artifact integrity.** Published native artifacts are built from reviewed sources and pinned
@@ -94,7 +97,8 @@ The main assets are:
 - the correctness of beacon states, state roots, fork selection, validator accounting, and head
   selection;
 - Ethereum consensus safety and liveness for a Lodestar node using this implementation;
-- availability and memory integrity of the hosting Node.js process;
+- availability, integrity, and confidentiality of the hosting Node.js process memory, including
+  unrelated validator material, JWTs, API credentials, and other resident secrets;
 - correctness of BLS signature verification and aggregation;
 - integrity of process-wide node pools, pubkey caches, configuration, and worker-pool state;
 - confidentiality of BLS secret-key material intentionally passed to this package;
@@ -132,8 +136,13 @@ library can contain.
 
 Code loaded into the same process can invoke exported functions, allocate memory, read and write
 files using its own runtime privileges, terminate the process, and serialize a `SecretKey` by design.
-It is not a security boundary. N-API still validates types, lengths, indexes, and encodings to prevent
-accidental misuse from becoming native undefined behavior or a process crash.
+It is not an authorization or OS-isolation boundary. It remains a JavaScript-to-native memory-safety,
+host-process confidentiality, and cross-environment integrity boundary. Same-process callers,
+including compromised dependencies, may intentionally supply malformed arrays, coercing objects,
+stale handles, and adversarial buffers; those inputs must not yield arbitrary native memory access or
+cross-worker corruption. N-API entry points must validate runtime types, lengths, indexes, encodings,
+and buffer ranges before unsafe native access. Gaps are boundary-hardening or security findings
+according to current or planned reachability.
 
 ### Checkpoint state provider
 
@@ -166,9 +175,10 @@ publishing, and provenance are the relevant controls.
 | JavaScript to N-API | Runtime types, byte contents, lengths, indices, offsets, arrays, and object shapes | Same-process caller chooses which method to call and owns policy options |
 | P2P object to SSZ | Bytes, offsets, list lengths, bitfields, and encodings are hostile | Lodestar-ts applies transport bounds; native decoding still enforces canonical SSZ and consensus limits |
 | Beacon-state deserialization | Bytes come from a trusted anchor, trusted database, or trusted ERA source | Deserialization establishes structural SSZ validity only; provenance establishes state trust |
-| State transition | Serialized signed block contents are hostile | Pre-state is trusted; full STF or equivalent prior checks are required; execution and DA statuses are accurate |
+| State transition and import | Serialized signed block contents are hostile | Pre-state is trusted; full STF or equivalent prior checks are required; publication is gated on joined execution and DA results |
 | Fork choice | Valid blocks and validated attestations still represent competing branches | Only STF-valid blocks enter; attestations passed the applicable upstream validation; local time is trusted |
 | BLS API | Serialized points, messages, list contents, and cardinality | Boolean validation options are caller policy; proof-of-possession preconditions apply where documented |
+| Zig to C/native dependencies | JavaScript- or network-influenced values may reach dependency calls | Lodestar-z ensures valid representation, initialization, cardinality, pointer lifetime, requested validation, and ABI compatibility; pinned dependencies are trusted to honor their documented contracts |
 | Shared native state | Worker scheduling and teardown are asynchronous | Configuration and administrative cache operations follow their lifecycle contract |
 | Checkpoint provider | Response may be malformed; provider is semitrusted | User-provided checkpoint root is authoritative, or checkpoint selection is explicitly delegated |
 | Database, PKIX, and ERA/E2S | Fallible local I/O, format compatibility, and accidental corruption | Contents and provenance are trusted; malicious local replacement is out of scope |
@@ -212,15 +222,16 @@ or construction entry point requires trusted state bytes. Trust originates at on
 - a user-provided checkpoint root, after the downloaded state's hash-tree-root is matched to it; or
 - explicit delegation of checkpoint selection to a checkpoint state provider.
 
-Subsequent states inherit trust through successful state transitions. A state written to trusted
-storage retains the trust it had when written. SSZ deserialization checks structural validity; it
-does not establish provenance, consensus validity, canonicality, or finality.
+Subsequent states inherit authenticated provenance through successful state transitions. A state
+written to trusted storage retains the provenance and validity status it had when written. SSZ
+deserialization checks structural validity; it does not establish provenance, consensus validity,
+canonicality, or finality.
 
 ```text
 genesis or authenticated checkpoint
                  |
                  v
-       trusted beacon pre-state
+      eligible trusted pre-state
                  |
         hostile candidate block
                  |
@@ -228,52 +239,61 @@ genesis or authenticated checkpoint
           |                    |
        reject                accept
           |                    |
- discard candidate       trusted post-state
+ discard candidate      authenticated post-state
                                |
-                    fork choice or trusted storage
+                 eligible pre-state or trusted storage
 ```
 
-For this model, a trusted beacon state is:
+For this model, an authenticated CL-derived beacon state is:
 
 - structurally valid SSZ;
-- consensus-layer valid, conditional on the execution and DA assertions supplied by the application;
+- produced by a successful consensus-layer state transition;
 - descended from a trusted anchor; and
-- associated with a block branch that is eligible for fork choice at the time it is accepted.
+- accompanied by the execution and DA status used when it was accepted.
+
+An eligible trusted pre-state is an authenticated CL-derived state whose branch remains eligible for
+fork choice under its current execution and DA status. Eligibility is therefore a current-use
+property, not part of the state's historical provenance.
 
 These properties must not be conflated:
 
-| Property | Guarantee for a trusted beacon state |
+| Property | Guarantee for an authenticated CL-derived state |
 | --- | --- |
 | Structural SSZ validity | Always |
-| Consensus-layer validity | Always, conditional on correct external execution and DA assertions |
+| Consensus-layer transition | Successful |
 | Descent from trusted anchor | Always |
 | Canonical | Not necessarily |
 | Finalized | Not necessarily |
 | Persisted | Not necessarily |
-| Execution status | Valid or conditionally trusted while `syncing` |
+| Execution status | Valid or conditionally valid while `syncing` |
 | DA status | Valid within the DA window; treated as satisfied outside the window |
+| Fork-choice eligibility | Not inherent; required when the state is used as an eligible trusted pre-state |
 
-A noncanonical block and its implied post-state remain valid and trusted while their branch remains
-viable. Finalization makes conflicting branches ineligible and their states are evicted. This does
-not mean those states were invalid before finalization, but they are no longer eligible trusted
-pre-states afterward.
+A noncanonical block and its implied post-state may remain valid and eligible trusted pre-states while
+their branch remains viable. Finalization makes conflicting branches ineligible and their states are
+evicted. It does not erase their authenticated provenance or historical successful CL transition,
+but they can no longer serve as eligible trusted pre-states.
 
-An execution-optimistic state is conditionally trusted. Each block carries its own execution status.
-While the EL is syncing, optimistic blocks and their descendants remain `syncing`. When the EL later
-reports valid or invalid, fork choice propagates that result through the affected branch. Latest
-valid hash processing makes an invalid block and all descendants immediately ineligible, revokes
-their conditional trust, and prevents their use as trusted pre-states. Lodestar-ts is responsible for
-preventing validator duties while the node is execution optimistic.
+An execution-optimistic state is authenticated but conditionally valid. Each block carries its own
+execution status. While the EL is syncing, optimistic blocks and their descendants remain `syncing`
+and may remain eligible for fork choice. When the EL later reports valid or invalid, fork choice
+propagates that result through the affected branch. Latest valid hash processing makes an invalid
+block and all descendants immediately ineligible, revokes their conditional validity, and prevents
+their use as eligible trusted pre-states. Lodestar-ts is responsible for preventing validator duties
+while the node is execution optimistic.
 
-DA must be satisfied before STF. Inside the DA window this means DA validation has completed. A
-super-node that custodies all columns may start STF after observing half because it can reconstruct
-the remainder. Outside the window during sync, DA is treated as satisfied rather than retained as an
-optimistic branch status.
+DA must be satisfied before block acceptance and publication, but DA verification and STF may run
+concurrently when an all-or-none result gates publication. Inside the DA window, successful import
+requires completed DA validation. A super-node that custodies all columns may treat DA as satisfied
+after observing half because it can reconstruct the remainder. Outside the window during sync, DA is
+treated as satisfied rather than retained as an optimistic branch status.
 
-`BeaconStateView.stateTransition` clones the trusted cached pre-state. Work before a late failure
-mutates only the disposable candidate clone, which is destroyed on error. Only a successful full STF
-may publish the post-state or enter fork choice. A finding that claims accepted-state corruption must
-demonstrate an alias or cache mutation crossing this isolation boundary.
+`BeaconStateView.stateTransition` clones the trusted cached pre-state. Branch-specific work before a
+late failure mutates the disposable candidate clone, which is destroyed on error. The documented
+exception is the shared append-only pubkey cache, which may safely advance during a failed candidate
+transition under the invariant below. Only after a successful full STF and all joined import checks
+may the post-state be published or enter fork choice. A finding that claims accepted-state corruption
+must demonstrate an alias or cache mutation that violates these isolation and append-only rules.
 
 Malicious database or ERA state bytes are outside the adversarial model. Checkpoint-provider bytes
 are the one state-loading surface where malformed input is plausible because the provider is only
@@ -294,19 +314,17 @@ canonical SSZ decoding
         +-- gossip: consensus-spec gossip validation
         |
         +-- range, unknown-block, or backward sync: hash-chain validation
-                                                       |
-                                                       v
-                         proposer and operation signatures checked
-                         individually by STF or batch-verified beforehand
-                                                       |
-                                                       v
-                                      full STF and state-root verification
-                                                       |
-                                                       v
-                                  valid block and trusted post-state
-                                                       |
-                                                       v
-                                                 fork choice
+        |
+        +--> CL STF and state-root verification ------------------+
+        +--> proposer and operation signatures, in STF or batch --+
+        +--> execution verification or optimistic status --------+
+        +--> DA verification or satisfied sync policy ------------+
+                                                                  |
+                                                 all-or-none import gate
+                                                                  |
+                                      accepted block and eligible trusted post-state
+                                                                  |
+                                                            fork choice
 ```
 
 Backward sync starts when a block, attestation, or another P2P object references an unknown block. It
@@ -342,9 +360,11 @@ results. The EL is trusted to be nonmalicious but may be fallible or still synci
 response is a Lodestar-z consensus bug. The `syncing` execution status becomes branch metadata in
 the planned fork-choice integration rather than weakening CL state-transition checks.
 
-DA orchestration currently belongs to Lodestar-ts. Supplying the correct DA status before STF is an
-integration precondition. Incorrect handling of that status in Lodestar-z is in scope; a trusted
-caller falsely claiming availability is not an independent native validation bypass.
+DA orchestration currently belongs to Lodestar-ts. The real DA result or satisfied sync policy must
+participate in the all-or-none acceptance gate. STF may evaluate concurrently using a provisional
+available status as long as its candidate result cannot be published independently. Incorrect
+handling of a correct DA result in Lodestar-z is in scope; a trusted caller falsely claiming
+availability is not an independent native validation bypass.
 
 ### Fork choice
 
@@ -380,13 +400,20 @@ the pubkey cache across Node.js environments. Sharing is intentional.
   resize.
 - PKIX save, load, and reset are restricted to the control environment. Reads and supported append
   operations may be shared.
-- The pubkey cache contains finalized validator-registry history. Pending deposits are processed into
-  this global append-only history only at finalization, so an orphaned or execution-invalid branch
-  cannot poison it.
+- The pubkey cache represents unforkable append-only validator pubkey/index history. Because cloned
+  epoch caches share it, candidate processing may append a future entry before the block's remaining
+  operations and state-root check succeed. That append is not rolled back.
+- A cached index at or beyond a state's validator count must be treated as absent for that state.
+  Later valid processing at the same index must reproduce the same pubkey; conflicting, duplicate,
+  or sparse appends fail. This prevents a safe future cache entry from being mistaken for accepted
+  state.
+- Former Eth1 bridge deposits may register a validator during block processing and append immediately.
+  In Electra the validator initially has zero balance while its amount remains pending. Execution-layer
+  deposit requests stay pending and register a new validator only after their source slot is finalized.
 - Other state-transition caches are short-lived, generally epoch-scoped, and derived from a trusted
   state. Candidate-block processing must isolate their mutations until acceptance. A failed STF may
-  leave metrics or completed signature computations, but nothing that can influence later validity
-  decisions.
+  leave metrics, completed signature computations, and a permitted pubkey-cache append, but no other
+  candidate-derived mutation that can influence later validity decisions.
 - Chain configuration is application startup state. The application must not concurrently replace
   it while states or transitions are using borrowed configuration data.
 - Explicit capacity APIs are controlled by the local application. They must reject arithmetic
@@ -426,12 +453,12 @@ impact rather than a claimed beacon-node remote exploit.
 
 | ID | Scenario | Security condition |
 | --- | --- | --- |
-| TM-01 | Malformed P2P SSZ, proof descriptors, BLS encodings, or remotely influenced N-API values trigger native memory corruption or a panic | Reachable through a current or identified planned P2P integration without first violating a trusted-caller precondition |
+| TM-01 | Malformed P2P SSZ, proof descriptors, BLS encodings, or remotely influenced N-API values trigger native memory corruption, host-process memory disclosure, or a panic | Reachable through a current or identified planned P2P integration without first violating a trusted-caller precondition |
 | TM-02 | An adversarial block or attestation produces a state root, validator result, fork upgrade, or head different from the pinned specification | Correct preset/configuration, trusted pre-state, full required validation, and accurate external statuses are used |
 | TM-03 | An invalid BLS signature, public key, or aggregate is accepted when the requested checks and documented preconditions hold | Report identifies the exact API flags, point validation state, and proof-of-possession assumption |
 | TM-04 | Attacker-controlled work or memory grows beyond protocol or documented application bounds | Report traces attacker control and quantifies amplification, not merely a theoretical maximum local call |
 | TM-05 | Node.js workers race on a cache, pool, configuration, async job, finalizer, or cleanup hook | Sequence uses the supported worker/lifecycle model |
-| TM-06 | Failed STF leaks candidate-derived caches into trusted state, enters fork choice, leaks, double-frees, or deadlocks | Report accounts for cloning, epoch-cache ownership, `defer`, `errdefer`, reference counts, locks, and rollback |
+| TM-06 | Failed STF leaks branch-specific candidate caches into trusted state, enters fork choice, violates the unforkable pubkey-cache invariant, leaks, double-frees, or deadlocks | Report accounts for cloning, epoch-cache ownership, permitted pubkey appends, `defer`, `errdefer`, reference counts, locks, and rollback |
 | TM-07 | Checkpoint bootstrap accepts a downloaded state whose hash-tree-root does not equal the user-provided checkpoint root | Report identifies the integration layer responsible for the mandatory root comparison |
 | TM-08 | A build or release workflow executes untrusted code with secrets or publishes a substituted native artifact | Report demonstrates the relevant CI event, permissions, pinning, and artifact path |
 | TM-09 | Secret-key material escapes through an unrelated API or memory-safety flaw | Calling documented `SecretKey.toBytes` or `toHex` is not an escape |
@@ -478,7 +505,8 @@ The following are not security findings without additional evidence that crosses
 - bypassing validation by explicitly setting a verification option to `false` from trusted code;
 - inaccurate execution or data-availability results supplied by the trusted application;
 - fork choice not repeating state transition, signature, or indexed-attestation validation;
-- mutation of the disposable post-state clone before a transition is rejected;
+- mutation of the disposable post-state clone or a permitted future pubkey-cache append before a
+  transition is rejected, without a demonstrated violation of their isolation invariants;
 - a noncanonical but still viable branch retaining a valid trusted post-state;
 - states from a finalized-away branch being evicted as no longer useful;
 - the PKIX checksum not being a MAC or PKIX affine entries not being revalidated;
@@ -516,8 +544,8 @@ Before filing a security finding, answer all of the following:
 9. **Reproduction:** Can the issue be reproduced on the target branch with the supported Zig version
    and, for bindings, a ReleaseSafe native build?
 10. **Impact:** Does it cause consensus divergence, false cryptographic acceptance, memory
-    corruption, branch misclassification, persistent integrity loss, process unavailability, secret
-    exposure, or only a handled error?
+    corruption, host-process memory disclosure, branch misclassification, persistent integrity loss,
+    process unavailability, secret exposure, or only a handled error?
 11. **Rollback and ownership:** Does the effect survive candidate-clone destruction, epoch-cache
     cleanup, lock release, worker teardown, cache staging, or fork-choice invalidation?
 12. **Bound:** For denial of service, what are the maximum input, allocation, loop count, and
@@ -551,7 +579,8 @@ incomplete:
 - SSZ and BLS fuzz targets;
 - full STF before import, including proposer and operation signatures checked by STF or an
   all-or-none prior batch, plus post-state-root verification;
-- copy-on-write state cloning and cleanup on rejected transitions;
+- copy-on-write state cloning and cleanup on rejected transitions, with explicit state-length checks
+  for permitted append-only pubkey-cache advancement;
 - gossip validation or sync hash-chain validation before full forward STF;
 - trusted-anchor bootstrapping through genesis or checkpoint-root authentication;
 - explicit protocol bounds, bounded stack buffers, and checked arithmetic in parsers;

--- a/THREAT_MODEL.md
+++ b/THREAT_MODEL.md
@@ -19,14 +19,16 @@ The assets protected here are:
 - Ethereum consensus safety and liveness;
 - state-transition, fork-choice, and BLS correctness;
 - native memory safety and availability of the hosting process; and
-- integrity of shared native state across calls and Node.js environments.
+- integrity of shared native state across calls and Node.js environments; and
+- integrity of source dependencies and published native artifacts.
 
 The relevant attackers are remote peers or API users whose values reach Lodestar-z, and
-same-process JavaScript callers that can supply malformed values. The operator and host application
-are trusted to select configuration, verification policy, initial state, local files, wall-clock
-time, and execution or data-availability status. Same-process Zig code is trusted to honor native
-API preconditions. Host compromise and malicious replacement of trusted local storage are out of
-scope.
+same-process JavaScript callers that can supply malformed values. Attackers may also target
+dependencies, build workflows, release credentials, or the package registry. The operator and host
+application are trusted to select configuration, verification policy, initial state, local files,
+wall-clock time, and execution or data-availability status. Same-process Zig code is trusted to
+honor native API preconditions. Host compromise and malicious replacement of trusted local storage
+are out of scope.
 
 ## Security objectives
 
@@ -39,6 +41,8 @@ scope.
    allocation.
 5. Rejected candidates cannot publish branch-specific state or corrupt shared state.
 6. Supported concurrent operations and environment teardown cannot race with borrowed native state.
+7. Build and release preserve the integrity and provenance of reviewed source, dependency inputs,
+   and published native artifacts.
 
 ## Trust boundaries
 
@@ -51,6 +55,7 @@ scope.
 | Fork choice | Blocks have passed full state transition, attestations have passed their applicable validation, external statuses are accurate, and local time is trusted. Fork choice still owns its specified ancestry, timing, vote, invalidation, and bound checks. |
 | Zig to native dependencies | Lodestar-z owns representation, cardinality, validation flags, pointer lifetime, and ABI compatibility. Pinned dependencies are trusted only within their documented contracts. |
 | Shared native state | Ownership, synchronization, bounds, worker visibility, and teardown must be defined for every shared pool or cache. |
+| Build and release | Dependency resolution, automation credentials, and artifact publication must preserve provenance from reviewed source to the published native addon. |
 
 ## BeaconState trust
 

--- a/THREAT_MODEL.md
+++ b/THREAT_MODEL.md
@@ -1,615 +1,246 @@
 # Lodestar-z threat model
 
-This document defines the security boundaries and review assumptions for Lodestar-z. It is written
-for maintainers and automated reviewers. Read it before reporting a security issue.
+This document is the stable security contract for Lodestar-z. It defines the assets, actors, trust
+boundaries, invariants, and classification rules that determine whether a finding is a security
+issue, security-readiness issue, correctness bug, or hardening opportunity.
 
-It applies to the `main` branch and was last reviewed on 2026-08-12.
+Current integration status, call paths, cache mechanics, file references, and implemented controls
+belong in the [security implementation map](docs/security/IMPLEMENTATION_MAP.md). Those details may
+change without changing this contract.
 
-This is a living model. A code path that violates an assumption may still contain a bug, but the
-report must explain why the violation is reachable in a supported Lodestar deployment.
+This model applies to the `main` branch. Review consensus claims against the specification version
+pinned in `build.zig.zon`, the active fork, and the active preset.
 
-## System and deployment context
+## Scope
 
-Lodestar-z is a Zig library and a Node.js native addon. It is not a network service, an HTTP server,
-an Ethereum peer-to-peer stack, an execution client, a key manager, or a slashing-protection
-database.
+Lodestar-z is a Zig library and Node.js native addon used by Lodestar. It is not itself a network
+service, P2P stack, execution client, key manager, or slashing-protection database.
 
-The production data flow is generally:
-
-```text
-remote consensus peer or external subsystem
-                    |
-                    v
-       Lodestar networking and orchestration       outside this repository
-                    |
-                    v
-       JavaScript wrappers and N-API boundary      bindings/src, bindings/napi
-                    |
-                    v
-   SSZ, state transition, BLS, caches, fork choice src
-                    |
-                    v
-        post-state, roots, proofs, or errors
-```
-
-P2P objects are the principal hostile data source. Lodestar-ts currently owns networking, message
-size and decompression limits, peer scoring, and orchestration. P2P objects that will cross into
-Lodestar-z may still contain adversarial SSZ bytes. Beacon states, ERA data, database contents,
-configuration, wall-clock time, and application policy have different trust contracts described
-below. Reviews must not treat every serialized object or JavaScript argument as remotely controlled.
-
-The package also supports direct use by JavaScript and Zig callers. Those callers are in the same
-process and privilege domain as Lodestar-z. The addon is not a sandbox around hostile JavaScript.
-
-### Integration maturity
-
-Threat reports must distinguish current production reachability from the required security posture
-of components planned to replace Lodestar-ts implementations:
-
-| Component | Integration status | Review classification |
-| --- | --- | --- |
-| BLS bindings | Integrated | Production-reachable |
-| Process-wide pubkey cache | Integrated | Production-reachable |
-| State transition | Next integration stage | Consensus correctness and security readiness; planned input is a trusted pre-state plus serialized hostile signed block |
-| Zig fork choice | Future integration stage | Parity and security readiness; planned inputs include STF-valid blocks and validated attestations |
-| Generic P2P-object deserialization | Planned as integrations expand | Hostile-input boundary where actually wired |
-| Beacon-state and ERA loading | Library surface using trusted input | Reliability and defense in depth unless another attacker path is demonstrated |
-
-A bug in a planned component can be important and release-blocking without being described as a
+Security classification depends on the least-privileged attacker, the supported or identified
+planned path to the affected code, the trusted preconditions on that path, and the resulting impact.
+A bug in a planned integration may be release-blocking security-readiness work without being a
 currently exploitable Lodestar vulnerability. Direct downstream users must establish their own
-reachable boundary.
+reachable boundaries.
+
+## Assets
+
+The protected assets are:
+
+- Ethereum consensus safety and liveness;
+- beacon-state, state-root, validator-accounting, fork-choice, and head correctness;
+- BLS verification and aggregation correctness;
+- availability, integrity, and confidentiality of the hosting Node.js process, including unrelated
+  validator material, JWTs, API credentials, and other resident secrets;
+- integrity of shared native pools, caches, configuration, and worker state;
+- confidentiality of BLS secret-key material intentionally passed to the library; and
+- integrity of source dependencies, npm packages, and native release artifacts.
+
+The library does not claim to provide an HSM, hardened secret memory, a JavaScript sandbox, or
+protection from arbitrary code that already has the Node.js process's privileges.
 
 ## Security objectives
 
-Lodestar-z aims to preserve the following properties in supported builds and deployments:
+1. **Consensus correctness.** Given the correct preset and configuration, an eligible trusted
+   pre-state, all required validation, and accurate execution and data-availability results, state
+   transition and fork choice agree with the pinned consensus specification.
+2. **Cryptographic correctness.** BLS operations do not accept invalid signatures or points when
+   the API contract requests the relevant checks. Batch operations preserve cardinality and use
+   unpredictable nonzero coefficients where required.
+3. **Memory safety.** Malformed externally influenced values do not cause out-of-bounds access,
+   use-after-free, double free, uninitialized-memory use, allocator mismatch, or native-memory
+   disclosure.
+4. **Process availability.** Attacker-controlled inputs and bounded sequences fail safely. They do
+   not cause panics, deadlocks, infinite loops, cumulative leaks, or unbounded queue or cache growth.
+   CPU and memory amplification remain within explicit protocol, transport, and application bounds.
+5. **State integrity.** Rejected candidates do not modify their trusted pre-state, publish
+   branch-specific derived state, enter fork choice, or corrupt shared state.
+6. **Lifecycle safety.** Supported workers, concurrent operations, environment teardown, and
+   finalization do not race or access freed shared state.
+7. **Artifact integrity.** Published native artifacts are built from reviewed source and pinned
+   dependencies through the repository release process.
 
-1. **Consensus correctness.** With the correct preset and chain configuration, a trusted pre-state,
-   all required checks completed locally or equivalently beforehand, and accurate external execution
-   and data-availability results, state transition and fork choice agree with the consensus
-   specification version pinned in `build.zig.zon`.
-2. **Cryptographic correctness.** BLS operations do not accept invalid signatures or points when the
-   relevant validation is requested by their API contract. Randomized batch operations use
-   unpredictable, nonzero coefficients and preserve the required cardinality.
-3. **Memory safety.** Malformed externally sourced bytes, points, indices, offsets, and collection
-   lengths do not cause out-of-bounds access, use-after-free, double free, uninitialized-memory use,
-   or allocator mismatch.
-4. **Process availability.** Attacker-controlled inputs and bounded sequences of inputs fail safely
-   and do not cause panics, deadlocks, infinite loops, cumulative leaks, or unbounded queue or cache
-   growth. CPU and memory amplification remain within explicit protocol, transport, and application
-   bounds.
-5. **State integrity.** Rejected candidate blocks do not partially modify the trusted pre-state,
-   publish branch-specific epoch-cache entries, enter fork choice, or violate the documented
-   process-wide pubkey-cache invariant.
-6. **Lifecycle safety.** Supported Node.js worker creation, concurrent cache access, environment
-   teardown, and finalization do not race or access freed global state.
-7. **Artifact integrity.** Published native artifacts are built from reviewed sources and pinned
-   dependencies through the repository release workflow.
+## Actors and trusted inputs
 
-Secret keys are sensitive when callers use the exported BLS `SecretKey` API. The library must not
-leak them through unrelated output, logs, memory-safety errors, or other objects. It does not claim
-to provide process isolation, an HSM, hardened memory, or protection from arbitrary code already
-executing in the Node.js process.
+| Actor or source | Capability and trust |
+| --- | --- |
+| Remote consensus participant | Controls protocol-shaped and malformed P2P objects. It does not directly control native options, configuration, local files, or capacity APIs without a demonstrated Lodestar path. |
+| Remote API user | Controls only values forwarded by Lodestar's API layer after its validation and limits. Reports must trace that path. |
+| Operator and host application | Trusted to choose the preset, configuration, initial state, local files, verification policy, external statuses, capacities, and wall-clock time. Accidental misuse should fail clearly, but a malicious operator is out of scope. |
+| Same-process JavaScript or Zig code | Has ambient application privileges and may intentionally provide malformed or coercing values. It is not an authorization or OS-isolation boundary, but it does not thereby possess arbitrary native-memory or cross-worker access. |
+| Checkpoint state provider | Semitrusted. A user-provided checkpoint root is authoritative; without one, checkpoint selection is explicitly delegated to the provider. |
+| Trusted local storage | Database state, ERA/E2S data, and PKIX files are application-owned. This model assumes bytes written are the bytes later read. Malicious local replacement and host compromise are out of scope. |
+| Contributor or supply-chain attacker | May attempt to introduce malicious source, workflow, dependency, or release changes. |
 
-## Assets and impact
+Raw checkpoint bytes are hostile to whichever component first decodes them before authentication.
+Lodestar-z state-loading entry points are defined to accept trusted state bytes. If a supported
+integration assigns initial checkpoint decoding to Lodestar-z, that entry point becomes a
+hostile-input boundary.
 
-The main assets are:
+## Trust boundaries
 
-- the correctness of beacon states, state roots, fork selection, validator accounting, and head
-  selection;
-- Ethereum consensus safety and liveness for a Lodestar node using this implementation;
-- availability, integrity, and confidentiality of the hosting Node.js process memory, including
-  unrelated validator material, JWTs, API credentials, and other resident secrets;
-- correctness of BLS signature verification and aggregation;
-- integrity of process-wide node pools, pubkey caches, configuration, and worker-pool state;
-- confidentiality of BLS secret-key material intentionally passed to this package;
-- integrity of npm packages and native release artifacts.
+| Boundary | Lodestar-z contract |
+| --- | --- |
+| Remote source to Lodestar-z | Remotely derived bytes remain hostile unless the exact required validation has already completed and is bound to the operation's result. |
+| JavaScript to N-API | Runtime types, lengths, indexes, encodings, arrays, object shapes, and buffer ranges must be validated before unsafe native access. Caller-selected policy remains trusted. |
+| Serialized input to SSZ | Decoding enforces canonical encoding, offsets, list limits, bitfields, arithmetic bounds, and safe ownership. |
+| Beacon-state construction | Input state bytes already have trusted provenance. SSZ decoding establishes structure only, not ancestry, canonicality, finality, or consensus validity. |
+| State transition | The pre-state is an eligible trusted pre-state; the signed candidate block is hostile. Required consensus checks and state-root verification must complete before publication. |
+| Fork choice | Blocks have passed full state transition, attestations have passed the applicable upstream validation, external statuses are accurate, and local time is trusted. Fork choice still owns its specified ancestry, timing, vote, status-propagation, and bound checks. |
+| BLS API | Serialized points, messages, collections, and cardinality may be hostile. Caller-controlled validation flags and proof-of-possession preconditions are explicit policy. |
+| Zig to native dependencies | Lodestar-z owns representation, initialization, cardinality, pointer lifetime, requested validation, and ABI compatibility. Pinned dependencies are trusted to honor documented contracts. |
+| Shared native state | Synchronization, ownership, worker visibility, and teardown order must be defined. |
+| Local persistence | Provenance is trusted. Parsers still enforce documented framing, size, format, checksum, ownership, and cleanup contracts for reliability and memory safety. |
+| Build and release | Maintainer review, pinned inputs, protected repository settings, and release credentials establish artifact trust. |
 
-A consensus mismatch, invalid signature acceptance, remotely reachable native memory corruption, or
-deterministic process crash can be security-significant. A wrong exception message, an unsupported
-API call, or bad output caused only by an operator supplying inconsistent trusted configuration is
-normally a correctness or usability issue instead.
+A `std.debug.assert` is not a parser guard for externally influenced data in ReleaseSafe. TypeScript
+declarations are not runtime validation.
 
-## Actors and capabilities
+## Consensus trust invariants
 
-### Remote consensus participant
+### Beacon-state provenance and eligibility
 
-A peer can send adversarial but protocol-shaped blocks, attestations, signatures, public keys, and
-SSZ payloads to Lodestar. It may also send malformed network payloads. It cannot directly choose
-native method options, mutate the local chain configuration, select local files, reserve arbitrary
-cache capacity, or call addon methods unless a concrete Lodestar path exposes that control.
+A beacon state is not an arbitrary network object. Trusted provenance originates from:
 
-### Remote API user
-
-An API user has only the capabilities granted by Lodestar's HTTP or RPC layer, which is outside this
-repository. A report relying on this actor must trace the value through that layer to a Lodestar-z
-entry point and account for upstream validation and limits.
-
-### Operator and host application
-
-The operator and the Lodestar application choose the network preset, chain configuration, trusted
-checkpoint or initial state, file paths, cache sizing, execution status, data-availability status,
-verification policy, and wall-clock time. These are trusted control-plane inputs. Accidental
-mistakes should fail clearly where practical, but a malicious operator is not an attacker this
-library can contain.
-
-### Same-process JavaScript or Zig code
-
-Code loaded into the same process can invoke exported functions, allocate memory, read and write
-files using its own runtime privileges, terminate the process, and serialize a `SecretKey` by design.
-It is not an authorization or OS-isolation boundary. It remains a JavaScript-to-native memory-safety,
-host-process confidentiality, and cross-environment integrity boundary. Same-process callers,
-including compromised dependencies, may intentionally supply malformed arrays, coercing objects,
-stale handles, and adversarial buffers; those inputs must not yield arbitrary native memory access or
-cross-worker corruption. N-API entry points must validate runtime types, lengths, indexes, encodings,
-and buffer ranges before unsafe native access. Gaps are boundary-hardening or security findings
-according to current or planned reachability.
-
-### Checkpoint state provider
-
-A checkpoint state provider is usually semitrusted. If the user supplies a checkpoint root, matching
-the downloaded state's hash-tree-root to that root is a mandatory part of establishing the trust
-chain. The exact Lodestar-ts or Lodestar-z integration point that performs this check is not yet
-fixed. If the user supplies no root, trust in checkpoint selection is explicitly delegated to the
-provider. A malicious provider under delegated trust is outside this threat model, while safely
-handling malformed responses remains worthwhile boundary hardening.
-
-### Trusted local storage
-
-Beacon states read from the database, ERA/E2S data, and PKIX snapshots are application-owned trusted
-inputs. The current model assumes bytes written are the bytes later read. Host or database compromise,
-silent storage corruption, and an operator selecting a file from the wrong network are outside the
-adversarial model. Framing checks and graceful failures remain reliability and defense-in-depth
-requirements, not evidence that these inputs are ordinarily hostile.
-
-### Contributor or supply-chain attacker
-
-A contributor may propose malicious source or workflow changes. A dependency or build service may
-be compromised. Code review, pinned Zig dependencies and GitHub Actions, tests, npm trusted
-publishing, and provenance are the relevant controls.
-
-## Trust boundaries and contracts
-
-| Boundary | Untrusted or fallible data | Trusted decision or precondition |
-| --- | --- | --- |
-| Network to Lodestar | P2P gossip and req/resp objects | Message framing, size/decompression limits, peer scoring, and orchestration are currently owned by Lodestar-ts |
-| JavaScript to N-API | Runtime types, byte contents, lengths, indices, offsets, arrays, and object shapes | Same-process caller chooses which method to call and owns policy options |
-| P2P object to SSZ | Bytes, offsets, list lengths, bitfields, and encodings are hostile | Lodestar-ts applies transport bounds; native decoding still enforces canonical SSZ and consensus limits |
-| Beacon-state deserialization | Bytes come from a trusted anchor, trusted database, or trusted ERA source | Deserialization establishes structural SSZ validity only; provenance establishes state trust |
-| State transition and import | Serialized signed block contents are hostile | Pre-state is trusted; full STF or equivalent prior checks are required; publication is gated on joined execution and DA results |
-| Fork choice | Valid blocks and validated attestations still represent competing branches | Only STF-valid blocks enter; attestations passed the applicable upstream validation; local time is trusted |
-| BLS API | Serialized points, messages, list contents, and cardinality | Boolean validation options are caller policy; proof-of-possession preconditions apply where documented |
-| Zig to C/native dependencies | JavaScript- or network-influenced values may reach dependency calls | Lodestar-z ensures valid representation, initialization, cardinality, pointer lifetime, requested validation, and ABI compatibility; pinned dependencies are trusted to honor their documented contracts |
-| Shared native state | Worker scheduling and teardown are asynchronous | Configuration and administrative cache operations follow their lifecycle contract |
-| Checkpoint provider | Response may be malformed; provider is semitrusted | User-provided checkpoint root is authoritative, or checkpoint selection is explicitly delegated |
-| Database, PKIX, and ERA/E2S | Fallible local I/O, format compatibility, and accidental corruption | Contents and provenance are trusted; malicious local replacement is out of scope |
-| Build and release | Source contributions and downloaded dependencies | Maintainer review, pinned versions/hashes, protected repository settings, and release credentials |
-
-### Component review map
-
-| Area | Primary security concern | Important inherited contract |
-| --- | --- | --- |
-| `src/ssz`, `src/persistent_merkle_tree`, `src/hashing` | Canonical decoding, offset and generalized-index bounds, ownership, proof correctness, and bounded merkleization | Generic typed callers obey allocator and lifetime contracts; serialized bytes can be hostile |
-| `src/consensus_types`, `src/fork_types`, `src/config`, `src/preset` | Correct fork schema, preset values, fork dispatch, and type-safe cross-fork access | Active preset and runtime chain configuration identify the intended network |
-| `src/state_transition` | Consensus equivalence, signature checks, rejected-state isolation, cache consistency, and bounded per-block work | Trusted anchored pre-state and accurate external execution/DA results |
-| `src/bls` | Point decoding, subgroup and infinity checks, aggregation cardinality, randomness, thread-pool cleanup, and false acceptance | Per-call validation flags and proof-of-possession requirements are explicit API policy |
-| `src/fork_choice` | Head correctness, optimistic invalidation, vote accounting, finalized ancestry, equivocation handling, queue bounds, and arithmetic | Blocks passed full state transition; indexed attestations passed upstream validation; time is advanced by the trusted caller |
-| `src/beacon_node`, `src/clock` | Cache ownership, event ordering, time/slot calculations, and integration invariants | A report must establish whether the component is wired into a production Lodestar path |
-| `src/era` | Format correctness, offsets, decompression, allocation bounds, SSZ parsing, and optional semantic validation | ERA data and its provenance are trusted; failures are ordinarily reliability issues |
-| `bindings/napi`, `bindings/src` | Runtime type and range checks, native lifetime, worker isolation, error stability, and JS/native API agreement | Same-process caller owns control-plane policy and has ambient process privileges |
-| `scripts`, `test`, `bench`, `examples` | Developer, CI, generation, or supply-chain impact | These are not runtime peer-facing surfaces without a demonstrated invocation path |
-
-### N-API boundary
-
-The native exports are registered from `bindings/napi/root.zig`: configuration, node-pool sizing,
-shuffle, metrics, state transition helpers, `BeaconStateView`, BLS, and the pubkey cache. Public
-JavaScript declarations and wrappers live in `bindings/src`.
-
-Every JavaScript-controlled length, index, byte encoding, buffer range, class instance, and numeric
-conversion that reaches native memory must be checked or passed to an API that returns a bounded
-error. JavaScript type declarations are not runtime validation. A `std.debug.assert` is not an
-acceptable parser guard in ReleaseSafe when malformed external data can reach it.
-
-This robustness requirement does not turn the addon into an authorization boundary. For example,
-`pubkeyCache.save(path)` is explicitly a local file-writing API. Letting its caller choose `path` is
-not path traversal by itself.
-
-### Beacon-state trust and provenance
-
-A beacon state is not an arbitrary network object in the Lodestar architecture. Every state-loading
-or construction entry point requires trusted state bytes. Trust originates at one of these anchors:
-
-- genesis, which can be viewed as the trusted checkpoint at epoch zero;
-- a user-provided checkpoint root, after the downloaded state's hash-tree-root is matched to it; or
+- genesis, treated as the checkpoint at epoch zero;
+- a state whose hash-tree-root matches a user-provided checkpoint root; or
 - explicit delegation of checkpoint selection to a checkpoint state provider.
 
-Subsequent states inherit authenticated provenance through successful state transitions. A state
-written to trusted storage retains the provenance and validity status it had when written. SSZ
-deserialization checks structural validity; it does not establish provenance, consensus validity,
-canonicality, or finality.
+A state read from trusted storage retains the provenance and validity status it had when written.
+Subsequent states inherit authenticated provenance through successful consensus-layer state
+transitions.
 
-```text
-genesis or authenticated checkpoint
-                 |
-                 v
-      eligible trusted pre-state
-                 |
-        hostile candidate block
-                 |
-       isolated full state transition
-          |                    |
-       reject                accept
-          |                    |
- discard candidate      authenticated post-state
-                               |
-                 eligible pre-state or trusted storage
-```
+An **authenticated CL-derived state** is structurally valid SSZ, descended from a trusted anchor,
+produced by a successful consensus-layer transition, and accompanied by the execution and DA status
+used at acceptance.
 
-For this model, an authenticated CL-derived beacon state is:
+An **eligible trusted pre-state** is an authenticated CL-derived state whose branch remains eligible
+for fork choice under its current execution and DA status. Eligibility is a current-use property,
+not part of historical provenance.
 
-- structurally valid SSZ;
-- produced by a successful consensus-layer state transition;
-- descended from a trusted anchor; and
-- accompanied by the execution and DA status used when it was accepted.
-
-An eligible trusted pre-state is an authenticated CL-derived state whose branch remains eligible for
-fork choice under its current execution and DA status. Eligibility is therefore a current-use
-property, not part of the state's historical provenance.
-
-These properties must not be conflated:
-
-| Property | Guarantee for an authenticated CL-derived state |
+| Property | Authenticated CL-derived state |
 | --- | --- |
 | Structural SSZ validity | Always |
-| Consensus-layer transition | Successful |
-| Descent from trusted anchor | Always |
-| Canonical | Not necessarily |
-| Finalized | Not necessarily |
-| Persisted | Not necessarily |
-| Execution status | Valid or conditionally valid while `syncing` |
-| DA status | Valid within the DA window; treated as satisfied outside the window |
-| Fork-choice eligibility | Not inherent; required when the state is used as an eligible trusted pre-state |
+| Successful CL transition and anchor descent | Always |
+| Canonical, finalized, or persisted | Not necessarily |
+| Execution status | Valid or conditionally valid while execution validity is unresolved |
+| DA status | Valid within the DA window; treated as satisfied by the defined sync policy outside it |
+| Fork-choice eligibility | Required only when used as an eligible trusted pre-state |
 
-A noncanonical block and its implied post-state may remain valid and eligible trusted pre-states while
-their branch remains viable. Finalization makes conflicting branches ineligible and their states are
-evicted. It does not erase their authenticated provenance or historical successful CL transition,
-but they can no longer serve as eligible trusted pre-states.
+A noncanonical branch may retain valid eligible pre-states while it remains viable. Finalization
+makes conflicting branches ineligible but does not erase their provenance or historical successful
+CL transitions. Execution invalidation instead revokes conditional validity and eligibility for the
+affected branch.
 
-An execution-optimistic state is authenticated but conditionally valid. Each block carries its own
-execution status. While the EL is syncing, optimistic blocks and their descendants remain `syncing`
-and may remain eligible for fork choice. When the EL later reports valid or invalid, fork choice
-propagates that result through the affected branch. Latest valid hash processing makes an invalid
-block and all descendants immediately ineligible, revokes their conditional validity, and prevents
-their use as eligible trusted pre-states. Lodestar-ts is responsible for preventing validator duties
-while the node is execution optimistic.
+### Candidate-block acceptance
 
-DA must be satisfied before block acceptance and publication, but DA verification and STF may run
-concurrently when an all-or-none result gates publication. Inside the DA window, successful import
-requires completed DA validation. A super-node that custodies all columns may treat DA as satisfied
-after observing half because it can reconstruct the remainder. Outside the window during sync, DA is
-treated as satisfied rather than retained as an optimistic branch status.
+- A full consensus-layer state transition is required before every block import. Gossip checks,
+  hash-chain checks during sync, and ancestry checks establish prerequisites but do not replace it.
+- All proposer and operation signatures are checked by the state transition or by an equivalent
+  prior batch whose all-or-none result gates the same import.
+- A candidate may publish its post-state and enter fork choice only after state transition,
+  state-root verification, signatures, execution handling, and DA handling have jointly succeeded.
+  Independent checks may run concurrently.
+- A state with unresolved execution validity is authenticated but conditionally valid. It may remain
+  fork-choice eligible, but validators must not perform duties while the node is execution
+  optimistic. A later invalid result invalidates the affected branch.
+- Within the DA window, DA must be satisfied before acceptance and publication. Outside the window,
+  the defined sync policy treats DA as satisfied rather than retaining a DA-optimistic branch.
+- Verification flags are trusted application policy. A required check may be disabled only when the
+  same accepted operation is gated on equivalent prior verification.
 
-`BeaconStateView.stateTransition` clones the trusted cached pre-state. Branch-specific work before a
-late failure mutates the disposable candidate clone, which is destroyed on error. The documented
-exception is the shared append-only pubkey cache, which may safely advance during a failed candidate
-transition under the invariant below. Only after a successful full STF and all joined import checks
-may the post-state be published or enter fork choice. A finding that claims accepted-state corruption
-must demonstrate an alias or cache mutation that violates these isolation and append-only rules.
+Lodestar-z consumes execution and DA results rather than establishing them. A false result supplied
+by a trusted external system is not an independent Lodestar-z bypass. Mishandling an accurate result
+is in scope.
 
-Malicious database or ERA state bytes are outside the adversarial model. Checkpoint-provider bytes
-are the one state-loading surface where malformed input is plausible because the provider is only
-semitrusted. Robust decoding there is defense in depth, and matching a user-provided checkpoint root
-is the critical authentication step.
+### Candidate isolation and shared facts
 
-### P2P block validation paths
+Candidate processing must isolate branch-specific mutations until acceptance. A rejected candidate
+may leave only work products or cache facts that cannot affect later validity based on the rejected
+branch.
 
-Gossip and sync establish different preliminary facts, but full STF is required before every block
-import:
+Shared caches may retain only branch-independent facts. In particular, an append-only
+validator-pubkey cache may advance during a failed candidate only if:
 
-```text
-hostile P2P bytes
-        |
-        v
-canonical SSZ decoding
-        |
-        +-- gossip: consensus-spec gossip validation
-        |
-        +-- range, unknown-block, or backward sync: hash-chain validation
-        |
-        +--> CL STF and state-root verification ------------------+
-        +--> proposer and operation signatures, in STF or batch --+
-        +--> execution verification or optimistic status --------+
-        +--> DA verification or satisfied sync policy ------------+
-                                                                  |
-                                                 all-or-none import gate
-                                                                  |
-                                      accepted block and eligible trusted post-state
-                                                                  |
-                                                            fork choice
-```
+- cached indexes beyond a state's validator count are treated as absent for that state;
+- later valid processing at an index must reproduce the same pubkey; and
+- conflicting, duplicate, or sparse appends fail.
 
-Backward sync starts when a block, attestation, or another P2P object references an unknown block. It
-fetches parents until reaching a block already known to fork choice, checks `parentRoot` against the
-parent block's hash-tree-root, and then processes the chain forward through full STF before import.
-Hash-chain membership proves ancestry, not consensus validity.
+Any new mutable global state must define its synchronization, ownership, worker visibility, bounds,
+and teardown order.
 
-Lodestar-ts may batch-verify signatures in parallel before STF. In practice, all required
-verification pathways are joined with all-or-none `Promise.all` behavior. Disabling a corresponding
-STF check is valid only when that exact import operation is gated on all prior verification promises.
-Successful signature computations may remain after a later STF failure, but they are useless and
-must not imply block validity.
+## Finding classification
 
-### Verification flags and external statuses
+### Required evidence
 
-The following values are trusted application policy, not remote authorization controls:
+A security report must identify:
 
-- `verifyStateRoot`, `verifyProposer`, and `verifySignatures`;
-- execution-payload status;
-- data-availability status;
-- BLS public-key, signature, group, and infinity-check options.
+1. the least-privileged attacker and controlled value;
+2. the current supported path or identified planned integration path to the operation;
+3. the integration maturity and every trusted precondition on that path;
+4. the validation, ownership, lifecycle, fork, preset, and external-status contracts involved;
+5. the violated security objective and concrete effect;
+6. whether the effect survives candidate cleanup, cache isolation, fork-choice invalidation, or
+   worker teardown; and
+7. a reproducible input or sequence with relevant size, work, and allocation bounds.
 
-Disabling a check is supported for call paths that already performed equivalent validation, tests,
-and controlled workloads. Production import still requires proposer verification, all operation
-signature checks, consensus processing, and post-state-root verification. A report is
-security-relevant only if an untrusted actor can cause a supported production path to omit a
-required check, prior verification is not bound into the all-or-none import result, a check marked
-enabled is ineffective, or the API contract falsely claims validation that does not occur.
+Severity follows demonstrated reachability, defaults, reproducibility, and impact. A
+dangerous-looking line is not sufficient evidence.
 
-Lodestar-z does not contact the execution layer or a data-availability subsystem. It consumes their
-results. The EL is trusted to be nonmalicious but may be fallible or still syncing. An incorrect
-`valid` response from a faulty EL is an external-system failure. Incorrect handling of a correct EL
-response is a Lodestar-z consensus bug. The `syncing` execution status becomes branch metadata in
-the planned fork-choice integration rather than weakening CL state-transition checks.
+### Categories
 
-DA orchestration currently belongs to Lodestar-ts. The real DA result or satisfied sync policy must
-participate in the all-or-none acceptance gate. STF may evaluate concurrently using a provisional
-available status as long as its candidate result cannot be published independently. Incorrect
-handling of a correct DA result in Lodestar-z is in scope; a trusted caller falsely claiming
-availability is not an independent native validation bypass.
+| Classification | Meaning |
+| --- | --- |
+| Security vulnerability | An in-scope attacker crosses a current supported boundary and violates a security objective. |
+| Security-readiness issue | A planned integration would expose the violation at a hostile boundary, but that path is not yet production-reachable. |
+| Consensus correctness bug | Behavior differs from the pinned specification under valid inputs without established attacker reachability. |
+| Boundary hardening | Validation or robustness is weak where the caller already has equivalent impact and no less-privileged hostile path is established. |
+| Trusted-input reliability bug | Trusted state, storage, or local-file use causes a leak, panic, race, cleanup failure, or bad error. |
+| Operator misuse or unsupported use | The trigger violates an explicit trusted precondition or supported lifecycle. |
+| Test or documentation gap | No current behavior violates this model. |
 
-### Fork choice
+### Resource exhaustion
 
-Fork choice intentionally does not repeat every expensive consensus check:
+Every denial-of-service report must quantify the input bound, work or allocation amplification,
+repeatability, and attacker-controlled path.
 
-- `ForkChoice.onBlock` requires the supplied block to have passed state transition upstream.
-- `ForkChoice.onAttestation` requires the indexed attestation to have passed
-  `is_valid_indexed_attestation` upstream.
-- `onAttesterSlashing` relies on state-transition validation, including sorted attesting indices.
+- One malformed remote input must fail safely before peer scoring can help.
+- Sustained attacks must account for supported transport limits, scoring, and disconnection, but
+  those controls do not excuse cumulative leaks or unbounded queues.
+- Protocol-bounded transition and cryptographic costs are expected unless amplification materially
+  exceeds the protocol work.
+- A large allocation requested only by a trusted same-process caller is hardening unless remote
+  influence is demonstrated.
+- Host-wide out-of-memory is not itself a vulnerability; attacker-controlled amplification before
+  it can be.
 
-On the gossip path, attestation prerequisites are the applicable consensus-spec gossip and indexed
-attestation validations. They include structural constraints, timing, shuffling and committee
-membership, sorted and unique indices, and BLS verification as applicable. Sync paths may establish
-their prerequisites differently, but may not put an invalid block into fork choice.
+### Common non-findings
 
-Fork choice remains responsible for its documented checks, including known parents, time, finalized
-ancestry, target consistency, execution and payload status propagation, latest-valid-hash branch
-invalidation, vote application, and internal bounds. Missing an upstream-owned signature check
-inside fork choice is not a vulnerability unless a production caller can bypass the prerequisite.
+Without evidence crossing a boundary above, these are not security vulnerabilities:
 
-The current production Lodestar fork-choice implementation remains in Lodestar-ts. The Zig module is
-intended to replace it, so parity of optimistic handling, invalidation, and validation prerequisites
-is a required integration invariant even before current remote reachability exists.
+- missing authentication on an in-process API, deliberate use of caller-owned policy flags, or
+  effects already available through the caller's ambient privileges without additional
+  native-memory or cross-worker impact;
+- an operator selecting malicious configuration, an untrusted initial state, a wrong-network file,
+  or an attacker-controlled output path;
+- treating trusted database, ERA/E2S, or PKIX bytes as remotely controlled;
+- expecting state SSZ decoding to establish trusted ancestry, canonicality, or finality;
+- fork choice relying on documented state-transition or attestation-validation prerequisites;
+- mutation of a disposable candidate or a permitted branch-independent cache append;
+- retention of a viable noncanonical state or eviction of a finalized-away state;
+- a checksum that detects corruption but is not an authentication mechanism;
+- intended secret-key serialization to the owning caller;
+- failures confined to tests, generators, fuzzers, examples, benchmarks, or explicit stubs; and
+- timing or memory-forensic attacks absent a separately adopted side-channel guarantee.
 
-### Process-wide configuration, pools, and caches
+These may still be correctness, reliability, API-design, or defense-in-depth issues.
 
-The addon shares BLS worker-pool state, the persistent Merkle node pool, configuration, metrics, and
-the pubkey cache across Node.js environments. Sharing is intentional.
+## Maintenance rule
 
-- Loading and unloading supported workers must not tear down state still used by another
-  environment.
-- Pubkey-cache movable storage is protected by its lock, and references into it must not escape a
-  resize.
-- PKIX save, load, and reset are restricted to the control environment. Reads and supported append
-  operations may be shared.
-- The pubkey cache represents unforkable append-only validator pubkey/index history. Because cloned
-  epoch caches share it, candidate processing may append a future entry before the block's remaining
-  operations and state-root check succeed. That append is not rolled back.
-- A cached index at or beyond a state's validator count must be treated as absent for that state.
-  Later valid processing at the same index must reproduce the same pubkey; conflicting, duplicate,
-  or sparse appends fail. This prevents a safe future cache entry from being mistaken for accepted
-  state.
-- Former Eth1 bridge deposits may register a validator during block processing and append immediately.
-  In Electra the validator initially has zero balance while its amount remains pending. Execution-layer
-  deposit requests stay pending and register a new validator only after their source slot is finalized.
-- Other state-transition caches are short-lived, generally epoch-scoped, and derived from a trusted
-  state. Candidate-block processing must isolate their mutations until acceptance. A failed STF may
-  leave metrics, completed signature computations, and a permitted pubkey-cache append, but no other
-  candidate-derived mutation that can influence later validity decisions.
-- Chain configuration is application startup state. The application must not concurrently replace
-  it while states or transitions are using borrowed configuration data.
-- Explicit capacity APIs are controlled by the local application. They must reject arithmetic
-  overflow and impossible capacities, but a same-process caller deliberately requesting a large
-  valid reservation is not a remote memory-exhaustion attack.
+Keep this file normative and short. A statement belongs here only if changing it can change a
+finding's trust analysis, classification, reachability, severity, or required security property.
+Descriptions of where or how the current implementation enforces a rule belong in the
+[implementation map](docs/security/IMPLEMENTATION_MAP.md).
 
-Any code change that adds mutable global state must define its synchronization, ownership, worker
-visibility, and teardown order.
-
-### PKIX cache files
-
-PKIX is a fast native cache snapshot, not a trust anchor. Its loader checks framing, exact file size,
-format version, ABI compatibility, caller-supplied capacity, and corruption checksums. The checksum
-is not intended to authenticate a maliciously modified file, and affine entries are not
-semantically revalidated on load. Callers must load only an application-owned file from the intended
-network while cache administration is safe.
-
-Reports about forged PKIX checksums or semantically invalid but well-framed local files are out of
-scope unless they show one of the following:
-
-- a normal Lodestar workflow allows a remote actor to replace or select the file;
-- the loader accepts a file contrary to its documented ABI, size, or checksum contract;
-- a failed or concurrent load corrupts the previously live cache.
-
-### ERA and E2S files
-
-ERA/E2S data is trusted local input, not a hostile runtime surface. Entry sizes, index counts,
-arithmetic, file offsets, decompression, and SSZ decoding should still be bounded and checked for
-reliability. `Reader.validate` additionally checks network and block/state consistency. Lower-level
-`read*` methods do not establish trust because trust already comes from provenance.
-
-Download scripts, test-vector generation, benchmarks, and fuzz harnesses are development tooling,
-not runtime network endpoints. Findings in them need a build, CI, developer-workstation, or release
-impact rather than a claimed beacon-node remote exploit.
-
-## Threat scenarios in scope
-
-| ID | Scenario | Security condition |
-| --- | --- | --- |
-| TM-01 | Malformed P2P SSZ, proof descriptors, BLS encodings, or remotely influenced N-API values trigger native memory corruption, host-process memory disclosure, or a panic | Reachable through a current or identified planned P2P integration without first violating a trusted-caller precondition |
-| TM-02 | An adversarial block or attestation produces a state root, validator result, fork upgrade, or head different from the pinned specification | Correct preset/configuration, trusted pre-state, full required validation, and accurate external statuses are used |
-| TM-03 | An invalid BLS signature, public key, or aggregate is accepted when the requested checks and documented preconditions hold | Report identifies the exact API flags, point validation state, and proof-of-possession assumption |
-| TM-04 | Attacker-controlled work or memory grows beyond protocol or documented application bounds | Report traces attacker control and quantifies amplification, not merely a theoretical maximum local call |
-| TM-05 | Node.js workers race on a cache, pool, configuration, async job, finalizer, or cleanup hook | Sequence uses the supported worker/lifecycle model |
-| TM-06 | Failed STF leaks branch-specific candidate caches into trusted state, enters fork choice, violates the unforkable pubkey-cache invariant, leaks, double-frees, or deadlocks | Report accounts for cloning, epoch-cache ownership, permitted pubkey appends, `defer`, `errdefer`, reference counts, locks, and rollback |
-| TM-07 | Checkpoint bootstrap accepts a downloaded state whose hash-tree-root does not equal the user-provided checkpoint root | Report identifies the integration layer responsible for the mandatory root comparison |
-| TM-08 | A build or release workflow executes untrusted code with secrets or publishes a substituted native artifact | Report demonstrates the relevant CI event, permissions, pinning, and artifact path |
-| TM-09 | Secret-key material escapes through an unrelated API or memory-safety flaw | Calling documented `SecretKey.toBytes` or `toHex` is not an escape |
-| TM-10 | Correct EL or DA status causes wrong optimistic eligibility, validator-safety signal, or branch invalidation | A false status supplied by an external system is distinguished from mishandling a correct status |
-
-## Resource-exhaustion standard
-
-This project requires bounded loops and allocations even when an immediate exploit is not proven.
-Security severity still depends on reachability:
-
-- A protocol-valid peer input that causes superlinear or grossly amplified work in the normal node
-  path is a security concern.
-- A malformed remote input that allocates before checking its encoded bound is a security concern.
-- A single malformed P2P object must fail safely before peer scoring can help. Scoring does not
-  mitigate a panic, memory corruption, deadlock, or large one-shot amplification.
-- A remote API input is relevant only when the Lodestar API actually forwards it and does not
-  impose an effective bound.
-- An arbitrary JavaScript array or explicit `ensureCapacity` value supplied by trusted same-process
-  code is boundary hardening unless a remote path is demonstrated.
-- Normal state-transition cost, cryptographic verification cost, and allocations bounded by
-  consensus constants are expected. A report should compare the cost with the protocol maximum and
-  the surrounding Lodestar rate controls.
-- Sustained invalid-input attacks must account for Lodestar-ts peer scoring and disconnection. A
-  report should show meaningful damage before scoring takes effect or an integration path that is
-  not scored appropriately. Scoring policy itself is currently a Lodestar-ts concern.
-- Unavoidable process behavior after genuine host-wide out-of-memory is not by itself a
-  vulnerability. Attacker-controlled allocation amplification before OOM can be one.
-
-Every denial-of-service report should provide an input-size bound, work or allocation estimate,
-repeatability, and the attacker-controlled call path.
-
-## Out of scope and common false positives
-
-The following are not security findings without additional evidence that crosses a boundary above:
-
-- lack of authentication or authorization on an in-process Zig or N-API function;
-- arbitrary code already executing inside the Lodestar Node.js process;
-- an operator choosing a malicious configuration, wrong preset, untrusted initial state, wrong
-  network file, or attacker-controlled output path;
-- treating trusted database beacon states or ERA/E2S data as attacker-controlled inputs without a
-  demonstrated boundary that can replace them;
-- expecting beacon-state SSZ deserialization to establish trusted ancestry, canonicality, finality,
-  or long-range-attack resistance;
-- bypassing validation by explicitly setting a verification option to `false` from trusted code;
-- inaccurate execution or data-availability results supplied by the trusted application;
-- fork choice not repeating state transition, signature, or indexed-attestation validation;
-- mutation of the disposable post-state clone or a permitted future pubkey-cache append before a
-  transition is rejected, without a demonstrated violation of their isolation invariants;
-- a noncanonical but still viable branch retaining a valid trusted post-state;
-- states from a finalized-away branch being evicted as no longer useful;
-- the PKIX checksum not being a MAC or PKIX affine entries not being revalidated;
-- path traversal based solely on the caller-controlled path of an explicit local load/save API;
-- disclosure of a secret through the documented `SecretKey.toBytes` or `toHex` method to its owning
-  caller;
-- crashes or hangs only in tests, generated spec-test runners, fuzz harnesses, examples, or
-  benchmarks, absent a production or supply-chain path;
-- missing implementation of an API that is explicitly stubbed and throws `NOT_IMPLEMENTED`;
-- a large allocation requested only by a malicious same-process caller, with no remote influence;
-- timing or memory-forensic attacks against secret keys, unless maintainers separately adopt a
-  hardened-memory or side-channel-resistance guarantee.
-
-These cases can still justify a correctness, reliability, API-design, or defense-in-depth issue.
-Label them accurately rather than presenting them as remote vulnerabilities.
-
-## Security-review procedure
-
-Before filing a security finding, answer all of the following:
-
-1. **Attacker:** Who is the least-privileged actor that controls the trigger?
-2. **Maturity:** Is the component production-integrated, planned for integration, or only a direct
-   library surface?
-3. **Provenance:** Is the input hostile P2P data, a semitrusted checkpoint response, trusted state or
-   ERA data, trusted application policy, or same-process caller data?
-4. **Entry point:** Which exported Zig function, N-API method, parser, file workflow, or CI event is
-   reached?
-5. **Call path:** How does attacker-controlled data reach the exact operation through gossip, sync,
-   req/resp, a binding, or another supported or identified planned deployment path?
-6. **Validation route:** Did gossip validation, hash-chain validation, individual STF checks, or
-   all-or-none prior batch verification establish a prerequisite?
-7. **Contract:** Which trust-anchor, execution/DA, lifecycle, ownership, fork, preset, and upstream
-   preconditions apply?
-8. **Violated objective:** Which numbered security objective or threat scenario is broken?
-9. **Reproduction:** Can the issue be reproduced on the target branch with the supported Zig version
-   and, for bindings, a ReleaseSafe native build?
-10. **Impact:** Does it cause consensus divergence, false cryptographic acceptance, memory
-    corruption, host-process memory disclosure, branch misclassification, persistent integrity loss,
-    process unavailability, secret exposure, or only a handled error?
-11. **Rollback and ownership:** Does the effect survive candidate-clone destruction, epoch-cache
-    cleanup, lock release, worker teardown, cache staging, or fork-choice invalidation?
-12. **Bound:** For denial of service, what are the maximum input, allocation, loop count, and
-   amplification?
-13. **Reference:** For consensus behavior, does the claim match the exact spec version pinned in
-    `build.zig.zon`, the active fork, and the active preset rather than upstream `master`?
-
-A useful report includes a minimal test or input and states whether the classification is:
-
-- **security vulnerability:** crosses an in-scope boundary and violates a security objective;
-- **consensus correctness bug:** wrong behavior under valid inputs, with deployment reachability not
-  yet established;
-- **security-readiness or integration invariant:** required before a planned component becomes a
-  hostile-input production boundary, but not currently remotely reachable;
-- **boundary hardening:** unsafe or weak validation at an in-process boundary without a remote path;
-- **trusted-input reliability bug:** leak, panic, format failure, race, or bad cleanup under
-  non-adversarial state, database, ERA, or local-file use;
-- **operator misuse or unsupported use:** violates an explicit trusted precondition;
-- **test or documentation gap:** no current behavior violating the model.
-
-Do not assign a high severity from a dangerous-looking line alone. Severity follows the demonstrated
-attacker, defaults, call path, reproducibility, and effect.
-
-## Existing controls to verify, not assume
-
-The repository has controls that reduce risk, but a review may show that an implementation is
-incomplete:
-
-- consensus, SSZ, and BLS vectors pinned through `build.zig.zon`;
-- minimal and mainnet preset testing;
-- SSZ and BLS fuzz targets;
-- full STF before import, including proposer and operation signatures checked by STF or an
-  all-or-none prior batch, plus post-state-root verification;
-- copy-on-write state cloning and cleanup on rejected transitions, with explicit state-length checks
-  for permitted append-only pubkey-cache advancement;
-- gossip validation or sync hash-chain validation before full forward STF;
-- trusted-anchor bootstrapping through genesis or checkpoint-root authentication;
-- explicit protocol bounds, bounded stack buffers, and checked arithmetic in parsers;
-- keyed pubkey-cache hashing, locking around movable storage, staged PKIX installation, capacity
-  limits, and control-environment administration;
-- reference-counted native pools and last-environment cleanup;
-- fork-choice execution-status propagation and latest-valid-hash invalidation as required parity
-  behavior for the future integration;
-- ReleaseSafe native artifacts;
-- pinned GitHub Actions, hashed Zig dependencies, lockfile installation, npm trusted publishing, and
-  provenance.
-
-Security reports should test whether the relevant control actually covers the claimed path.
-
-## Open deployment questions
-
-Maintainers should update this model as the integration matures. Until then, reviewers should state
-their assumption for these questions rather than silently choosing the most alarming one:
-
-- Which N-API methods are stable end-user APIs versus Lodestar-internal compatibility surfaces?
-- Which additional serialized P2P object types are connected to Lodestar-z as STF and fork-choice
-  integration proceeds?
-- Which layer will own the mandatory comparison between a downloaded checkpoint state root and a
-  user-provided checkpoint root?
-- What stable error taxonomy will let Lodestar-ts distinguish invalid peer data, consensus failure,
-  execution invalidity, and internal failure for scoring and operations?
-- What production limits should apply to proof descriptors, aggregate lists, pool preheating, and
-  pubkey-cache growth?
-- Is chain configuration guaranteed to be set once before workers and state views are created?
-- How are PKIX files provisioned, permissioned, and invalidated across network or binary upgrades?
-- Is the exported `SecretKey` API intended for production validator key material, or only API
-  compatibility and testing?
+Review both documents when a change adds or alters a trust boundary, native dependency, persistence
+path or format, shared mutable cache or pool, externally influenced native input, or supported
+integration.

--- a/THREAT_MODEL.md
+++ b/THREAT_MODEL.md
@@ -66,7 +66,8 @@ protection from arbitrary code that already has the Node.js process's privileges
 | Remote consensus participant | Controls protocol-shaped and malformed P2P objects. It does not directly control native options, configuration, local files, or capacity APIs without a demonstrated Lodestar path. |
 | Remote API user | Controls only values forwarded by Lodestar's API layer after its validation and limits. Reports must trace that path. |
 | Operator and host application | Trusted to choose the preset, configuration, initial state, local files, verification policy, external statuses, capacities, and wall-clock time. Accidental misuse should fail clearly, but a malicious operator is out of scope. |
-| Same-process JavaScript or Zig code | Has ambient application privileges and may intentionally provide malformed or coercing values. It is not an authorization or OS-isolation boundary, but it does not thereby possess arbitrary native-memory or cross-worker access. |
+| Same-process JavaScript | Has ambient application privileges and may intentionally provide malformed or coercing values. It is not an authorization or OS-isolation boundary, but it does not thereby possess arbitrary native-memory or cross-worker access. |
+| Same-process Zig code | Executes native code with process privileges and can construct or dereference arbitrary pointers. It is trusted to honor Zig API preconditions and is not a native-memory isolation boundary. |
 | Checkpoint state provider | Semitrusted. A user-provided checkpoint root is authoritative; without one, checkpoint selection is explicitly delegated to the provider. |
 | Trusted local storage | Database state, ERA/E2S data, and PKIX files are application-owned. This model assumes bytes written are the bytes later read. Malicious local replacement and host compromise are out of scope. |
 | Contributor or supply-chain attacker | May attempt to introduce malicious source, workflow, dependency, or release changes. |
@@ -109,32 +110,33 @@ A state read from trusted storage retains the provenance and validity status it 
 Subsequent states inherit authenticated provenance through successful consensus-layer state
 transitions.
 
-An **authenticated CL-derived state** is structurally valid SSZ, descended from a trusted anchor,
-produced by a successful consensus-layer transition, and accompanied by the execution and DA status
-used at acceptance.
+An **authenticated beacon state** is structurally valid SSZ and is either a trusted anchor or the
+result of a successful consensus-layer transition from an eligible trusted pre-state. It carries the
+execution and DA status applicable when it was accepted.
 
-An **eligible trusted pre-state** is an authenticated CL-derived state whose branch remains eligible
+An **eligible trusted pre-state** is an authenticated beacon state whose branch remains eligible
 for fork choice under its current execution and DA status. Eligibility is a current-use property,
 not part of historical provenance.
 
-| Property | Authenticated CL-derived state |
+| Property | Authenticated beacon state |
 | --- | --- |
 | Structural SSZ validity | Always |
-| Successful CL transition and anchor descent | Always |
+| Trusted origin | Authenticated anchor or successful CL transition from an eligible trusted pre-state |
 | Canonical, finalized, or persisted | Not necessarily |
-| Execution status | Valid or conditionally valid while execution validity is unresolved |
-| DA status | Valid within the DA window; treated as satisfied by the defined sync policy outside it |
+| Execution status | Where applicable, valid or conditionally valid while execution validity is unresolved |
+| DA status | Where applicable, valid within the DA window; treated as satisfied by the defined sync policy outside it |
 | Fork-choice eligibility | Required only when used as an eligible trusted pre-state |
 
 A noncanonical branch may retain valid eligible pre-states while it remains viable. Finalization
-makes conflicting branches ineligible but does not erase their provenance or historical successful
-CL transitions. Execution invalidation instead revokes conditional validity and eligibility for the
+makes conflicting branches ineligible but does not erase their provenance or historical CL
+validity. Execution invalidation instead revokes conditional validity and eligibility for the
 affected branch.
 
 ### Candidate-block acceptance
 
-- A full consensus-layer state transition is required before every block import. Gossip checks,
-  hash-chain checks during sync, and ancestry checks establish prerequisites but do not replace it.
+- A full consensus-layer state transition is required before a block enters the live chain or fork
+  choice, or establishes a trusted post-state. Gossip, sync, hash-chain, and ancestry checks may
+  establish prerequisites but do not replace it.
 - All proposer and operation signatures are checked by the state transition or by an equivalent
   prior batch whose all-or-none result gates the same import.
 - A candidate may publish its post-state and enter fork choice only after state transition,
@@ -147,6 +149,10 @@ affected branch.
   the defined sync policy treats DA as satisfied rather than retaining a DA-optimistic branch.
 - Verification flags are trusted application policy. A required check may be disabled only when the
   same accepted operation is gated on equivalent prior verification.
+
+Blocks stored only as historical archive data need not run STF when they cannot affect consensus
+decisions or establish trusted state. Any later promotion into the live chain must satisfy the full
+acceptance contract.
 
 Lodestar-z consumes execution and DA results rather than establishing them. A false result supplied
 by a trusted external system is not an independent Lodestar-z bypass. Mishandling an accurate result

--- a/THREAT_MODEL.md
+++ b/THREAT_MODEL.md
@@ -1,0 +1,586 @@
+# Lodestar-z threat model
+
+This document defines the security boundaries and review assumptions for Lodestar-z. It is written
+for maintainers and automated reviewers. Read it before reporting a security issue.
+
+It applies to the `main` branch and was last reviewed on 2026-08-12.
+
+This is a living model. A code path that violates an assumption may still contain a bug, but the
+report must explain why the violation is reachable in a supported Lodestar deployment.
+
+## System and deployment context
+
+Lodestar-z is a Zig library and a Node.js native addon. It is not a network service, an HTTP server,
+an Ethereum peer-to-peer stack, an execution client, a key manager, or a slashing-protection
+database.
+
+The production data flow is generally:
+
+```text
+remote consensus peer or external subsystem
+                    |
+                    v
+       Lodestar networking and orchestration       outside this repository
+                    |
+                    v
+       JavaScript wrappers and N-API boundary      bindings/src, bindings/napi
+                    |
+                    v
+   SSZ, state transition, BLS, caches, fork choice src
+                    |
+                    v
+        post-state, roots, proofs, or errors
+```
+
+P2P objects are the principal hostile data source. Lodestar-ts currently owns networking, message
+size and decompression limits, peer scoring, and orchestration. P2P objects that will cross into
+Lodestar-z may still contain adversarial SSZ bytes. Beacon states, ERA data, database contents,
+configuration, wall-clock time, and application policy have different trust contracts described
+below. Reviews must not treat every serialized object or JavaScript argument as remotely controlled.
+
+The package also supports direct use by JavaScript and Zig callers. Those callers are in the same
+process and privilege domain as Lodestar-z. The addon is not a sandbox around hostile JavaScript.
+
+### Integration maturity
+
+Threat reports must distinguish current production reachability from the required security posture
+of components planned to replace Lodestar-ts implementations:
+
+| Component | Integration status | Review classification |
+| --- | --- | --- |
+| BLS bindings | Integrated | Production-reachable |
+| Process-wide pubkey cache | Integrated | Production-reachable |
+| State transition | Next integration stage | Consensus correctness and security readiness; planned input is a trusted pre-state plus serialized hostile signed block |
+| Zig fork choice | Future integration stage | Parity and security readiness; planned inputs include STF-valid blocks and validated attestations |
+| Generic P2P-object deserialization | Planned as integrations expand | Hostile-input boundary where actually wired |
+| Beacon-state and ERA loading | Library surface using trusted input | Reliability and defense in depth unless another attacker path is demonstrated |
+
+A bug in a planned component can be important and release-blocking without being described as a
+currently exploitable Lodestar vulnerability. Direct downstream users must establish their own
+reachable boundary.
+
+## Security objectives
+
+Lodestar-z aims to preserve the following properties in supported builds and deployments:
+
+1. **Consensus correctness.** With the correct preset and chain configuration, a trusted pre-state,
+   all required checks completed locally or equivalently beforehand, and accurate external execution
+   and data-availability results, state transition and fork choice agree with the consensus
+   specification version pinned in `build.zig.zon`.
+2. **Cryptographic correctness.** BLS operations do not accept invalid signatures or points when the
+   relevant validation is requested by their API contract. Randomized batch operations use
+   unpredictable, nonzero coefficients and preserve the required cardinality.
+3. **Memory safety.** Malformed externally sourced bytes, points, indices, offsets, and collection
+   lengths do not cause out-of-bounds access, use-after-free, double free, uninitialized-memory use,
+   or allocator mismatch.
+4. **Process availability.** A single malformed or protocol-bounded remote input fails with an error
+   rather than a panic, deadlock, infinite loop, or unreasonable amplification of CPU or memory.
+5. **State integrity.** Rejected candidate blocks do not partially modify the trusted pre-state,
+   publish derived epoch-cache entries, enter fork choice, or corrupt process-wide caches.
+6. **Lifecycle safety.** Supported Node.js worker creation, concurrent cache access, environment
+   teardown, and finalization do not race or access freed global state.
+7. **Artifact integrity.** Published native artifacts are built from reviewed sources and pinned
+   dependencies through the repository release workflow.
+
+Secret keys are sensitive when callers use the exported BLS `SecretKey` API. The library must not
+leak them through unrelated output, logs, memory-safety errors, or other objects. It does not claim
+to provide process isolation, an HSM, hardened memory, or protection from arbitrary code already
+executing in the Node.js process.
+
+## Assets and impact
+
+The main assets are:
+
+- the correctness of beacon states, state roots, fork selection, validator accounting, and head
+  selection;
+- Ethereum consensus safety and liveness for a Lodestar node using this implementation;
+- availability and memory integrity of the hosting Node.js process;
+- correctness of BLS signature verification and aggregation;
+- integrity of process-wide node pools, pubkey caches, configuration, and worker-pool state;
+- confidentiality of BLS secret-key material intentionally passed to this package;
+- integrity of npm packages and native release artifacts.
+
+A consensus mismatch, invalid signature acceptance, remotely reachable native memory corruption, or
+deterministic process crash can be security-significant. A wrong exception message, an unsupported
+API call, or bad output caused only by an operator supplying inconsistent trusted configuration is
+normally a correctness or usability issue instead.
+
+## Actors and capabilities
+
+### Remote consensus participant
+
+A peer can send adversarial but protocol-shaped blocks, attestations, signatures, public keys, and
+SSZ payloads to Lodestar. It may also send malformed network payloads. It cannot directly choose
+native method options, mutate the local chain configuration, select local files, reserve arbitrary
+cache capacity, or call addon methods unless a concrete Lodestar path exposes that control.
+
+### Remote API user
+
+An API user has only the capabilities granted by Lodestar's HTTP or RPC layer, which is outside this
+repository. A report relying on this actor must trace the value through that layer to a Lodestar-z
+entry point and account for upstream validation and limits.
+
+### Operator and host application
+
+The operator and the Lodestar application choose the network preset, chain configuration, trusted
+checkpoint or initial state, file paths, cache sizing, execution status, data-availability status,
+verification policy, and wall-clock time. These are trusted control-plane inputs. Accidental
+mistakes should fail clearly where practical, but a malicious operator is not an attacker this
+library can contain.
+
+### Same-process JavaScript or Zig code
+
+Code loaded into the same process can invoke exported functions, allocate memory, read and write
+files using its own runtime privileges, terminate the process, and serialize a `SecretKey` by design.
+It is not a security boundary. N-API still validates types, lengths, indexes, and encodings to prevent
+accidental misuse from becoming native undefined behavior or a process crash.
+
+### Checkpoint state provider
+
+A checkpoint state provider is usually semitrusted. If the user supplies a checkpoint root, matching
+the downloaded state's hash-tree-root to that root is a mandatory part of establishing the trust
+chain. The exact Lodestar-ts or Lodestar-z integration point that performs this check is not yet
+fixed. If the user supplies no root, trust in checkpoint selection is explicitly delegated to the
+provider. A malicious provider under delegated trust is outside this threat model, while safely
+handling malformed responses remains worthwhile boundary hardening.
+
+### Trusted local storage
+
+Beacon states read from the database, ERA/E2S data, and PKIX snapshots are application-owned trusted
+inputs. The current model assumes bytes written are the bytes later read. Host or database compromise,
+silent storage corruption, and an operator selecting a file from the wrong network are outside the
+adversarial model. Framing checks and graceful failures remain reliability and defense-in-depth
+requirements, not evidence that these inputs are ordinarily hostile.
+
+### Contributor or supply-chain attacker
+
+A contributor may propose malicious source or workflow changes. A dependency or build service may
+be compromised. Code review, pinned Zig dependencies and GitHub Actions, tests, npm trusted
+publishing, and provenance are the relevant controls.
+
+## Trust boundaries and contracts
+
+| Boundary | Untrusted or fallible data | Trusted decision or precondition |
+| --- | --- | --- |
+| Network to Lodestar | P2P gossip and req/resp objects | Message framing, size/decompression limits, peer scoring, and orchestration are currently owned by Lodestar-ts |
+| JavaScript to N-API | Runtime types, byte contents, lengths, indices, offsets, arrays, and object shapes | Same-process caller chooses which method to call and owns policy options |
+| P2P object to SSZ | Bytes, offsets, list lengths, bitfields, and encodings are hostile | Lodestar-ts applies transport bounds; native decoding still enforces canonical SSZ and consensus limits |
+| Beacon-state deserialization | Bytes come from a trusted anchor, trusted database, or trusted ERA source | Deserialization establishes structural SSZ validity only; provenance establishes state trust |
+| State transition | Serialized signed block contents are hostile | Pre-state is trusted; full STF or equivalent prior checks are required; execution and DA statuses are accurate |
+| Fork choice | Valid blocks and validated attestations still represent competing branches | Only STF-valid blocks enter; attestations passed the applicable upstream validation; local time is trusted |
+| BLS API | Serialized points, messages, list contents, and cardinality | Boolean validation options are caller policy; proof-of-possession preconditions apply where documented |
+| Shared native state | Worker scheduling and teardown are asynchronous | Configuration and administrative cache operations follow their lifecycle contract |
+| Checkpoint provider | Response may be malformed; provider is semitrusted | User-provided checkpoint root is authoritative, or checkpoint selection is explicitly delegated |
+| Database, PKIX, and ERA/E2S | Fallible local I/O, format compatibility, and accidental corruption | Contents and provenance are trusted; malicious local replacement is out of scope |
+| Build and release | Source contributions and downloaded dependencies | Maintainer review, pinned versions/hashes, protected repository settings, and release credentials |
+
+### Component review map
+
+| Area | Primary security concern | Important inherited contract |
+| --- | --- | --- |
+| `src/ssz`, `src/persistent_merkle_tree`, `src/hashing` | Canonical decoding, offset and generalized-index bounds, ownership, proof correctness, and bounded merkleization | Generic typed callers obey allocator and lifetime contracts; serialized bytes can be hostile |
+| `src/consensus_types`, `src/fork_types`, `src/config`, `src/preset` | Correct fork schema, preset values, fork dispatch, and type-safe cross-fork access | Active preset and runtime chain configuration identify the intended network |
+| `src/state_transition` | Consensus equivalence, signature checks, rejected-state isolation, cache consistency, and bounded per-block work | Trusted anchored pre-state and accurate external execution/DA results |
+| `src/bls` | Point decoding, subgroup and infinity checks, aggregation cardinality, randomness, thread-pool cleanup, and false acceptance | Per-call validation flags and proof-of-possession requirements are explicit API policy |
+| `src/fork_choice` | Head correctness, optimistic invalidation, vote accounting, finalized ancestry, equivocation handling, queue bounds, and arithmetic | Blocks passed full state transition; indexed attestations passed upstream validation; time is advanced by the trusted caller |
+| `src/beacon_node`, `src/clock` | Cache ownership, event ordering, time/slot calculations, and integration invariants | A report must establish whether the component is wired into a production Lodestar path |
+| `src/era` | Format correctness, offsets, decompression, allocation bounds, SSZ parsing, and optional semantic validation | ERA data and its provenance are trusted; failures are ordinarily reliability issues |
+| `bindings/napi`, `bindings/src` | Runtime type and range checks, native lifetime, worker isolation, error stability, and JS/native API agreement | Same-process caller owns control-plane policy and has ambient process privileges |
+| `scripts`, `test`, `bench`, `examples` | Developer, CI, generation, or supply-chain impact | These are not runtime peer-facing surfaces without a demonstrated invocation path |
+
+### N-API boundary
+
+The native exports are registered from `bindings/napi/root.zig`: configuration, node-pool sizing,
+shuffle, metrics, state transition helpers, `BeaconStateView`, BLS, and the pubkey cache. Public
+JavaScript declarations and wrappers live in `bindings/src`.
+
+Every JavaScript-controlled length, index, byte encoding, buffer range, class instance, and numeric
+conversion that reaches native memory must be checked or passed to an API that returns a bounded
+error. JavaScript type declarations are not runtime validation. A `std.debug.assert` is not an
+acceptable parser guard in ReleaseSafe when malformed external data can reach it.
+
+This robustness requirement does not turn the addon into an authorization boundary. For example,
+`pubkeyCache.save(path)` is explicitly a local file-writing API. Letting its caller choose `path` is
+not path traversal by itself.
+
+### Beacon-state trust and provenance
+
+A beacon state is not an arbitrary network object in the Lodestar architecture. Every state-loading
+or construction entry point requires trusted state bytes. Trust originates at one of these anchors:
+
+- genesis, which can be viewed as the trusted checkpoint at epoch zero;
+- a user-provided checkpoint root, after the downloaded state's hash-tree-root is matched to it; or
+- explicit delegation of checkpoint selection to a checkpoint state provider.
+
+Subsequent states inherit trust through successful state transitions. A state written to trusted
+storage retains the trust it had when written. SSZ deserialization checks structural validity; it
+does not establish provenance, consensus validity, canonicality, or finality.
+
+```text
+genesis or authenticated checkpoint
+                 |
+                 v
+       trusted beacon pre-state
+                 |
+        hostile candidate block
+                 |
+       isolated full state transition
+          |                    |
+       reject                accept
+          |                    |
+ discard candidate       trusted post-state
+                               |
+                    fork choice or trusted storage
+```
+
+For this model, a trusted beacon state is:
+
+- structurally valid SSZ;
+- consensus-layer valid, conditional on the execution and DA assertions supplied by the application;
+- descended from a trusted anchor; and
+- associated with a block branch that is eligible for fork choice at the time it is accepted.
+
+These properties must not be conflated:
+
+| Property | Guarantee for a trusted beacon state |
+| --- | --- |
+| Structural SSZ validity | Always |
+| Consensus-layer validity | Always, conditional on correct external execution and DA assertions |
+| Descent from trusted anchor | Always |
+| Canonical | Not necessarily |
+| Finalized | Not necessarily |
+| Persisted | Not necessarily |
+| Execution status | Valid or conditionally trusted while `syncing` |
+| DA status | Valid within the DA window; treated as satisfied outside the window |
+
+A noncanonical block and its implied post-state remain valid and trusted while their branch remains
+viable. Finalization makes conflicting branches ineligible and their states are evicted. This does
+not mean those states were invalid before finalization, but they are no longer eligible trusted
+pre-states afterward.
+
+An execution-optimistic state is conditionally trusted. Each block carries its own execution status.
+While the EL is syncing, optimistic blocks and their descendants remain `syncing`. When the EL later
+reports valid or invalid, fork choice propagates that result through the affected branch. Latest
+valid hash processing makes an invalid block and all descendants immediately ineligible, revokes
+their conditional trust, and prevents their use as trusted pre-states. Lodestar-ts is responsible for
+preventing validator duties while the node is execution optimistic.
+
+DA must be satisfied before STF. Inside the DA window this means DA validation has completed. A
+super-node that custodies all columns may start STF after observing half because it can reconstruct
+the remainder. Outside the window during sync, DA is treated as satisfied rather than retained as an
+optimistic branch status.
+
+`BeaconStateView.stateTransition` clones the trusted cached pre-state. Work before a late failure
+mutates only the disposable candidate clone, which is destroyed on error. Only a successful full STF
+may publish the post-state or enter fork choice. A finding that claims accepted-state corruption must
+demonstrate an alias or cache mutation crossing this isolation boundary.
+
+Malicious database or ERA state bytes are outside the adversarial model. Checkpoint-provider bytes
+are the one state-loading surface where malformed input is plausible because the provider is only
+semitrusted. Robust decoding there is defense in depth, and matching a user-provided checkpoint root
+is the critical authentication step.
+
+### P2P block validation paths
+
+Gossip and sync establish different preliminary facts, but full STF is required before every block
+import:
+
+```text
+hostile P2P bytes
+        |
+        v
+canonical SSZ decoding
+        |
+        +-- gossip: consensus-spec gossip validation
+        |
+        +-- range, unknown-block, or backward sync: hash-chain validation
+                                                       |
+                                                       v
+                         proposer and operation signatures checked
+                         individually by STF or batch-verified beforehand
+                                                       |
+                                                       v
+                                      full STF and state-root verification
+                                                       |
+                                                       v
+                                  valid block and trusted post-state
+                                                       |
+                                                       v
+                                                 fork choice
+```
+
+Backward sync starts when a block, attestation, or another P2P object references an unknown block. It
+fetches parents until reaching a block already known to fork choice, checks `parentRoot` against the
+parent block's hash-tree-root, and then processes the chain forward through full STF before import.
+Hash-chain membership proves ancestry, not consensus validity.
+
+Lodestar-ts may batch-verify signatures in parallel before STF. In practice, all required
+verification pathways are joined with all-or-none `Promise.all` behavior. Disabling a corresponding
+STF check is valid only when that exact import operation is gated on all prior verification promises.
+Successful signature computations may remain after a later STF failure, but they are useless and
+must not imply block validity.
+
+### Verification flags and external statuses
+
+The following values are trusted application policy, not remote authorization controls:
+
+- `verifyStateRoot`, `verifyProposer`, and `verifySignatures`;
+- execution-payload status;
+- data-availability status;
+- BLS public-key, signature, group, and infinity-check options.
+
+Disabling a check is supported for call paths that already performed equivalent validation, tests,
+and controlled workloads. Production import still requires proposer verification, all operation
+signature checks, consensus processing, and post-state-root verification. A report is
+security-relevant only if an untrusted actor can cause a supported production path to omit a
+required check, prior verification is not bound into the all-or-none import result, a check marked
+enabled is ineffective, or the API contract falsely claims validation that does not occur.
+
+Lodestar-z does not contact the execution layer or a data-availability subsystem. It consumes their
+results. The EL is trusted to be nonmalicious but may be fallible or still syncing. An incorrect
+`valid` response from a faulty EL is an external-system failure. Incorrect handling of a correct EL
+response is a Lodestar-z consensus bug. The `syncing` execution status becomes branch metadata in
+the planned fork-choice integration rather than weakening CL state-transition checks.
+
+DA orchestration currently belongs to Lodestar-ts. Supplying the correct DA status before STF is an
+integration precondition. Incorrect handling of that status in Lodestar-z is in scope; a trusted
+caller falsely claiming availability is not an independent native validation bypass.
+
+### Fork choice
+
+Fork choice intentionally does not repeat every expensive consensus check:
+
+- `ForkChoice.onBlock` requires the supplied block to have passed state transition upstream.
+- `ForkChoice.onAttestation` requires the indexed attestation to have passed
+  `is_valid_indexed_attestation` upstream.
+- `onAttesterSlashing` relies on state-transition validation, including sorted attesting indices.
+
+On the gossip path, attestation prerequisites are the applicable consensus-spec gossip and indexed
+attestation validations. They include structural constraints, timing, shuffling and committee
+membership, sorted and unique indices, and BLS verification as applicable. Sync paths may establish
+their prerequisites differently, but may not put an invalid block into fork choice.
+
+Fork choice remains responsible for its documented checks, including known parents, time, finalized
+ancestry, target consistency, execution and payload status propagation, latest-valid-hash branch
+invalidation, vote application, and internal bounds. Missing an upstream-owned signature check
+inside fork choice is not a vulnerability unless a production caller can bypass the prerequisite.
+
+The current production Lodestar fork-choice implementation remains in Lodestar-ts. The Zig module is
+intended to replace it, so parity of optimistic handling, invalidation, and validation prerequisites
+is a required integration invariant even before current remote reachability exists.
+
+### Process-wide configuration, pools, and caches
+
+The addon shares BLS worker-pool state, the persistent Merkle node pool, configuration, metrics, and
+the pubkey cache across Node.js environments. Sharing is intentional.
+
+- Loading and unloading supported workers must not tear down state still used by another
+  environment.
+- Pubkey-cache movable storage is protected by its lock, and references into it must not escape a
+  resize.
+- PKIX save, load, and reset are restricted to the control environment. Reads and supported append
+  operations may be shared.
+- The pubkey cache contains finalized validator-registry history. Pending deposits are processed into
+  this global append-only history only at finalization, so an orphaned or execution-invalid branch
+  cannot poison it.
+- Other state-transition caches are short-lived, generally epoch-scoped, and derived from a trusted
+  state. Candidate-block processing must isolate their mutations until acceptance. A failed STF may
+  leave metrics or completed signature computations, but nothing that can influence later validity
+  decisions.
+- Chain configuration is application startup state. The application must not concurrently replace
+  it while states or transitions are using borrowed configuration data.
+- Explicit capacity APIs are controlled by the local application. They must reject arithmetic
+  overflow and impossible capacities, but a same-process caller deliberately requesting a large
+  valid reservation is not a remote memory-exhaustion attack.
+
+Any code change that adds mutable global state must define its synchronization, ownership, worker
+visibility, and teardown order.
+
+### PKIX cache files
+
+PKIX is a fast native cache snapshot, not a trust anchor. Its loader checks framing, exact file size,
+format version, ABI compatibility, caller-supplied capacity, and corruption checksums. The checksum
+is not intended to authenticate a maliciously modified file, and affine entries are not
+semantically revalidated on load. Callers must load only an application-owned file from the intended
+network while cache administration is safe.
+
+Reports about forged PKIX checksums or semantically invalid but well-framed local files are out of
+scope unless they show one of the following:
+
+- a normal Lodestar workflow allows a remote actor to replace or select the file;
+- the loader accepts a file contrary to its documented ABI, size, or checksum contract;
+- a failed or concurrent load corrupts the previously live cache.
+
+### ERA and E2S files
+
+ERA/E2S data is trusted local input, not a hostile runtime surface. Entry sizes, index counts,
+arithmetic, file offsets, decompression, and SSZ decoding should still be bounded and checked for
+reliability. `Reader.validate` additionally checks network and block/state consistency. Lower-level
+`read*` methods do not establish trust because trust already comes from provenance.
+
+Download scripts, test-vector generation, benchmarks, and fuzz harnesses are development tooling,
+not runtime network endpoints. Findings in them need a build, CI, developer-workstation, or release
+impact rather than a claimed beacon-node remote exploit.
+
+## Threat scenarios in scope
+
+| ID | Scenario | Security condition |
+| --- | --- | --- |
+| TM-01 | Malformed P2P SSZ, proof descriptors, BLS encodings, or remotely influenced N-API values trigger native memory corruption or a panic | Reachable through a current or identified planned P2P integration without first violating a trusted-caller precondition |
+| TM-02 | An adversarial block or attestation produces a state root, validator result, fork upgrade, or head different from the pinned specification | Correct preset/configuration, trusted pre-state, full required validation, and accurate external statuses are used |
+| TM-03 | An invalid BLS signature, public key, or aggregate is accepted when the requested checks and documented preconditions hold | Report identifies the exact API flags, point validation state, and proof-of-possession assumption |
+| TM-04 | Attacker-controlled work or memory grows beyond protocol or documented application bounds | Report traces attacker control and quantifies amplification, not merely a theoretical maximum local call |
+| TM-05 | Node.js workers race on a cache, pool, configuration, async job, finalizer, or cleanup hook | Sequence uses the supported worker/lifecycle model |
+| TM-06 | Failed STF leaks candidate-derived caches into trusted state, enters fork choice, leaks, double-frees, or deadlocks | Report accounts for cloning, epoch-cache ownership, `defer`, `errdefer`, reference counts, locks, and rollback |
+| TM-07 | Checkpoint bootstrap accepts a downloaded state whose hash-tree-root does not equal the user-provided checkpoint root | Report identifies the integration layer responsible for the mandatory root comparison |
+| TM-08 | A build or release workflow executes untrusted code with secrets or publishes a substituted native artifact | Report demonstrates the relevant CI event, permissions, pinning, and artifact path |
+| TM-09 | Secret-key material escapes through an unrelated API or memory-safety flaw | Calling documented `SecretKey.toBytes` or `toHex` is not an escape |
+| TM-10 | Correct EL or DA status causes wrong optimistic eligibility, validator-safety signal, or branch invalidation | A false status supplied by an external system is distinguished from mishandling a correct status |
+
+## Resource-exhaustion standard
+
+This project requires bounded loops and allocations even when an immediate exploit is not proven.
+Security severity still depends on reachability:
+
+- A protocol-valid peer input that causes superlinear or grossly amplified work in the normal node
+  path is a security concern.
+- A malformed remote input that allocates before checking its encoded bound is a security concern.
+- A single malformed P2P object must fail safely before peer scoring can help. Scoring does not
+  mitigate a panic, memory corruption, deadlock, or large one-shot amplification.
+- A remote API input is relevant only when the Lodestar API actually forwards it and does not
+  impose an effective bound.
+- An arbitrary JavaScript array or explicit `ensureCapacity` value supplied by trusted same-process
+  code is boundary hardening unless a remote path is demonstrated.
+- Normal state-transition cost, cryptographic verification cost, and allocations bounded by
+  consensus constants are expected. A report should compare the cost with the protocol maximum and
+  the surrounding Lodestar rate controls.
+- Sustained invalid-input attacks must account for Lodestar-ts peer scoring and disconnection. A
+  report should show meaningful damage before scoring takes effect or an integration path that is
+  not scored appropriately. Scoring policy itself is currently a Lodestar-ts concern.
+- Unavoidable process behavior after genuine host-wide out-of-memory is not by itself a
+  vulnerability. Attacker-controlled allocation amplification before OOM can be one.
+
+Every denial-of-service report should provide an input-size bound, work or allocation estimate,
+repeatability, and the attacker-controlled call path.
+
+## Out of scope and common false positives
+
+The following are not security findings without additional evidence that crosses a boundary above:
+
+- lack of authentication or authorization on an in-process Zig or N-API function;
+- arbitrary code already executing inside the Lodestar Node.js process;
+- an operator choosing a malicious configuration, wrong preset, untrusted initial state, wrong
+  network file, or attacker-controlled output path;
+- treating trusted database beacon states or ERA/E2S data as attacker-controlled inputs without a
+  demonstrated boundary that can replace them;
+- expecting beacon-state SSZ deserialization to establish trusted ancestry, canonicality, finality,
+  or long-range-attack resistance;
+- bypassing validation by explicitly setting a verification option to `false` from trusted code;
+- inaccurate execution or data-availability results supplied by the trusted application;
+- fork choice not repeating state transition, signature, or indexed-attestation validation;
+- mutation of the disposable post-state clone before a transition is rejected;
+- a noncanonical but still viable branch retaining a valid trusted post-state;
+- states from a finalized-away branch being evicted as no longer useful;
+- the PKIX checksum not being a MAC or PKIX affine entries not being revalidated;
+- path traversal based solely on the caller-controlled path of an explicit local load/save API;
+- disclosure of a secret through the documented `SecretKey.toBytes` or `toHex` method to its owning
+  caller;
+- crashes or hangs only in tests, generated spec-test runners, fuzz harnesses, examples, or
+  benchmarks, absent a production or supply-chain path;
+- missing implementation of an API that is explicitly stubbed and throws `NOT_IMPLEMENTED`;
+- a large allocation requested only by a malicious same-process caller, with no remote influence;
+- timing or memory-forensic attacks against secret keys, unless maintainers separately adopt a
+  hardened-memory or side-channel-resistance guarantee.
+
+These cases can still justify a correctness, reliability, API-design, or defense-in-depth issue.
+Label them accurately rather than presenting them as remote vulnerabilities.
+
+## Security-review procedure
+
+Before filing a security finding, answer all of the following:
+
+1. **Attacker:** Who is the least-privileged actor that controls the trigger?
+2. **Maturity:** Is the component production-integrated, planned for integration, or only a direct
+   library surface?
+3. **Provenance:** Is the input hostile P2P data, a semitrusted checkpoint response, trusted state or
+   ERA data, trusted application policy, or same-process caller data?
+4. **Entry point:** Which exported Zig function, N-API method, parser, file workflow, or CI event is
+   reached?
+5. **Call path:** How does attacker-controlled data reach the exact operation through gossip, sync,
+   req/resp, a binding, or another supported or identified planned deployment path?
+6. **Validation route:** Did gossip validation, hash-chain validation, individual STF checks, or
+   all-or-none prior batch verification establish a prerequisite?
+7. **Contract:** Which trust-anchor, execution/DA, lifecycle, ownership, fork, preset, and upstream
+   preconditions apply?
+8. **Violated objective:** Which numbered security objective or threat scenario is broken?
+9. **Reproduction:** Can the issue be reproduced on the target branch with the supported Zig version
+   and, for bindings, a ReleaseSafe native build?
+10. **Impact:** Does it cause consensus divergence, false cryptographic acceptance, memory
+    corruption, branch misclassification, persistent integrity loss, process unavailability, secret
+    exposure, or only a handled error?
+11. **Rollback and ownership:** Does the effect survive candidate-clone destruction, epoch-cache
+    cleanup, lock release, worker teardown, cache staging, or fork-choice invalidation?
+12. **Bound:** For denial of service, what are the maximum input, allocation, loop count, and
+   amplification?
+13. **Reference:** For consensus behavior, does the claim match the exact spec version pinned in
+    `build.zig.zon`, the active fork, and the active preset rather than upstream `master`?
+
+A useful report includes a minimal test or input and states whether the classification is:
+
+- **security vulnerability:** crosses an in-scope boundary and violates a security objective;
+- **consensus correctness bug:** wrong behavior under valid inputs, with deployment reachability not
+  yet established;
+- **security-readiness or integration invariant:** required before a planned component becomes a
+  hostile-input production boundary, but not currently remotely reachable;
+- **boundary hardening:** unsafe or weak validation at an in-process boundary without a remote path;
+- **trusted-input reliability bug:** leak, panic, format failure, race, or bad cleanup under
+  non-adversarial state, database, ERA, or local-file use;
+- **operator misuse or unsupported use:** violates an explicit trusted precondition;
+- **test or documentation gap:** no current behavior violating the model.
+
+Do not assign a high severity from a dangerous-looking line alone. Severity follows the demonstrated
+attacker, defaults, call path, reproducibility, and effect.
+
+## Existing controls to verify, not assume
+
+The repository has controls that reduce risk, but a review may show that an implementation is
+incomplete:
+
+- consensus, SSZ, and BLS vectors pinned through `build.zig.zon`;
+- minimal and mainnet preset testing;
+- SSZ and BLS fuzz targets;
+- full STF before import, including proposer and operation signatures checked by STF or an
+  all-or-none prior batch, plus post-state-root verification;
+- copy-on-write state cloning and cleanup on rejected transitions;
+- gossip validation or sync hash-chain validation before full forward STF;
+- trusted-anchor bootstrapping through genesis or checkpoint-root authentication;
+- explicit protocol bounds, bounded stack buffers, and checked arithmetic in parsers;
+- keyed pubkey-cache hashing, locking around movable storage, staged PKIX installation, capacity
+  limits, and control-environment administration;
+- reference-counted native pools and last-environment cleanup;
+- fork-choice execution-status propagation and latest-valid-hash invalidation as required parity
+  behavior for the future integration;
+- ReleaseSafe native artifacts;
+- pinned GitHub Actions, hashed Zig dependencies, lockfile installation, npm trusted publishing, and
+  provenance.
+
+Security reports should test whether the relevant control actually covers the claimed path.
+
+## Open deployment questions
+
+Maintainers should update this model as the integration matures. Until then, reviewers should state
+their assumption for these questions rather than silently choosing the most alarming one:
+
+- Which N-API methods are stable end-user APIs versus Lodestar-internal compatibility surfaces?
+- Which additional serialized P2P object types are connected to Lodestar-z as STF and fork-choice
+  integration proceeds?
+- Which layer will own the mandatory comparison between a downloaded checkpoint state root and a
+  user-provided checkpoint root?
+- What stable error taxonomy will let Lodestar-ts distinguish invalid peer data, consensus failure,
+  execution invalidity, and internal failure for scoring and operations?
+- What production limits should apply to proof descriptors, aggregate lists, pool preheating, and
+  pubkey-cache growth?
+- Is chain configuration guaranteed to be set once before workers and state views are created?
+- How are PKIX files provisioned, permissioned, and invalidated across network or binary upgrades?
+- Is the exported `SecretKey` API intended for production validator key material, or only API
+  compatibility and testing?

--- a/THREAT_MODEL.md
+++ b/THREAT_MODEL.md
@@ -1,252 +1,138 @@
 # Lodestar-z threat model
 
-This document is the stable security contract for Lodestar-z. It defines the assets, actors, trust
-boundaries, invariants, and classification rules that determine whether a finding is a security
-issue, security-readiness issue, correctness bug, or hardening opportunity.
+This document defines the security assumptions that materially affect how findings in Lodestar-z
+are classified. Current integration details live in the
+[implementation map](docs/security/IMPLEMENTATION_MAP.md).
 
-Current integration status, call paths, cache mechanics, file references, and implemented controls
-belong in the [security implementation map](docs/security/IMPLEMENTATION_MAP.md). Those details may
-change without changing this contract.
-
-This model applies to the `main` branch. Review consensus claims against the specification version
-pinned in `build.zig.zon`, the active fork, and the active preset.
+This model is not an allowlist. Reviewers should first surface candidate violations, then use these
+assumptions to determine reachability and severity. A finding may be downgraded only when the
+applicable call path establishes the cited assumption. If the code contradicts this document, report
+the code issue and the documentation gap.
 
 ## Scope
 
-Lodestar-z is a Zig library and Node.js native addon used by Lodestar. It is not itself a network
-service, P2P stack, execution client, key manager, or slashing-protection database.
+Lodestar-z is a Zig consensus library and Node.js native addon. Its host integration owns networking,
+API exposure, checkpoint acquisition, execution-layer communication, and validator duties.
 
-Security classification depends on the least-privileged attacker, the supported or identified
-planned path to the affected code, the trusted preconditions on that path, and the resulting impact.
-A bug in a planned integration may be release-blocking security-readiness work without being a
-currently exploitable Lodestar vulnerability. Direct downstream users must establish their own
-reachable boundaries.
-
-## Assets
-
-The protected assets are:
+The assets protected here are:
 
 - Ethereum consensus safety and liveness;
-- beacon-state, state-root, validator-accounting, fork-choice, and head correctness;
-- BLS verification and aggregation correctness;
-- availability, integrity, and confidentiality of the hosting Node.js process, including unrelated
-  validator material, JWTs, API credentials, and other resident secrets;
-- integrity of shared native pools, caches, configuration, and worker state;
-- confidentiality of BLS secret-key material intentionally passed to the library; and
-- integrity of source dependencies, npm packages, and native release artifacts.
+- state-transition, fork-choice, and BLS correctness;
+- native memory safety and availability of the hosting process; and
+- integrity of shared native state across calls and Node.js environments.
 
-The library does not claim to provide an HSM, hardened secret memory, a JavaScript sandbox, or
-protection from arbitrary code that already has the Node.js process's privileges.
+The relevant attackers are remote peers or API users whose values reach Lodestar-z, and
+same-process JavaScript callers that can supply malformed values. The operator and host application
+are trusted to select configuration, verification policy, initial state, local files, wall-clock
+time, and execution or data-availability status. Same-process Zig code is trusted to honor native
+API preconditions. Host compromise and malicious replacement of trusted local storage are out of
+scope.
 
 ## Security objectives
 
-1. **Consensus correctness.** Given the correct preset and configuration, an eligible trusted
-   pre-state, all required validation, and accurate execution and data-availability results, state
-   transition and fork choice agree with the pinned consensus specification.
-2. **Cryptographic correctness.** BLS operations do not accept invalid signatures or points when
-   the API contract requests the relevant checks. Batch operations preserve cardinality and use
-   unpredictable nonzero coefficients where required.
-3. **Memory safety.** Malformed externally influenced values do not cause out-of-bounds access,
-   use-after-free, double free, uninitialized-memory use, allocator mismatch, or native-memory
-   disclosure.
-4. **Process availability.** Attacker-controlled inputs and bounded sequences fail safely. They do
-   not cause panics, deadlocks, infinite loops, cumulative leaks, or unbounded queue or cache growth.
-   CPU and memory amplification remain within explicit protocol, transport, and application bounds.
-5. **State integrity.** Rejected candidates do not modify their trusted pre-state, publish
-   branch-specific derived state, enter fork choice, or corrupt shared state.
-6. **Lifecycle safety.** Supported workers, concurrent operations, environment teardown, and
-   finalization do not race or access freed shared state.
-7. **Artifact integrity.** Published native artifacts are built from reviewed source and pinned
-   dependencies through the repository release process.
-
-## Actors and trusted inputs
-
-| Actor or source | Capability and trust |
-| --- | --- |
-| Remote consensus participant | Controls protocol-shaped and malformed P2P objects. It does not directly control native options, configuration, local files, or capacity APIs without a demonstrated Lodestar path. |
-| Remote API user | Controls only values forwarded by Lodestar's API layer after its validation and limits. Reports must trace that path. |
-| Operator and host application | Trusted to choose the preset, configuration, initial state, local files, verification policy, external statuses, capacities, and wall-clock time. Accidental misuse should fail clearly, but a malicious operator is out of scope. |
-| Same-process JavaScript | Has ambient application privileges and may intentionally provide malformed or coercing values. It is not an authorization or OS-isolation boundary, but it does not thereby possess arbitrary native-memory or cross-worker access. |
-| Same-process Zig code | Executes native code with process privileges and can construct or dereference arbitrary pointers. It is trusted to honor Zig API preconditions and is not a native-memory isolation boundary. |
-| Checkpoint state provider | Semitrusted. A user-provided checkpoint root is authoritative; without one, checkpoint selection is explicitly delegated to the provider. |
-| Trusted local storage | Database state, ERA/E2S data, and PKIX files are application-owned. This model assumes bytes written are the bytes later read. Malicious local replacement and host compromise are out of scope. |
-| Contributor or supply-chain attacker | May attempt to introduce malicious source, workflow, dependency, or release changes. |
-
-Raw checkpoint bytes are hostile to whichever component first decodes them before authentication.
-Lodestar-z state-loading entry points are defined to accept trusted state bytes. If a supported
-integration assigns initial checkpoint decoding to Lodestar-z, that entry point becomes a
-hostile-input boundary.
+1. Given the correct preset and configuration, an eligible trusted pre-state, and accurate external
+   statuses, consensus behavior agrees with the pinned Ethereum consensus specification.
+2. BLS operations do not falsely accept invalid signatures or points when their API contract
+   requires validation.
+3. Externally influenced values cannot cause native-memory corruption or disclosure.
+4. Attacker-controlled inputs fail without panics, deadlocks, cumulative leaks, or unbounded work or
+   allocation.
+5. Rejected candidates cannot publish branch-specific state or corrupt shared state.
+6. Supported concurrent operations and environment teardown cannot race with borrowed native state.
 
 ## Trust boundaries
 
-| Boundary | Lodestar-z contract |
+| Boundary | Contract |
 | --- | --- |
-| Remote source to Lodestar-z | Remotely derived bytes remain hostile unless the exact required validation has already completed and is bound to the operation's result. |
-| JavaScript to N-API | Runtime types, lengths, indexes, encodings, arrays, object shapes, and buffer ranges must be validated before unsafe native access. Caller-selected policy remains trusted. |
-| Serialized input to SSZ | Decoding enforces canonical encoding, offsets, list limits, bitfields, arithmetic bounds, and safe ownership. |
-| Beacon-state construction | Input state bytes already have trusted provenance. SSZ decoding establishes structure only, not ancestry, canonicality, finality, or consensus validity. |
-| State transition | The pre-state is an eligible trusted pre-state; the signed candidate block is hostile. Required consensus checks and state-root verification must complete before publication. |
-| Fork choice | Blocks have passed full state transition, attestations have passed the applicable upstream validation, external statuses are accurate, and local time is trusted. Fork choice still owns its specified ancestry, timing, vote, status-propagation, and bound checks. |
-| BLS API | Serialized points, messages, collections, and cardinality may be hostile. Caller-controlled validation flags and proof-of-possession preconditions are explicit policy. |
-| Zig to native dependencies | Lodestar-z owns representation, initialization, cardinality, pointer lifetime, requested validation, and ABI compatibility. Pinned dependencies are trusted to honor documented contracts. |
-| Shared native state | Synchronization, ownership, worker visibility, and teardown order must be defined. |
-| Local persistence | Provenance is trusted. Parsers still enforce documented framing, size, format, checksum, ownership, and cleanup contracts for reliability and memory safety. |
-| Build and release | Maintainer review, pinned inputs, protected repository settings, and release credentials establish artifact trust. |
+| Remote input through Lodestar | Values remain hostile until the validation required by the consuming operation has completed. Reports must trace the supported or planned path into Lodestar-z. |
+| JavaScript to N-API | Runtime types, lengths, indexes, encodings, and buffer ranges are untrusted. TypeScript declarations and debug assertions are not runtime validation. |
+| Serialized input to SSZ | Decoders must enforce canonical encoding, bounds, offsets, and safe ownership. Beacon-state construction is the exception described below: its bytes have trusted provenance, but still require structural SSZ validation. |
+| State transition | The pre-state is an eligible trusted state. The signed block is hostile. Processing must not mutate the pre-state, and the result becomes trusted only after the required checks succeed. |
+| Fork choice | Blocks have passed full state transition, attestations have passed their applicable validation, external statuses are accurate, and local time is trusted. Fork choice still owns its specified ancestry, timing, vote, invalidation, and bound checks. |
+| Zig to native dependencies | Lodestar-z owns representation, cardinality, validation flags, pointer lifetime, and ABI compatibility. Pinned dependencies are trusted only within their documented contracts. |
+| Shared native state | Ownership, synchronization, bounds, worker visibility, and teardown must be defined for every shared pool or cache. |
 
-A `std.debug.assert` is not a parser guard for externally influenced data in ReleaseSafe. TypeScript
-declarations are not runtime validation.
+## BeaconState trust
 
-## Consensus trust invariants
+Beacon states accepted by Lodestar-z are trusted inputs. SSZ deserialization establishes structural
+validity only. It does not establish provenance, canonicality, finality, execution validity, or data
+availability.
 
-### Beacon-state provenance and eligibility
+Trusted provenance begins at one of these anchors:
 
-A beacon state is not an arbitrary network object. Trusted provenance originates from:
+- genesis;
+- a state matching a user-provided checkpoint root; or
+- a checkpoint selected by a provider to which the user has delegated trust.
 
-- genesis, treated as the checkpoint at epoch zero;
-- a state whose hash-tree-root matches a user-provided checkpoint root; or
-- explicit delegation of checkpoint selection to a checkpoint state provider.
+A successfully transitioned descendant inherits that provenance. A state loaded from trusted local
+storage retains the status it had when written.
 
-A state read from trusted storage retains the provenance and validity status it had when written.
-Subsequent states inherit authenticated provenance through successful consensus-layer state
-transitions.
+A **trusted state** is structurally valid SSZ and is either an anchor or the result of a successful
+consensus-layer transition from an eligible trusted pre-state. It need not be canonical, finalized,
+or persisted. An **eligible trusted pre-state** additionally belongs to a branch that remains
+fork-choice eligible under its current execution and data-availability status.
 
-An **authenticated beacon state** is structurally valid SSZ and is either a trusted anchor or the
-result of a successful consensus-layer transition from an eligible trusted pre-state. It carries the
-execution and DA status applicable when it was accepted.
+A viable noncanonical branch can therefore contain trusted states. Finalization can make the branch
+ineligible without changing its historical consensus validity. An execution-optimistic state is
+conditionally trusted: it may remain in fork choice while execution is unresolved, but validators
+must not perform duties from an optimistic node. An invalid execution result revokes eligibility for
+the affected branch.
 
-An **eligible trusted pre-state** is an authenticated beacon state whose branch remains eligible
-for fork choice under its current execution and DA status. Eligibility is a current-use property,
-not part of historical provenance.
+Raw checkpoint bytes are hostile to whichever component first decodes them before authentication.
+Lodestar-z does not currently own that boundary. If it does in a supported integration, the new
+entry point must treat those bytes as hostile.
 
-| Property | Authenticated beacon state |
-| --- | --- |
-| Structural SSZ validity | Always |
-| Trusted origin | Authenticated anchor or successful CL transition from an eligible trusted pre-state |
-| Canonical, finalized, or persisted | Not necessarily |
-| Execution status | Where applicable, valid or conditionally valid while execution validity is unresolved |
-| DA status | Where applicable, valid within the DA window; treated as satisfied by the defined sync policy outside it |
-| Fork-choice eligibility | Required only when used as an eligible trusted pre-state |
-
-A noncanonical branch may retain valid eligible pre-states while it remains viable. Finalization
-makes conflicting branches ineligible but does not erase their provenance or historical CL
-validity. Execution invalidation instead revokes conditional validity and eligibility for the
-affected branch.
-
-### Candidate-block acceptance
+## Block acceptance
 
 - A full consensus-layer state transition is required before a block enters the live chain or fork
-  choice, or establishes a trusted post-state. Gossip, sync, hash-chain, and ancestry checks may
-  establish prerequisites but do not replace it.
-- All proposer and operation signatures are checked by the state transition or by an equivalent
-  prior batch whose all-or-none result gates the same import.
-- A candidate may publish its post-state and enter fork choice only after state transition,
-  state-root verification, signatures, execution handling, and DA handling have jointly succeeded.
-  Independent checks may run concurrently.
-- A state with unresolved execution validity is authenticated but conditionally valid. It may remain
-  fork-choice eligible, but validators must not perform duties while the node is execution
-  optimistic. A later invalid result invalidates the affected branch.
-- Within the DA window, DA must be satisfied before acceptance and publication. Outside the window,
-  the defined sync policy treats DA as satisfied rather than retaining a DA-optimistic branch.
-- Verification flags are trusted application policy. A required check may be disabled only when the
-  same accepted operation is gated on equivalent prior verification.
+  choice, or establishes a trusted post-state. Gossip, ancestry, and hash-chain checks do not replace
+  the transition.
+- Signatures are checked by the transition or by an equivalent prior batch whose all-or-none result
+  gates the same import.
+- State transition, signature checks, execution verification, and data-availability verification may
+  run concurrently, but all required results must gate live-chain and fork-choice admission.
+- Within the data-availability window, availability must be satisfied before acceptance. Outside the
+  window, the sync policy treats availability as satisfied.
+- Verification flags are trusted host policy. Disabling a required check is safe only when equivalent
+  prior verification gates the same operation.
+- Historical archive backfill may omit the full transition only while its blocks cannot enter live
+  consensus or establish trusted state. Later promotion must satisfy the normal acceptance contract.
 
-Blocks stored only as historical archive data need not run STF when they cannot affect consensus
-decisions or establish trusted state. Any later promotion into the live chain must satisfy the full
-acceptance contract.
+Lodestar-z consumes execution and data-availability results rather than establishing them. A false
+result from a trusted external component is outside this boundary; mishandling an accurate result is
+in scope.
 
-Lodestar-z consumes execution and DA results rather than establishing them. A false result supplied
-by a trusted external system is not an independent Lodestar-z bypass. Mishandling an accurate result
-is in scope.
-
-### Candidate isolation and shared facts
+## Candidate and cache isolation
 
 Candidate processing must isolate branch-specific mutations until acceptance. A rejected candidate
-may leave only work products or cache facts that cannot affect later validity based on the rejected
-branch.
+may leave only branch-independent facts or completed work that cannot affect later validity.
 
-Shared caches may retain only branch-independent facts. In particular, an append-only
-validator-pubkey cache may advance during a failed candidate only if:
+An append-only validator-pubkey cache may advance during a failed candidate when entries beyond the
+current state's validator count are treated as absent, later valid processing must reproduce the
+same pubkey at an index, and conflicting or sparse appends fail. This is permitted cache population,
+not publication of the rejected state.
 
-- cached indexes beyond a state's validator count are treated as absent for that state;
-- later valid processing at an index must reproduce the same pubkey; and
-- conflicting, duplicate, or sparse appends fail.
+## Classifying findings
 
-Any new mutable global state must define its synchronization, ownership, worker visibility, bounds,
-and teardown order.
-
-## Finding classification
-
-### Required evidence
-
-A security report must identify:
-
-1. the least-privileged attacker and controlled value;
-2. the current supported path or identified planned integration path to the operation;
-3. the integration maturity and every trusted precondition on that path;
-4. the validation, ownership, lifecycle, fork, preset, and external-status contracts involved;
-5. the violated security objective and concrete effect;
-6. whether the effect survives candidate cleanup, cache isolation, fork-choice invalidation, or
-   worker teardown; and
-7. a reproducible input or sequence with relevant size, work, and allocation bounds.
-
-Severity follows demonstrated reachability, defaults, reproducibility, and impact. A
-dangerous-looking line is not sufficient evidence.
-
-### Categories
+A report should identify the least-privileged attacker, the supported or planned call path, the
+trusted precondition under review, the violated objective, and the concrete effect. Uncertain
+reachability should be stated rather than assumed away.
 
 | Classification | Meaning |
 | --- | --- |
 | Security vulnerability | An in-scope attacker crosses a current supported boundary and violates a security objective. |
-| Security-readiness issue | A planned integration would expose the violation at a hostile boundary, but that path is not yet production-reachable. |
-| Consensus correctness bug | Behavior differs from the pinned specification under valid inputs without established attacker reachability. |
-| Boundary hardening | Validation or robustness is weak where the caller already has equivalent impact and no less-privileged hostile path is established. |
-| Trusted-input reliability bug | Trusted state, storage, or local-file use causes a leak, panic, race, cleanup failure, or bad error. |
-| Operator misuse or unsupported use | The trigger violates an explicit trusted precondition or supported lifecycle. |
-| Test or documentation gap | No current behavior violates this model. |
+| Security-readiness issue | An identified planned integration would expose the violation, but the path is not production-reachable. |
+| Consensus correctness bug | Consensus behavior violates the pinned specification without established hostile reachability. |
+| Reliability bug | The implementation violates another contract without established hostile reachability. |
+| Boundary hardening | Validation or failure handling is weak, but the caller already has equivalent impact or violates a trusted precondition. |
+| Unsupported use | The trigger is outside the documented caller, lifecycle, or provenance contract. |
 
-### Resource exhaustion
+For denial-of-service findings, quantify the attacker-controlled input, amplification, repetition,
+and applicable transport or peer-scoring limits. Peer scoring can limit sustained abuse but does not
+excuse a crash, cumulative leak, or unbounded queue.
 
-Every denial-of-service report must quantify the input bound, work or allocation amplification,
-repeatability, and attacker-controlled path.
+## Maintenance
 
-- One malformed remote input must fail safely before peer scoring can help.
-- Sustained attacks must account for supported transport limits, scoring, and disconnection, but
-  those controls do not excuse cumulative leaks or unbounded queues.
-- Protocol-bounded transition and cryptographic costs are expected unless amplification materially
-  exceeds the protocol work.
-- A large allocation requested only by a trusted same-process caller is hardening unless remote
-  influence is demonstrated.
-- Host-wide out-of-memory is not itself a vulnerability; attacker-controlled amplification before
-  it can be.
-
-### Common non-findings
-
-Without evidence crossing a boundary above, these are not security vulnerabilities:
-
-- missing authentication on an in-process API, deliberate use of caller-owned policy flags, or
-  effects already available through the caller's ambient privileges without additional
-  native-memory or cross-worker impact;
-- an operator selecting malicious configuration, an untrusted initial state, a wrong-network file,
-  or an attacker-controlled output path;
-- treating trusted database, ERA/E2S, or PKIX bytes as remotely controlled;
-- expecting state SSZ decoding to establish trusted ancestry, canonicality, or finality;
-- fork choice relying on documented state-transition or attestation-validation prerequisites;
-- mutation of a disposable candidate or a permitted branch-independent cache append;
-- retention of a viable noncanonical state or eviction of a finalized-away state;
-- a checksum that detects corruption but is not an authentication mechanism;
-- intended secret-key serialization to the owning caller;
-- failures confined to tests, generators, fuzzers, examples, benchmarks, or explicit stubs; and
-- timing or memory-forensic attacks absent a separately adopted side-channel guarantee.
-
-These may still be correctness, reliability, API-design, or defense-in-depth issues.
-
-## Maintenance rule
-
-Keep this file normative and short. A statement belongs here only if changing it can change a
-finding's trust analysis, classification, reachability, severity, or required security property.
-Descriptions of where or how the current implementation enforces a rule belong in the
-[implementation map](docs/security/IMPLEMENTATION_MAP.md).
-
-Review both documents when a change adds or alters a trust boundary, native dependency, persistence
-path or format, shared mutable cache or pool, externally influenced native input, or supported
-integration.
+Change this file only when a trust assumption or security objective changes. Update the
+[implementation map](docs/security/IMPLEMENTATION_MAP.md) when integration status, call paths,
+shared-state behavior, or file locations change.

--- a/docs/security/IMPLEMENTATION_MAP.md
+++ b/docs/security/IMPLEMENTATION_MAP.md
@@ -1,217 +1,54 @@
 # Lodestar-z security implementation map
 
-This document maps the stable [threat model](../../THREAT_MODEL.md) to the current implementation.
-It is an audit aid, not a normative security contract. Implementation details may change without
-changing the threat model.
+This is the volatile companion to the stable [threat model](../../THREAT_MODEL.md). It records only
+implementation facts needed to establish a trust boundary or precondition.
 
 - **Owner:** `@ChainSafe/lodestar`
 - **Last reviewed:** 2026-08-14
-- **Review baseline:** PR #557
 
-Update this map when a change adds or alters a trust boundary, native dependency, persistence path
-or format, shared mutable cache or pool, externally influenced native input, or supported
-integration. Update the threat model only when the security contract or finding classification also
-changes.
+## Integration status
 
-## Integration maturity
+The following status is maintainer-confirmed as of the review date:
 
-| Component | Current status | Review treatment |
+| Surface | Lodestar-z status | Lodestar production status |
 | --- | --- | --- |
-| BLS bindings | Implemented and exported by the addon; not wired into Lodestar-ts production | Direct library surface and planned-integration security readiness |
-| Process-wide pubkey cache | Implemented and exported by the addon; not wired into Lodestar-ts production | Direct library surface and planned-integration security readiness |
-| State transition | Next integration stage | Consensus correctness and security readiness; planned input is a trusted pre-state plus a serialized hostile signed block |
-| Zig fork choice | Future integration stage | Parity and security readiness; planned inputs are STF-valid blocks and validated attestations |
-| Generic P2P deserialization | Planned as integrations expand | Hostile-input boundary only where a current or identified planned path exists |
-| Beacon-state and ERA loading | Library surface using trusted input | Reliability and hardening unless another attacker path is demonstrated |
+| BLS and pubkey cache | Exported through N-API | Lodestar-ts still uses `@chainsafe/blst` and its TypeScript pubkey cache |
+| State transition | Exported as `BeaconStateView.stateTransition` | Integration is in progress |
+| Fork choice | Implemented in Zig but not exported through N-API | Lodestar-ts owns production fork choice |
+| Networking and P2P validation | Not implemented here | Lodestar-ts owns gossip, req/resp, framing, peer scoring, and import orchestration |
 
-Lodestar-ts production currently uses `@chainsafe/blst` and its TypeScript pubkey cache rather than
-these addon surfaces.
+A report against an unintegrated surface should be classified as security readiness unless another
+supported caller supplies a current hostile path.
 
-A planned-component bug can block integration without being described as a currently exploitable
-Lodestar vulnerability.
+## Boundary map
 
-## Component map
+| Boundary or invariant | Current implementation evidence |
+| --- | --- |
+| N-API exports and shared addon lifecycle | [`bindings/napi/root.zig`](../../bindings/napi/root.zig) registers exports and initializes or tears down process-wide configuration, pools, metrics, and the pubkey cache on first or last environment. |
+| Beacon-state construction | [`BeaconStateView.createFromBytes`](../../bindings/napi/BeaconStateView.zig) reads the slot and SSZ-deserializes bytes without authenticating a root. Its contract therefore requires trusted state bytes. |
+| State-transition candidate isolation | [`stateTransition`](../../src/state_transition/state_transition.zig) clones the cached state and destroys the clone on error before returning a post-state. Verification options are caller policy. |
+| Serialized block boundary | [`BeaconStateView.stateTransition`](../../bindings/napi/BeaconStateView.zig) accepts serialized signed-block bytes and passes the decoded block to the transition. This is a hostile-input boundary for integrated callers. |
+| Pubkey cache | [`pubkey_cache.zig`](../../src/state_transition/cache/pubkey_cache.zig) defines an application-wide, append-only cache with locked access and no escaping pointers into movable storage. [`bindings/napi/pubkeys.zig`](../../bindings/napi/pubkeys.zig) owns its process-wide instance. |
+| Reused epoch cache | [`epoch_transition_cache.zig`](../../src/state_transition/cache/epoch_transition_cache.zig) stores process-global arrays borrowed by an `EpochTransitionCache`. The lock covers acquisition and resize, not the full borrowed lifetime. Current safe use requires non-overlapping transitions and no concurrent teardown. |
+| PKIX persistence | [`pkix.zig`](../../src/state_transition/cache/pkix.zig) checks framing, bounds, ABI compatibility, and corruption checksums. It does not authenticate the file or semantically revalidate affine entries, so file provenance remains trusted. |
 
-| Area | Current security concern | Inherited contract |
-| --- | --- | --- |
-| `src/ssz`, `src/persistent_merkle_tree`, `src/hashing` | Canonical decoding, offsets, generalized indexes, ownership, proof correctness, and bounded merkleization | Serialized bytes may be hostile; typed callers obey lifetime contracts |
-| `src/consensus_types`, `src/fork_types`, `src/config`, `src/preset` | Fork schema, preset values, dispatch, and safe cross-fork access | Configuration identifies the intended network |
-| `src/state_transition` | Spec equivalence, signature checks, candidate isolation, cache consistency, and bounded per-block work | Eligible trusted pre-state and accurate external statuses |
-| `src/bls` | Point validation, aggregation cardinality, randomness, thread-pool cleanup, and false acceptance | Validation flags and proof-of-possession requirements are caller policy |
-| `src/fork_choice` | Head correctness, invalidation, votes, finalized ancestry, equivocation, queues, and arithmetic | STF-valid blocks, validated attestations, and trusted time |
-| `src/beacon_node`, `src/clock` | Cache ownership, event ordering, time calculations, and integration invariants | Production reachability must be established |
-| `src/era` | Framing, offsets, decompression, allocation bounds, and optional semantic validation | ERA provenance is trusted |
-| `bindings/napi`, `bindings/src` | Runtime checks, native lifetime, worker isolation, errors, and JS/native agreement | Same-process caller owns policy and has ambient process privileges |
-| `scripts`, `test`, `bench`, `examples` | Developer, CI, generation, or supply-chain impact | No runtime peer-facing path without additional evidence |
+## Host integration contracts
 
-## Current boundary mappings
+These are Lodestar-ts preconditions supplied by maintainers. They are recorded here because they
+change reachability and classification, but they are not enforced by this repository.
 
-### JavaScript and N-API
+- Lodestar-ts owns initial checkpoint decoding and root authentication. Without a user-provided
+  checkpoint root, trust is delegated to the checkpoint provider.
+- Gossip objects receive their specification-defined validation. Range sync and unknown-parent
+  recovery instead establish a parent-root hash chain before processing blocks forward.
+- A full state transition is required before a block enters the live chain or fork choice. Archive
+  backfill is separate and may persist hash-chain and signature-checked blocks without establishing
+  trusted state.
+- Signature, transition, execution, and data-availability work may run concurrently, but required
+  results join before live-chain and fork-choice admission.
+- Execution `syncing` is conditionally valid. Lodestar suppresses validator duties while optimistic,
+  and a later invalid result removes the affected fork-choice branch.
+- Data availability is required inside its validation window and treated as satisfied outside it.
 
-Native exports are registered from `bindings/napi/root.zig`; public wrappers and declarations live
-in `bindings/src`.
-
-All JavaScript-controlled types, lengths, indexes, encodings, object shapes, and buffer ranges need
-runtime checks before native memory access. TypeScript declarations do not provide those checks.
-Assertions are acceptable for internal invariants only after hostile lengths and offsets have been
-validated.
-
-Explicit local APIs remain caller-controlled policy. For example, allowing the caller of a cache
-save API to choose its output path is not independently path traversal.
-
-### Beacon-state loading
-
-`BeaconStateView.createFromBytes` and ERA state loading currently accept state bytes under the
-trusted-state contract. SSZ deserialization checks structure but does not authenticate provenance.
-
-Lodestar-ts currently owns raw checkpoint decoding and authentication. `initBeaconState` downloads
-or loads checkpoint bytes and `readWSState` decodes them. When the user supplies a weak-subjectivity
-checkpoint, `ensureWithinWeakSubjectivityPeriod` compares both the checkpoint root and epoch after
-decoding. Without a supplied checkpoint, trust in checkpoint selection is delegated to the source.
-
-If Lodestar-z becomes the first decoder of raw checkpoint responses, its slot extraction and state
-decoding must become checked hostile-input parsing before root comparison.
-
-### Live P2P block processing
-
-Lodestar-ts currently owns networking, framing, decompression limits, peer scoring, and import
-orchestration.
-
-- Gossip blocks receive the consensus-spec gossip validation applicable to that object.
-- Forward range sync and unknown-parent recovery establish ancestry through the parent-root hash
-  chain. Unknown-parent recovery fetches ancestors until reaching a block already known to fork
-  choice, then processes descendants forward.
-- Hash-chain membership does not establish consensus validity. Full STF is required before a block
-  enters the live chain or fork choice or establishes a trusted post-state.
-- Proposer and operation signatures are checked by STF or batch-verified beforehand. Prior batch
-  results must join the same all-or-none import result.
-- Serialized P2P objects are expected to cross the binding as integrations expand.
-
-The Lodestar-ts import path may run STF, signature checks, execution verification, and DA
-verification concurrently. STF may receive a provisional available DA status, but the real DA
-result or satisfied sync policy joins before publication.
-
-### Historical archive backfill
-
-Archive backfill is distinct from unknown-parent recovery. It verifies reverse hash-chain continuity
-and proposer signatures, then writes blocks directly to `blockArchive` without full STF. These blocks
-do not enter the live chain or fork choice and do not establish trusted post-states. Any later use in
-a live consensus path must first satisfy the full acceptance contract.
-
-### Execution, DA, and fork choice
-
-Lodestar-z does not contact the execution layer or DA subsystem. The host supplies their results.
-The execution layer is assumed nonmalicious but may be fallible or syncing.
-
-Each block carries its execution status. A `syncing` status remains conditionally valid until the
-execution layer returns `valid` or `invalid`; latest-valid-hash processing propagates invalidity
-through the affected branch. Lodestar-ts currently prevents validator duties while execution
-optimistic.
-
-Inside the DA window, availability is joined before acceptance. A super-node that custodies every
-column may treat DA as satisfied after enough columns are observed to reconstruct the remainder.
-Outside the window during sync, DA is treated as satisfied.
-
-The production fork-choice implementation remains in Lodestar-ts. The Zig implementation is
-intended to replace it and must preserve:
-
-- full-STF prerequisites for blocks;
-- applicable gossip and indexed-attestation prerequisites;
-- known-parent, time, finalized-ancestry, and target checks;
-- execution-status and latest-valid-hash propagation;
-- vote, equivocation, and internal-bound behavior.
-
-Gloas payload resolution (`EMPTY` versus `FULL`) is distinct from execution validity
-(`valid`, `syncing`, or `invalid`). The current Zig `ExecutionStatus.payload_separated` model
-should be reviewed before fork-choice integration rather than treated as a threat-model trust state.
-
-### Shared configuration, pools, and caches
-
-The addon currently shares configuration, metrics, the BLS worker pool, persistent Merkle node pool,
-pubkey cache, and reused epoch-transition cache across Node.js environments.
-
-- Worker and environment teardown must not destroy state still in use elsewhere.
-- Movable pubkey-cache storage is locked, and borrowed references must not survive a resize.
-- PKIX save, load, and reset are restricted to the control environment.
-- Configuration is startup state and must not be replaced while borrowed.
-- Explicit capacity APIs reject overflow and impossible capacities. Large valid reservations remain
-  local caller policy unless a remote path controls them.
-
-State-transition clones share the process-wide pubkey cache. Candidate processing can append a
-future validator pubkey before later operations or state-root verification fail; that append is not
-rolled back. Safety depends on the stable branch-independent cache invariant:
-
-- an index at or beyond the current state's validator count is treated as absent;
-- later valid processing must reproduce the same pubkey at that index; and
-- conflicting, duplicate, or sparse appends fail.
-
-Former Eth1 bridge deposits can register validators and append during block processing. In Electra,
-the new validator initially has zero balance while its amount remains pending. Execution-layer
-deposit requests remain pending and register a new validator only after their source slot is
-finalized.
-
-Apart from the process-wide pubkey and reused epoch-transition caches, state-transition caches are
-generally epoch-scoped and candidate-specific. A failed STF may leave metrics, completed signature
-computations, and a permitted pubkey-cache append, but no other candidate-derived mutation that
-influences later validity.
-
-The reused epoch-transition cache in `epoch_transition_cache.zig` is process-global and survives
-until explicit deinitialization. Its lock covers lookup and resize, but `EpochTransitionCache.init`
-mutates the shared arrays after that lock is released, and returned candidate caches borrow those
-arrays. Correctness therefore currently requires non-overlapping epoch-transition cache use and no
-concurrent teardown across environments. Concurrent integrations must serialize the full borrowed
-lifetime or replace this sharing model.
-
-## Persistence paths
-
-### PKIX
-
-PKIX is a cache snapshot, not a trust anchor. Its loader currently checks framing, exact size, format
-version, ABI compatibility, caller-supplied capacity, and corruption checksums. The checksum is not
-authentication, and affine entries are not semantically revalidated on load.
-
-A report needs one of these paths to cross the trusted-file assumption:
-
-- a supported remote workflow can replace or select the file;
-- the loader violates its documented size, framing, ABI, checksum, ownership, or cleanup contract;
-  or
-- a failed or concurrent load corrupts the previously live cache.
-
-### ERA and E2S
-
-ERA/E2S data is trusted local input. Sizes, counts, arithmetic, offsets, decompression, and SSZ
-decoding are still checked for bounded reliability. `Reader.validate` additionally checks network
-and block/state consistency; lower-level reads rely on provenance.
-
-Download scripts, test generation, benchmarks, and fuzz harnesses are development surfaces unless a
-build, CI, workstation, or release path is shown.
-
-## Current controls to verify
-
-Reviewers should test these controls rather than assume they are complete:
-
-- consensus, SSZ, and BLS vectors pinned through `build.zig.zon`;
-- minimal and mainnet preset tests plus SSZ and BLS fuzz targets;
-- full STF, signatures, and state-root verification before live-chain or fork-choice admission;
-- copy-on-write candidate state and cleanup on rejection;
-- gossip validation or sync hash-chain validation before forward STF;
-- genesis or checkpoint-root trust bootstrapping;
-- protocol bounds and checked arithmetic in parsers;
-- pubkey-cache locking, state-length guards, staged PKIX installation, and capacity limits;
-- reference-counted pools and last-environment cleanup;
-- ReleaseSafe native artifacts; and
-- pinned workflows and dependencies, lockfile installation, npm trusted publishing, and provenance.
-
-## Open integration questions
-
-- Which N-API methods are stable public APIs versus Lodestar compatibility surfaces?
-- Which serialized P2P objects will cross the binding as STF and fork choice integrate?
-- Which layer will compare a downloaded state root with a user-provided checkpoint root?
-- Which errors will distinguish invalid peer data, consensus failure, external invalidity, and
-  internal failure for scoring and operations?
-- Which production limits apply to proof descriptors, aggregate lists, pool preheating, and pubkey
-  cache growth?
-- Is configuration guaranteed to be set once before workers and state views exist?
-- How will reused epoch-transition cache use and teardown be serialized across environments?
-- How are PKIX files provisioned and invalidated across network or binary upgrades?
-- Is the exported `SecretKey` intended for production validator keys or compatibility and testing?
+If code or a supported integration conflicts with any item above, use the code to assess the finding
+and update this map.

--- a/docs/security/IMPLEMENTATION_MAP.md
+++ b/docs/security/IMPLEMENTATION_MAP.md
@@ -17,12 +17,15 @@ changes.
 
 | Component | Current status | Review treatment |
 | --- | --- | --- |
-| BLS bindings | Integrated | Production-reachable |
-| Process-wide pubkey cache | Integrated | Production-reachable |
+| BLS bindings | Implemented and exported by the addon; not wired into Lodestar-ts production | Direct library surface and planned-integration security readiness |
+| Process-wide pubkey cache | Implemented and exported by the addon; not wired into Lodestar-ts production | Direct library surface and planned-integration security readiness |
 | State transition | Next integration stage | Consensus correctness and security readiness; planned input is a trusted pre-state plus a serialized hostile signed block |
 | Zig fork choice | Future integration stage | Parity and security readiness; planned inputs are STF-valid blocks and validated attestations |
 | Generic P2P deserialization | Planned as integrations expand | Hostile-input boundary only where a current or identified planned path exists |
 | Beacon-state and ERA loading | Library surface using trusted input | Reliability and hardening unless another attacker path is demonstrated |
+
+Lodestar-ts production currently uses `@chainsafe/blst` and its TypeScript pubkey cache rather than
+these addon surfaces.
 
 A planned-component bug can block integration without being described as a currently exploitable
 Lodestar vulnerability.
@@ -61,21 +64,25 @@ save API to choose its output path is not independently path traversal.
 `BeaconStateView.createFromBytes` and ERA state loading currently accept state bytes under the
 trusted-state contract. SSZ deserialization checks structure but does not authenticate provenance.
 
-Checkpoint-root authentication is not yet assigned to a stable Lodestar-ts or Lodestar-z integration
-point. If Lodestar-z becomes the first decoder of raw checkpoint responses, its slot extraction and
-state decoding must become checked hostile-input parsing before root comparison.
+Lodestar-ts currently owns raw checkpoint decoding and authentication. `initBeaconState` downloads
+or loads checkpoint bytes and `readWSState` decodes them. When the user supplies a weak-subjectivity
+checkpoint, `ensureWithinWeakSubjectivityPeriod` compares both the checkpoint root and epoch after
+decoding. Without a supplied checkpoint, trust in checkpoint selection is delegated to the source.
 
-### P2P block import
+If Lodestar-z becomes the first decoder of raw checkpoint responses, its slot extraction and state
+decoding must become checked hostile-input parsing before root comparison.
+
+### Live P2P block processing
 
 Lodestar-ts currently owns networking, framing, decompression limits, peer scoring, and import
 orchestration.
 
 - Gossip blocks receive the consensus-spec gossip validation applicable to that object.
-- Range, unknown-block, and backward sync establish ancestry through the parent-root hash chain.
-- Backward sync fetches parents until a block already known to fork choice, then processes the chain
-  forward.
-- Hash-chain membership does not establish consensus validity. Full STF is required before every
-  import.
+- Forward range sync and unknown-parent recovery establish ancestry through the parent-root hash
+  chain. Unknown-parent recovery fetches ancestors until reaching a block already known to fork
+  choice, then processes descendants forward.
+- Hash-chain membership does not establish consensus validity. Full STF is required before a block
+  enters the live chain or fork choice or establishes a trusted post-state.
 - Proposer and operation signatures are checked by STF or batch-verified beforehand. Prior batch
   results must join the same all-or-none import result.
 - Serialized P2P objects are expected to cross the binding as integrations expand.
@@ -83,6 +90,13 @@ orchestration.
 The Lodestar-ts import path may run STF, signature checks, execution verification, and DA
 verification concurrently. STF may receive a provisional available DA status, but the real DA
 result or satisfied sync policy joins before publication.
+
+### Historical archive backfill
+
+Archive backfill is distinct from unknown-parent recovery. It verifies reverse hash-chain continuity
+and proposer signatures, then writes blocks directly to `blockArchive` without full STF. These blocks
+do not enter the live chain or fork choice and do not establish trusted post-states. Any later use in
+a live consensus path must first satisfy the full acceptance contract.
 
 ### Execution, DA, and fork choice
 
@@ -114,7 +128,7 @@ should be reviewed before fork-choice integration rather than treated as a threa
 ### Shared configuration, pools, and caches
 
 The addon currently shares configuration, metrics, the BLS worker pool, persistent Merkle node pool,
-and pubkey cache across Node.js environments.
+pubkey cache, and reused epoch-transition cache across Node.js environments.
 
 - Worker and environment teardown must not destroy state still in use elsewhere.
 - Movable pubkey-cache storage is locked, and borrowed references must not survive a resize.
@@ -136,9 +150,17 @@ the new validator initially has zero balance while its amount remains pending. E
 deposit requests remain pending and register a new validator only after their source slot is
 finalized.
 
-Other state-transition caches are generally epoch-scoped and candidate-specific. A failed STF may
-leave metrics, completed signature computations, and a permitted pubkey-cache append, but no other
-candidate-derived mutation that influences later validity.
+Apart from the process-wide pubkey and reused epoch-transition caches, state-transition caches are
+generally epoch-scoped and candidate-specific. A failed STF may leave metrics, completed signature
+computations, and a permitted pubkey-cache append, but no other candidate-derived mutation that
+influences later validity.
+
+The reused epoch-transition cache in `epoch_transition_cache.zig` is process-global and survives
+until explicit deinitialization. Its lock covers lookup and resize, but `EpochTransitionCache.init`
+mutates the shared arrays after that lock is released, and returned candidate caches borrow those
+arrays. Correctness therefore currently requires non-overlapping epoch-transition cache use and no
+concurrent teardown across environments. Concurrent integrations must serialize the full borrowed
+lifetime or replace this sharing model.
 
 ## Persistence paths
 
@@ -170,7 +192,7 @@ Reviewers should test these controls rather than assume they are complete:
 
 - consensus, SSZ, and BLS vectors pinned through `build.zig.zon`;
 - minimal and mainnet preset tests plus SSZ and BLS fuzz targets;
-- full STF, signatures, and state-root verification before import;
+- full STF, signatures, and state-root verification before live-chain or fork-choice admission;
 - copy-on-write candidate state and cleanup on rejection;
 - gossip validation or sync hash-chain validation before forward STF;
 - genesis or checkpoint-root trust bootstrapping;
@@ -190,5 +212,6 @@ Reviewers should test these controls rather than assume they are complete:
 - Which production limits apply to proof descriptors, aggregate lists, pool preheating, and pubkey
   cache growth?
 - Is configuration guaranteed to be set once before workers and state views exist?
+- How will reused epoch-transition cache use and teardown be serialized across environments?
 - How are PKIX files provisioned and invalidated across network or binary upgrades?
 - Is the exported `SecretKey` intended for production validator keys or compatibility and testing?

--- a/docs/security/IMPLEMENTATION_MAP.md
+++ b/docs/security/IMPLEMENTATION_MAP.md
@@ -1,0 +1,194 @@
+# Lodestar-z security implementation map
+
+This document maps the stable [threat model](../../THREAT_MODEL.md) to the current implementation.
+It is an audit aid, not a normative security contract. Implementation details may change without
+changing the threat model.
+
+- **Owner:** `@ChainSafe/lodestar`
+- **Last reviewed:** 2026-08-14
+- **Review baseline:** PR #557
+
+Update this map when a change adds or alters a trust boundary, native dependency, persistence path
+or format, shared mutable cache or pool, externally influenced native input, or supported
+integration. Update the threat model only when the security contract or finding classification also
+changes.
+
+## Integration maturity
+
+| Component | Current status | Review treatment |
+| --- | --- | --- |
+| BLS bindings | Integrated | Production-reachable |
+| Process-wide pubkey cache | Integrated | Production-reachable |
+| State transition | Next integration stage | Consensus correctness and security readiness; planned input is a trusted pre-state plus a serialized hostile signed block |
+| Zig fork choice | Future integration stage | Parity and security readiness; planned inputs are STF-valid blocks and validated attestations |
+| Generic P2P deserialization | Planned as integrations expand | Hostile-input boundary only where a current or identified planned path exists |
+| Beacon-state and ERA loading | Library surface using trusted input | Reliability and hardening unless another attacker path is demonstrated |
+
+A planned-component bug can block integration without being described as a currently exploitable
+Lodestar vulnerability.
+
+## Component map
+
+| Area | Current security concern | Inherited contract |
+| --- | --- | --- |
+| `src/ssz`, `src/persistent_merkle_tree`, `src/hashing` | Canonical decoding, offsets, generalized indexes, ownership, proof correctness, and bounded merkleization | Serialized bytes may be hostile; typed callers obey lifetime contracts |
+| `src/consensus_types`, `src/fork_types`, `src/config`, `src/preset` | Fork schema, preset values, dispatch, and safe cross-fork access | Configuration identifies the intended network |
+| `src/state_transition` | Spec equivalence, signature checks, candidate isolation, cache consistency, and bounded per-block work | Eligible trusted pre-state and accurate external statuses |
+| `src/bls` | Point validation, aggregation cardinality, randomness, thread-pool cleanup, and false acceptance | Validation flags and proof-of-possession requirements are caller policy |
+| `src/fork_choice` | Head correctness, invalidation, votes, finalized ancestry, equivocation, queues, and arithmetic | STF-valid blocks, validated attestations, and trusted time |
+| `src/beacon_node`, `src/clock` | Cache ownership, event ordering, time calculations, and integration invariants | Production reachability must be established |
+| `src/era` | Framing, offsets, decompression, allocation bounds, and optional semantic validation | ERA provenance is trusted |
+| `bindings/napi`, `bindings/src` | Runtime checks, native lifetime, worker isolation, errors, and JS/native agreement | Same-process caller owns policy and has ambient process privileges |
+| `scripts`, `test`, `bench`, `examples` | Developer, CI, generation, or supply-chain impact | No runtime peer-facing path without additional evidence |
+
+## Current boundary mappings
+
+### JavaScript and N-API
+
+Native exports are registered from `bindings/napi/root.zig`; public wrappers and declarations live
+in `bindings/src`.
+
+All JavaScript-controlled types, lengths, indexes, encodings, object shapes, and buffer ranges need
+runtime checks before native memory access. TypeScript declarations do not provide those checks.
+Assertions are acceptable for internal invariants only after hostile lengths and offsets have been
+validated.
+
+Explicit local APIs remain caller-controlled policy. For example, allowing the caller of a cache
+save API to choose its output path is not independently path traversal.
+
+### Beacon-state loading
+
+`BeaconStateView.createFromBytes` and ERA state loading currently accept state bytes under the
+trusted-state contract. SSZ deserialization checks structure but does not authenticate provenance.
+
+Checkpoint-root authentication is not yet assigned to a stable Lodestar-ts or Lodestar-z integration
+point. If Lodestar-z becomes the first decoder of raw checkpoint responses, its slot extraction and
+state decoding must become checked hostile-input parsing before root comparison.
+
+### P2P block import
+
+Lodestar-ts currently owns networking, framing, decompression limits, peer scoring, and import
+orchestration.
+
+- Gossip blocks receive the consensus-spec gossip validation applicable to that object.
+- Range, unknown-block, and backward sync establish ancestry through the parent-root hash chain.
+- Backward sync fetches parents until a block already known to fork choice, then processes the chain
+  forward.
+- Hash-chain membership does not establish consensus validity. Full STF is required before every
+  import.
+- Proposer and operation signatures are checked by STF or batch-verified beforehand. Prior batch
+  results must join the same all-or-none import result.
+- Serialized P2P objects are expected to cross the binding as integrations expand.
+
+The Lodestar-ts import path may run STF, signature checks, execution verification, and DA
+verification concurrently. STF may receive a provisional available DA status, but the real DA
+result or satisfied sync policy joins before publication.
+
+### Execution, DA, and fork choice
+
+Lodestar-z does not contact the execution layer or DA subsystem. The host supplies their results.
+The execution layer is assumed nonmalicious but may be fallible or syncing.
+
+Each block carries its execution status. A `syncing` status remains conditionally valid until the
+execution layer returns `valid` or `invalid`; latest-valid-hash processing propagates invalidity
+through the affected branch. Lodestar-ts currently prevents validator duties while execution
+optimistic.
+
+Inside the DA window, availability is joined before acceptance. A super-node that custodies every
+column may treat DA as satisfied after enough columns are observed to reconstruct the remainder.
+Outside the window during sync, DA is treated as satisfied.
+
+The production fork-choice implementation remains in Lodestar-ts. The Zig implementation is
+intended to replace it and must preserve:
+
+- full-STF prerequisites for blocks;
+- applicable gossip and indexed-attestation prerequisites;
+- known-parent, time, finalized-ancestry, and target checks;
+- execution-status and latest-valid-hash propagation;
+- vote, equivocation, and internal-bound behavior.
+
+Gloas payload resolution (`EMPTY` versus `FULL`) is distinct from execution validity
+(`valid`, `syncing`, or `invalid`). The current Zig `ExecutionStatus.payload_separated` model
+should be reviewed before fork-choice integration rather than treated as a threat-model trust state.
+
+### Shared configuration, pools, and caches
+
+The addon currently shares configuration, metrics, the BLS worker pool, persistent Merkle node pool,
+and pubkey cache across Node.js environments.
+
+- Worker and environment teardown must not destroy state still in use elsewhere.
+- Movable pubkey-cache storage is locked, and borrowed references must not survive a resize.
+- PKIX save, load, and reset are restricted to the control environment.
+- Configuration is startup state and must not be replaced while borrowed.
+- Explicit capacity APIs reject overflow and impossible capacities. Large valid reservations remain
+  local caller policy unless a remote path controls them.
+
+State-transition clones share the process-wide pubkey cache. Candidate processing can append a
+future validator pubkey before later operations or state-root verification fail; that append is not
+rolled back. Safety depends on the stable branch-independent cache invariant:
+
+- an index at or beyond the current state's validator count is treated as absent;
+- later valid processing must reproduce the same pubkey at that index; and
+- conflicting, duplicate, or sparse appends fail.
+
+Former Eth1 bridge deposits can register validators and append during block processing. In Electra,
+the new validator initially has zero balance while its amount remains pending. Execution-layer
+deposit requests remain pending and register a new validator only after their source slot is
+finalized.
+
+Other state-transition caches are generally epoch-scoped and candidate-specific. A failed STF may
+leave metrics, completed signature computations, and a permitted pubkey-cache append, but no other
+candidate-derived mutation that influences later validity.
+
+## Persistence paths
+
+### PKIX
+
+PKIX is a cache snapshot, not a trust anchor. Its loader currently checks framing, exact size, format
+version, ABI compatibility, caller-supplied capacity, and corruption checksums. The checksum is not
+authentication, and affine entries are not semantically revalidated on load.
+
+A report needs one of these paths to cross the trusted-file assumption:
+
+- a supported remote workflow can replace or select the file;
+- the loader violates its documented size, framing, ABI, checksum, ownership, or cleanup contract;
+  or
+- a failed or concurrent load corrupts the previously live cache.
+
+### ERA and E2S
+
+ERA/E2S data is trusted local input. Sizes, counts, arithmetic, offsets, decompression, and SSZ
+decoding are still checked for bounded reliability. `Reader.validate` additionally checks network
+and block/state consistency; lower-level reads rely on provenance.
+
+Download scripts, test generation, benchmarks, and fuzz harnesses are development surfaces unless a
+build, CI, workstation, or release path is shown.
+
+## Current controls to verify
+
+Reviewers should test these controls rather than assume they are complete:
+
+- consensus, SSZ, and BLS vectors pinned through `build.zig.zon`;
+- minimal and mainnet preset tests plus SSZ and BLS fuzz targets;
+- full STF, signatures, and state-root verification before import;
+- copy-on-write candidate state and cleanup on rejection;
+- gossip validation or sync hash-chain validation before forward STF;
+- genesis or checkpoint-root trust bootstrapping;
+- protocol bounds and checked arithmetic in parsers;
+- pubkey-cache locking, state-length guards, staged PKIX installation, and capacity limits;
+- reference-counted pools and last-environment cleanup;
+- ReleaseSafe native artifacts; and
+- pinned workflows and dependencies, lockfile installation, npm trusted publishing, and provenance.
+
+## Open integration questions
+
+- Which N-API methods are stable public APIs versus Lodestar compatibility surfaces?
+- Which serialized P2P objects will cross the binding as STF and fork choice integrate?
+- Which layer will compare a downloaded state root with a user-provided checkpoint root?
+- Which errors will distinguish invalid peer data, consensus failure, external invalidity, and
+  internal failure for scoring and operations?
+- Which production limits apply to proof descriptors, aggregate lists, pool preheating, and pubkey
+  cache growth?
+- Is configuration guaranteed to be set once before workers and state views exist?
+- How are PKIX files provisioned and invalidated across network or binary upgrades?
+- Is the exported `SecretKey` intended for production validator keys or compatibility and testing?

--- a/docs/security/IMPLEMENTATION_MAP.md
+++ b/docs/security/IMPLEMENTATION_MAP.md
@@ -4,7 +4,7 @@ This is the volatile companion to the stable [threat model](../../THREAT_MODEL.m
 implementation facts needed to establish a trust boundary or precondition.
 
 - **Owner:** `@ChainSafe/lodestar`
-- **Last reviewed:** 2026-08-14
+- **Last reviewed:** 2026-08-15
 
 ## Integration status
 
@@ -31,6 +31,7 @@ supported caller supplies a current hostile path.
 | Pubkey cache | [`pubkey_cache.zig`](../../src/state_transition/cache/pubkey_cache.zig) defines an application-wide, append-only cache with locked access and no escaping pointers into movable storage. [`bindings/napi/pubkeys.zig`](../../bindings/napi/pubkeys.zig) owns its process-wide instance. |
 | Reused epoch cache | [`epoch_transition_cache.zig`](../../src/state_transition/cache/epoch_transition_cache.zig) stores process-global arrays borrowed by an `EpochTransitionCache`. The lock covers acquisition and resize, not the full borrowed lifetime. Current safe use requires non-overlapping transitions and no concurrent teardown. |
 | PKIX persistence | [`pkix.zig`](../../src/state_transition/cache/pkix.zig) checks framing, bounds, ABI compatibility, and corruption checksums. It does not authenticate the file or semantically revalidate affine entries, so file provenance remains trusted. |
+| Build and release provenance | [`build.zig.zon`](../../build.zig.zon) and [`pnpm-lock.yaml`](../../pnpm-lock.yaml) pin dependency inputs. [`publish-bindings.yml`](../../.github/workflows/publish-bindings.yml) pins actions, builds ReleaseSafe artifacts, and publishes them with npm provenance. |
 
 ## Host integration contracts
 


### PR DESCRIPTION
## Summary

- add a concise normative threat model covering assets, actors, trust boundaries, consensus trust invariants, security objectives, and finding classification
- separate volatile integration maturity, current call paths, cache mechanics, persistence details, controls, and open questions into a dated implementation map with an explicit owner
- require reviewers and contributors in `AGENTS.md` to consult both documents and revisit them when security-relevant integration boundaries change

## Why

Security reports have produced faulty findings because Lodestar and Ethereum trust assumptions were implicit. In particular, agents treated trusted beacon states and local ERA/database data as hostile, confused ancestry checks with full validation, and overlooked validation performed by Lodestar-ts.

Separating the stable security contract from current implementation mappings also reduces verbosity and limits documentation bitrot. The normative core changes only when trust or classification changes; implementation details can evolve in the audit map.

## Impact

Documentation only. Maintainers and automated reviewers gain a shorter basis for distinguishing security vulnerabilities, integration-readiness issues, consensus bugs, boundary hardening, trusted-input reliability problems, and operator misuse.

## AI assistance

This documentation was primarily AI-authored through an extended collaborative threat-modeling discussion with maintainer-provided Lodestar and Ethereum domain guidance.