### PR TITLE
feat(shuffle): add PTC sampling

### DIFF
--- a/bindings/napi/shuffle.zig
+++ b/bindings/napi/shuffle.zig
@@ -98,3 +98,100 @@ pub fn computeSyncCommitteeIndices(
     defer allocator.free(result);
     return js.Uint32Array.from(result);
 }
+
+pub fn computePtcIndices(
+    seed: js.Uint8Array,
+    indices: js.Uint32Array,
+    effective_balance_increments: js.Uint16Array,
+    ptc_size: js.Number,
+    max_effective_balance_electra: js.Number,
+    effective_balance_increment: js.Number,
+) !js.Uint32Array {
+    const out_array = try js.Uint32Array.alloc(try ptc_size.toU32Exact());
+    try sons.computePtcIndicesInto(
+        try seed.toSlice(),
+        try indices.toSlice(),
+        try effective_balance_increments.toSlice(),
+        max_effective_balance_electra.assertI64(),
+        effective_balance_increment.assertI64(),
+        try out_array.toSlice(),
+    );
+    return out_array;
+}
+
+pub fn computePtcIndicesForEpoch(
+    epoch_seed: js.Uint8Array,
+    start_slot: js.Number,
+    slots_per_epoch: js.Number,
+    shuffling: js.Uint32Array,
+    slot_offsets: js.Uint32Array,
+    effective_balance_increments: js.Uint16Array,
+    ptc_size: js.Number,
+    max_effective_balance_electra: js.Number,
+    effective_balance_increment: js.Number,
+) !js.Uint32Array {
+    const slots = try slots_per_epoch.toU32Exact();
+    const size = try ptc_size.toU32Exact();
+    const out_array = try js.Uint32Array.alloc(@as(usize, slots) * size);
+    try sons.computePtcIndicesForEpochInto(
+        try epoch_seed.toSlice(),
+        try start_slot.toU32Exact(),
+        slots,
+        try shuffling.toSlice(),
+        try slot_offsets.toSlice(),
+        try effective_balance_increments.toSlice(),
+        size,
+        max_effective_balance_electra.assertI64(),
+        effective_balance_increment.assertI64(),
+        try out_array.toSlice(),
+    );
+    return out_array;
+}
+
+/// Fills the caller's `out` array instead of allocating a new one; its length
+/// is the committee size.
+pub fn computePtcIndicesInto(
+    out: js.Uint32Array,
+    seed: js.Uint8Array,
+    indices: js.Uint32Array,
+    effective_balance_increments: js.Uint16Array,
+    max_effective_balance_electra: js.Number,
+    effective_balance_increment: js.Number,
+) !void {
+    try sons.computePtcIndicesInto(
+        try seed.toSlice(),
+        try indices.toSlice(),
+        try effective_balance_increments.toSlice(),
+        max_effective_balance_electra.assertI64(),
+        effective_balance_increment.assertI64(),
+        try out.toSlice(),
+    );
+}
+
+/// Fills the caller's `out` array instead of allocating a new one; it must hold
+/// `slotsPerEpoch * ptcSize` entries.
+pub fn computePtcIndicesForEpochInto(
+    out: js.Uint32Array,
+    epoch_seed: js.Uint8Array,
+    start_slot: js.Number,
+    slots_per_epoch: js.Number,
+    shuffling: js.Uint32Array,
+    slot_offsets: js.Uint32Array,
+    effective_balance_increments: js.Uint16Array,
+    ptc_size: js.Number,
+    max_effective_balance_electra: js.Number,
+    effective_balance_increment: js.Number,
+) !void {
+    try sons.computePtcIndicesForEpochInto(
+        try epoch_seed.toSlice(),
+        try start_slot.toU32Exact(),
+        try slots_per_epoch.toU32Exact(),
+        try shuffling.toSlice(),
+        try slot_offsets.toSlice(),
+        try effective_balance_increments.toSlice(),
+        try ptc_size.toU32Exact(),
+        max_effective_balance_electra.assertI64(),
+        effective_balance_increment.assertI64(),
+        try out.toSlice(),
+    );
+}

--- a/bindings/perf/shuffle.test.ts
+++ b/bindings/perf/shuffle.test.ts
@@ -82,3 +82,80 @@ describe("committee indices", () => {
     });
   }
 });
+
+describe("computePtcIndices - per slot", () => {
+  const {EFFECTIVE_BALANCE_INCREMENT, MAX_EFFECTIVE_BALANCE_ELECTRA, PTC_SIZE} = shuffleReference;
+  for (const vc of [16_384, 250_000, 1_000_000]) {
+    const seed = new Uint8Array(crypto.randomBytes(32));
+    const indices = getInputArray(vc);
+    const effectiveBalanceIncrements = new Uint16Array(vc).fill(32);
+
+    bench({
+      fn: () => {
+        shuffleReference.naiveComputePayloadTimelinessCommitteeIndices(effectiveBalanceIncrements, indices, seed);
+      },
+      id: `JS  - computePtcIndices - ${vc} indices`,
+    });
+
+    bench({
+      fn: () => {
+        shuffle.computePtcIndices(
+          seed,
+          indices,
+          effectiveBalanceIncrements,
+          PTC_SIZE,
+          MAX_EFFECTIVE_BALANCE_ELECTRA,
+          EFFECTIVE_BALANCE_INCREMENT
+        );
+      },
+      id: `zig - computePtcIndices - ${vc} indices`,
+    });
+  }
+});
+
+describe("computePtcIndicesForEpoch - full epoch (32 slots)", () => {
+  const {EFFECTIVE_BALANCE_INCREMENT, MAX_EFFECTIVE_BALANCE_ELECTRA, PTC_SIZE, SLOTS_PER_EPOCH} = shuffleReference;
+  for (const vc of [250_000, 1_000_000]) {
+    const shuffling = getInputArray(vc);
+    const indicesPerSlot = Math.floor(vc / SLOTS_PER_EPOCH);
+    const slotOffsets = new Uint32Array(SLOTS_PER_EPOCH + 1);
+    for (let i = 0; i <= SLOTS_PER_EPOCH; i++) slotOffsets[i] = i * indicesPerSlot;
+    const effectiveBalanceIncrements = new Uint16Array(vc).fill(32);
+    const epochSeed = new Uint8Array(crypto.randomBytes(32));
+    const startSlot = 0;
+
+    const committees: Uint32Array[][] = new Array(SLOTS_PER_EPOCH);
+    for (let i = 0; i < SLOTS_PER_EPOCH; i++) {
+      committees[i] = [shuffling.subarray(slotOffsets[i], slotOffsets[i + 1])];
+    }
+
+    bench({
+      fn: () => {
+        shuffleReference.naiveComputePayloadTimelinessCommitteesForEpoch(
+          epochSeed,
+          startSlot,
+          committees,
+          effectiveBalanceIncrements
+        );
+      },
+      id: `JS  - computePtcIndicesForEpoch - ${vc} validators`,
+    });
+
+    bench({
+      fn: () => {
+        shuffle.computePtcIndicesForEpoch(
+          epochSeed,
+          startSlot,
+          SLOTS_PER_EPOCH,
+          shuffling,
+          slotOffsets,
+          effectiveBalanceIncrements,
+          PTC_SIZE,
+          MAX_EFFECTIVE_BALANCE_ELECTRA,
+          EFFECTIVE_BALANCE_INCREMENT
+        );
+      },
+      id: `zig - computePtcIndicesForEpoch - ${vc} validators`,
+    });
+  }
+});

--- a/bindings/src/index.d.ts
+++ b/bindings/src/index.d.ts
@@ -399,6 +399,54 @@ declare const bindings: {
       effectiveBalanceIncrement: number,
       rounds: number
     ) => Uint32Array;
+    /** Samples the payload timeliness committee for one slot from its (pre-shuffled) indices. */
+    computePtcIndices: (
+      seed: Uint8Array,
+      indices: Uint32Array,
+      effectiveBalanceIncrements: Uint16Array,
+      ptcSize: number,
+      maxEffectiveBalanceElectra: number,
+      effectiveBalanceIncrement: number
+    ) => Uint32Array;
+    /**
+     * Samples the payload timeliness committees for all slots of an epoch from
+     * the flat epoch shuffling; `slotOffsets` (length slotsPerEpoch + 1) marks
+     * each slot's window. Returns the concatenated per-slot committees
+     * (slotsPerEpoch * ptcSize entries).
+     */
+    computePtcIndicesForEpoch: (
+      epochSeed: Uint8Array,
+      startSlot: number,
+      slotsPerEpoch: number,
+      shuffling: Uint32Array,
+      slotOffsets: Uint32Array,
+      effectiveBalanceIncrements: Uint16Array,
+      ptcSize: number,
+      maxEffectiveBalanceElectra: number,
+      effectiveBalanceIncrement: number
+    ) => Uint32Array;
+    /** Fills `out` (length = ptc size) instead of allocating a new array. */
+    computePtcIndicesInto: (
+      out: Uint32Array,
+      seed: Uint8Array,
+      indices: Uint32Array,
+      effectiveBalanceIncrements: Uint16Array,
+      maxEffectiveBalanceElectra: number,
+      effectiveBalanceIncrement: number
+    ) => void;
+    /** Fills `out` (length = slotsPerEpoch * ptcSize) instead of allocating a new array. */
+    computePtcIndicesForEpochInto: (
+      out: Uint32Array,
+      epochSeed: Uint8Array,
+      startSlot: number,
+      slotsPerEpoch: number,
+      shuffling: Uint32Array,
+      slotOffsets: Uint32Array,
+      effectiveBalanceIncrements: Uint16Array,
+      ptcSize: number,
+      maxEffectiveBalanceElectra: number,
+      effectiveBalanceIncrement: number
+    ) => void;
   };
   stateTransition: {
     deinitReusedEpochTransitionCache: () => void;

--- a/bindings/test/shuffle.test.ts
+++ b/bindings/test/shuffle.test.ts
@@ -243,3 +243,187 @@ describe("committee indices", () => {
     }
   });
 });
+
+describe("ptc indices", () => {
+  const vc = 1000;
+  const activeIndices = getInputArray(vc);
+  const effectiveBalanceIncrements = new Uint16Array(vc);
+  for (let i = 0; i < vc; i++) {
+    effectiveBalanceIncrements[i] = 32 + 32 * (i % 64);
+  }
+  const {EFFECTIVE_BALANCE_INCREMENT, MAX_EFFECTIVE_BALANCE_ELECTRA, PTC_SIZE, SLOTS_PER_EPOCH} = shuffleReference;
+
+  it("computePtcIndices should match the naive implementation", () => {
+    const seed = new Uint8Array(randomBytes(32));
+    expect(
+      Array.from(
+        shuffle.computePtcIndices(
+          seed,
+          activeIndices,
+          effectiveBalanceIncrements,
+          PTC_SIZE,
+          MAX_EFFECTIVE_BALANCE_ELECTRA,
+          EFFECTIVE_BALANCE_INCREMENT
+        )
+      ),
+      `seed 0x${Buffer.from(seed).toString("hex")}`
+    ).toEqual(
+      shuffleReference.naiveComputePayloadTimelinessCommitteeIndices(effectiveBalanceIncrements, activeIndices, seed)
+    );
+  });
+
+  it("computePtcIndicesForEpoch should match the naive implementation", {timeout: 10_000}, () => {
+    const epochSeed = new Uint8Array(randomBytes(32));
+    const startSlot = 12345;
+    const indicesPerSlot = Math.floor(vc / SLOTS_PER_EPOCH);
+    const slotOffsets = new Uint32Array(SLOTS_PER_EPOCH + 1);
+    for (let i = 0; i <= SLOTS_PER_EPOCH; i++) slotOffsets[i] = i * indicesPerSlot;
+
+    const committees: Uint32Array[][] = new Array(SLOTS_PER_EPOCH);
+    for (let i = 0; i < SLOTS_PER_EPOCH; i++) {
+      committees[i] = [activeIndices.subarray(slotOffsets[i], slotOffsets[i + 1])];
+    }
+
+    expect(
+      Array.from(
+        shuffle.computePtcIndicesForEpoch(
+          epochSeed,
+          startSlot,
+          SLOTS_PER_EPOCH,
+          activeIndices,
+          slotOffsets,
+          effectiveBalanceIncrements,
+          PTC_SIZE,
+          MAX_EFFECTIVE_BALANCE_ELECTRA,
+          EFFECTIVE_BALANCE_INCREMENT
+        )
+      ),
+      `epochSeed 0x${Buffer.from(epochSeed).toString("hex")}`
+    ).toEqual(
+      shuffleReference
+        .naiveComputePayloadTimelinessCommitteesForEpoch(epochSeed, startSlot, committees, effectiveBalanceIncrements)
+        .flat()
+    );
+  });
+
+  it("should reject non-u32 sizes and slots instead of coercing", () => {
+    const seed = new Uint8Array(32);
+    for (const ptcSize of [-1, 1.5, 2 ** 32]) {
+      expect(() =>
+        shuffle.computePtcIndices(
+          seed,
+          activeIndices,
+          effectiveBalanceIncrements,
+          ptcSize,
+          MAX_EFFECTIVE_BALANCE_ELECTRA,
+          EFFECTIVE_BALANCE_INCREMENT
+        )
+      ).to.throw("InvalidUnsignedInteger");
+    }
+    expect(() =>
+      shuffle.computePtcIndicesForEpoch(
+        seed,
+        2 ** 32,
+        1,
+        activeIndices,
+        Uint32Array.from([0, activeIndices.length]),
+        effectiveBalanceIncrements,
+        4,
+        MAX_EFFECTIVE_BALANCE_ELECTRA,
+        EFFECTIVE_BALANCE_INCREMENT
+      )
+    ).to.throw("InvalidUnsignedInteger");
+  });
+
+  it("the Into variants should fill a caller-provided array", () => {
+    const seed = new Uint8Array(randomBytes(32));
+    const expected = shuffle.computePtcIndices(
+      seed,
+      activeIndices,
+      effectiveBalanceIncrements,
+      PTC_SIZE,
+      MAX_EFFECTIVE_BALANCE_ELECTRA,
+      EFFECTIVE_BALANCE_INCREMENT
+    );
+    const out = new Uint32Array(PTC_SIZE);
+    shuffle.computePtcIndicesInto(
+      out,
+      seed,
+      activeIndices,
+      effectiveBalanceIncrements,
+      MAX_EFFECTIVE_BALANCE_ELECTRA,
+      EFFECTIVE_BALANCE_INCREMENT
+    );
+    expect(Array.from(out)).toEqual(Array.from(expected));
+
+    const indicesPerSlot = Math.floor(vc / SLOTS_PER_EPOCH);
+    const slotOffsets = new Uint32Array(SLOTS_PER_EPOCH + 1);
+    for (let i = 0; i <= SLOTS_PER_EPOCH; i++) slotOffsets[i] = i * indicesPerSlot;
+    const ptcSize = 8;
+    const expectedEpoch = shuffle.computePtcIndicesForEpoch(
+      seed,
+      0,
+      SLOTS_PER_EPOCH,
+      activeIndices,
+      slotOffsets,
+      effectiveBalanceIncrements,
+      ptcSize,
+      MAX_EFFECTIVE_BALANCE_ELECTRA,
+      EFFECTIVE_BALANCE_INCREMENT
+    );
+    const epochOut = new Uint32Array(SLOTS_PER_EPOCH * ptcSize);
+    shuffle.computePtcIndicesForEpochInto(
+      epochOut,
+      seed,
+      0,
+      SLOTS_PER_EPOCH,
+      activeIndices,
+      slotOffsets,
+      effectiveBalanceIncrements,
+      ptcSize,
+      MAX_EFFECTIVE_BALANCE_ELECTRA,
+      EFFECTIVE_BALANCE_INCREMENT
+    );
+    expect(Array.from(epochOut)).toEqual(Array.from(expectedEpoch));
+
+    // a wrongly sized out array is rejected rather than partially filled
+    expect(() =>
+      shuffle.computePtcIndicesForEpochInto(
+        new Uint32Array(SLOTS_PER_EPOCH * ptcSize - 1),
+        seed,
+        0,
+        SLOTS_PER_EPOCH,
+        activeIndices,
+        slotOffsets,
+        effectiveBalanceIncrements,
+        ptcSize,
+        MAX_EFFECTIVE_BALANCE_ELECTRA,
+        EFFECTIVE_BALANCE_INCREMENT
+      )
+    ).to.throw("InvalidOutputLength");
+  });
+
+  it("computePtcIndices should throw for invalid inputs", () => {
+    const seed = new Uint8Array(32);
+    expect(() =>
+      shuffle.computePtcIndices(
+        new Uint8Array(31),
+        activeIndices,
+        effectiveBalanceIncrements,
+        PTC_SIZE,
+        MAX_EFFECTIVE_BALANCE_ELECTRA,
+        EFFECTIVE_BALANCE_INCREMENT
+      )
+    ).to.throw("InvalidSeedLength");
+    expect(() =>
+      shuffle.computePtcIndices(
+        seed,
+        new Uint32Array([]),
+        effectiveBalanceIncrements,
+        PTC_SIZE,
+        MAX_EFFECTIVE_BALANCE_ELECTRA,
+        EFFECTIVE_BALANCE_INCREMENT
+      )
+    ).to.throw("EmptyActiveIndices");
+  });
+});

--- a/bindings/test/shuffleReference.ts
+++ b/bindings/test/shuffleReference.ts
@@ -7,6 +7,8 @@ export const EFFECTIVE_BALANCE_INCREMENT = 1_000_000_000;
 export const MAX_EFFECTIVE_BALANCE = 32_000_000_000;
 export const MAX_EFFECTIVE_BALANCE_ELECTRA = 2_048_000_000_000;
 export const SYNC_COMMITTEE_SIZE = 512;
+export const PTC_SIZE = 512;
+export const SLOTS_PER_EPOCH = 32;
 
 function digest(data: Uint8Array): Uint8Array {
   return createHash("sha256").update(data).digest();
@@ -282,4 +284,62 @@ export function naiveComputeSyncCommitteeIndicesElectra(
     2,
     MAX_EFFECTIVE_BALANCE_ELECTRA
   );
+}
+
+/// PTC sampler from lodestar (naiveComputePayloadTimelinessCommitteeIndices),
+/// ported from https://github.com/ChainSafe/swap-or-not-shuffle/pull/24
+export function naiveComputePayloadTimelinessCommitteeIndices(
+  effectiveBalanceIncrements: Uint16Array,
+  indices: ArrayLike<number>,
+  seed: Uint8Array
+): number[] {
+  if (indices.length === 0) {
+    throw Error("Validator indices must not be empty");
+  }
+
+  const result: number[] = [];
+  const maxRandomValue = 2 ** 16 - 1;
+  const maxEffectiveBalanceIncrement = MAX_EFFECTIVE_BALANCE_ELECTRA / EFFECTIVE_BALANCE_INCREMENT;
+
+  let i = 0;
+  while (result.length < PTC_SIZE) {
+    const candidateIndex = indices[i % indices.length];
+    const randomBytes = digest(concatBytes(seed, intToBytesLE(Math.floor(i / 16), 8)));
+    const offset = (i % 16) * 2;
+    const randomValue = randomBytes[offset] + 256 * randomBytes[offset + 1];
+
+    const effectiveBalanceIncrement = effectiveBalanceIncrements[candidateIndex];
+    if (effectiveBalanceIncrement * maxRandomValue >= maxEffectiveBalanceIncrement * randomValue) {
+      result.push(candidateIndex);
+    }
+    i += 1;
+  }
+
+  return result;
+}
+
+/// epoch PTC from lodestar (computePayloadTimelinessCommitteesForEpoch),
+/// tweaked to avoid beacon state param; ported from
+/// https://github.com/ChainSafe/swap-or-not-shuffle/pull/24
+export function naiveComputePayloadTimelinessCommitteesForEpoch(
+  epochSeed: Uint8Array,
+  startSlot: number,
+  committees: Uint32Array[][],
+  effectiveBalanceIncrements: Uint16Array
+): number[][] {
+  const result: number[][] = new Array(SLOTS_PER_EPOCH);
+  for (let i = 0; i < SLOTS_PER_EPOCH; i++) {
+    const slotSeed = digest(concatBytes(epochSeed, intToBytesLE(startSlot + i, 8)));
+    const slotCommittees = committees[i];
+    let totalLen = 0;
+    for (const c of slotCommittees) totalLen += c.length;
+    const allIndices = new Uint32Array(totalLen);
+    let offset = 0;
+    for (const c of slotCommittees) {
+      allIndices.set(c, offset);
+      offset += c.length;
+    }
+    result[i] = naiveComputePayloadTimelinessCommitteeIndices(effectiveBalanceIncrements, allIndices, slotSeed);
+  }
+  return result;
 }

--- a/src/swap_or_not_shuffle/root.zig
+++ b/src/swap_or_not_shuffle/root.zig
@@ -458,7 +458,6 @@ pub fn computeSyncCommitteeIndicesElectra(
 /// Fills `out` by sampling from the pre-shuffled `indices`, weighted by
 /// effective balance; one SHA-256 per 16 candidates.
 /// Port of https://github.com/ChainSafe/swap-or-not-shuffle/pull/24 (453b639b).
-/// Callers guarantee `out.len > 0`, otherwise this never returns.
 fn computePtcIndicesInner(
     seed: *const [SEED_SIZE]u8,
     indices: []const u32,

--- a/src/swap_or_not_shuffle/root.zig
+++ b/src/swap_or_not_shuffle/root.zig
@@ -455,6 +455,151 @@ pub fn computeSyncCommitteeIndicesElectra(
     );
 }
 
+/// Fills `out` by sampling from the pre-shuffled `indices`, weighted by
+/// effective balance; one SHA-256 per 16 candidates.
+/// Port of https://github.com/ChainSafe/swap-or-not-shuffle/pull/24 (453b639b).
+/// Callers guarantee `out.len > 0`, otherwise this never returns.
+fn computePtcIndicesInner(
+    seed: *const [SEED_SIZE]u8,
+    indices: []const u32,
+    effective_balance_increments: []const u16,
+    max_ebi: i64,
+    out: []u32,
+) !void {
+    const max_random_value: i64 = 0xffff;
+    const indices_len = indices.len;
+
+    var hash_input = [_]u8{0} ** (SEED_SIZE + 8);
+    @memcpy(hash_input[0..SEED_SIZE], seed);
+
+    var digest: [Sha256.digest_length]u8 = undefined;
+    var count: usize = 0;
+
+    var i: usize = 0;
+    // bounded by `count` so an empty `out` cannot spin; the inner break still
+    // stops mid-block, which also keeps `out[count]` in range
+    outer: while (count < out.len) : (i += 16) {
+        // one SHA-256 per 16 candidates; encode block index in bytes 32..40
+        std.mem.writeInt(u64, hash_input[SEED_SIZE..][0..8], i / 16, .little);
+        Sha256.hash(&hash_input, &digest, .{});
+
+        // consume all 16 u16 random values from this hash block
+        for (0..16) |j| {
+            const candidate_index = indices[(i + j) % indices_len];
+            const random_value: i64 = std.mem.readInt(u16, digest[j * 2 ..][0..2], .little);
+            if (candidate_index >= effective_balance_increments.len) {
+                // the reference panics on the out-of-bounds read
+                return error.EffectiveBalanceIncrementsOutOfBounds;
+            }
+            const ebi: i64 = effective_balance_increments[candidate_index];
+            // accept if ebi / max_ebi >= random_value / max_random_value;
+            // wrapping multiplies mirror the reference release-mode behavior
+            if (ebi *% max_random_value >= max_ebi *% random_value) {
+                out[count] = candidate_index;
+                count += 1;
+                if (count == out.len) {
+                    break :outer;
+                }
+            }
+        }
+    }
+}
+
+/// Samples one slot's payload timeliness committee into `out`, whose length is
+/// the committee size. Caller owns `out`.
+pub fn computePtcIndicesInto(
+    seed: []const u8,
+    indices: []const u32,
+    effective_balance_increments: []const u16,
+    max_effective_balance_electra: i64,
+    effective_balance_increment: i64,
+    out: []u32,
+) !void {
+    // The reference panics on a non-32-byte seed and on `% 0`, and divides by
+    // zero on a zero increment; return errors instead. An empty `out` is a
+    // no-op, where the reference would loop forever.
+    if (seed.len != SEED_SIZE) {
+        return error.InvalidSeedLength;
+    }
+    if (indices.len == 0) {
+        return error.EmptyActiveIndices;
+    }
+    if (effective_balance_increment == 0) {
+        return error.InvalidEffectiveBalanceIncrement;
+    }
+    if (out.len == 0) {
+        return;
+    }
+
+    const max_ebi = @divTrunc(max_effective_balance_electra, effective_balance_increment);
+    try computePtcIndicesInner(seed[0..SEED_SIZE], indices, effective_balance_increments, max_ebi, out);
+}
+
+/// Samples every slot's payload timeliness committee for an epoch into `out`,
+/// which must hold `slots_per_epoch * ptc_size` entries, slot-major.
+/// `slot_offsets` (length `slots_per_epoch + 1`) marks each slot's window into
+/// the flat `shuffling`; per-slot seed is
+/// `sha256(epoch_seed ++ u64le(start_slot + slot))`. Caller owns `out`.
+pub fn computePtcIndicesForEpochInto(
+    epoch_seed: []const u8,
+    start_slot: u32,
+    slots_per_epoch: u32,
+    shuffling: []const u32,
+    slot_offsets: []const u32,
+    effective_balance_increments: []const u16,
+    ptc_size: u32,
+    max_effective_balance_electra: i64,
+    effective_balance_increment: i64,
+    out: []u32,
+) !void {
+    // graceful errors where the reference panics (see computePtcIndicesInto)
+    if (epoch_seed.len != SEED_SIZE) {
+        return error.InvalidSeedLength;
+    }
+    if (effective_balance_increment == 0) {
+        return error.InvalidEffectiveBalanceIncrement;
+    }
+    const slots: usize = slots_per_epoch;
+    if (slot_offsets.len < slots + 1) {
+        return error.InvalidSlotOffsets;
+    }
+    if (out.len != slots * ptc_size) {
+        return error.InvalidOutputLength;
+    }
+
+    const max_ebi = @divTrunc(max_effective_balance_electra, effective_balance_increment);
+
+    var slot_seed_input = [_]u8{0} ** (SEED_SIZE + 8);
+    @memcpy(slot_seed_input[0..SEED_SIZE], epoch_seed);
+
+    for (0..slots) |i| {
+        // per-slot seed: sha256(epoch_seed ++ u64le(start_slot + i))
+        std.mem.writeInt(u64, slot_seed_input[SEED_SIZE..][0..8], @as(u64, start_slot) + i, .little);
+        var slot_seed: [SEED_SIZE]u8 = undefined;
+        Sha256.hash(&slot_seed_input, &slot_seed, .{});
+
+        const start = slot_offsets[i];
+        const end = slot_offsets[i + 1];
+        if (start > end or end > shuffling.len) {
+            return error.InvalidSlotOffsets;
+        }
+        const slot_indices = shuffling[start..end];
+        if (slot_indices.len == 0) {
+            return error.EmptyActiveIndices;
+        }
+
+        if (ptc_size != 0) {
+            try computePtcIndicesInner(
+                &slot_seed,
+                slot_indices,
+                effective_balance_increments,
+                max_ebi,
+                out[i * ptc_size ..][0..ptc_size],
+            );
+        }
+    }
+}
+
 test {
     _ = @import("./test.zig");
 }

--- a/src/swap_or_not_shuffle/test.zig
+++ b/src/swap_or_not_shuffle/test.zig
@@ -278,3 +278,208 @@ test "getCommitteeIndices rejects out-of-bounds candidate index" {
         90,
     ));
 }
+
+test "computePtcIndices matches naive reference vector" {
+    const allocator = std.testing.allocator;
+    const seed = [_]u8{1} ** SEED_SIZE;
+    const data = testBalances(100);
+
+    const result = try allocator.alloc(u32, 32);
+    defer allocator.free(result);
+    try shuffle.computePtcIndicesInto(
+        seed[0..],
+        data.indices[0..],
+        data.increments[0..],
+        MAX_EFFECTIVE_BALANCE_ELECTRA,
+        EFFECTIVE_BALANCE_INCREMENT,
+        result,
+    );
+
+    // generated with the naive lodestar PTC sampler ported in
+    // https://github.com/ChainSafe/swap-or-not-shuffle/pull/24
+    const expected = [_]u32{
+        4,  8,  9,  15, 20, 22, 30, 31, 32, 35, 38, 41, 42, 44, 45, 46,
+        49, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 78, 81, 83, 84,
+    };
+    try std.testing.expectEqualSlices(u32, expected[0..], result);
+}
+
+test "computePtcIndicesForEpoch matches naive reference vector" {
+    const allocator = std.testing.allocator;
+    const epoch_seed = [_]u8{2} ** SEED_SIZE;
+    const data = testBalances(80);
+    const slot_offsets = [_]u32{ 0, 20, 40, 60, 80 };
+
+    const result = try allocator.alloc(u32, 4 * 8);
+    defer allocator.free(result);
+    try shuffle.computePtcIndicesForEpochInto(
+        epoch_seed[0..],
+        5,
+        4,
+        data.indices[0..],
+        slot_offsets[0..],
+        data.increments[0..],
+        8,
+        MAX_EFFECTIVE_BALANCE_ELECTRA,
+        EFFECTIVE_BALANCE_INCREMENT,
+        result,
+    );
+
+    const expected = [_]u32{
+        8,  9,  10, 15, 16, 14, 16, 4,  21, 26, 27, 28, 29, 30, 31, 35,
+        40, 42, 44, 45, 46, 47, 48, 49, 60, 62, 63, 68, 76, 60, 62, 63,
+    };
+    try std.testing.expectEqualSlices(u32, expected[0..], result);
+}
+
+test "computePtcIndicesForEpoch slots agree with computePtcIndices" {
+    const allocator = std.testing.allocator;
+    const epoch_seed = [_]u8{2} ** SEED_SIZE;
+    const data = testBalances(80);
+    const slot_offsets = [_]u32{ 0, 20, 40, 60, 80 };
+    const start_slot = 5;
+    const ptc_size = 8;
+
+    const epoch_result = try allocator.alloc(u32, 4 * ptc_size);
+    defer allocator.free(epoch_result);
+    try shuffle.computePtcIndicesForEpochInto(
+        epoch_seed[0..],
+        start_slot,
+        4,
+        data.indices[0..],
+        slot_offsets[0..],
+        data.increments[0..],
+        ptc_size,
+        MAX_EFFECTIVE_BALANCE_ELECTRA,
+        EFFECTIVE_BALANCE_INCREMENT,
+        epoch_result,
+    );
+
+    const Sha256 = std.crypto.hash.sha2.Sha256;
+    for (0..4) |slot| {
+        var input = [_]u8{0} ** (SEED_SIZE + 8);
+        @memcpy(input[0..SEED_SIZE], epoch_seed[0..]);
+        std.mem.writeInt(u64, input[SEED_SIZE..][0..8], start_slot + slot, .little);
+        var slot_seed: [SEED_SIZE]u8 = undefined;
+        Sha256.hash(&input, &slot_seed, .{});
+
+        const slot_result = try allocator.alloc(u32, ptc_size);
+        defer allocator.free(slot_result);
+        try shuffle.computePtcIndicesInto(
+            slot_seed[0..],
+            data.indices[slot_offsets[slot]..slot_offsets[slot + 1]],
+            data.increments[0..],
+            MAX_EFFECTIVE_BALANCE_ELECTRA,
+            EFFECTIVE_BALANCE_INCREMENT,
+            slot_result,
+        );
+        try std.testing.expectEqualSlices(u32, slot_result, epoch_result[slot * ptc_size ..][0..ptc_size]);
+    }
+}
+
+test "computePtcIndicesInto rejects invalid inputs gracefully" {
+    const good_seed = [_]u8{1} ** SEED_SIZE;
+    const bad_seed = [_]u8{1} ** 31;
+    const data = testBalances(10);
+    var out: [8]u32 = undefined;
+
+    try std.testing.expectError(error.InvalidSeedLength, shuffle.computePtcIndicesInto(
+        bad_seed[0..],
+        data.indices[0..],
+        data.increments[0..],
+        MAX_EFFECTIVE_BALANCE_ELECTRA,
+        EFFECTIVE_BALANCE_INCREMENT,
+        out[0..],
+    ));
+
+    try std.testing.expectError(error.EmptyActiveIndices, shuffle.computePtcIndicesInto(
+        good_seed[0..],
+        &[_]u32{},
+        data.increments[0..],
+        MAX_EFFECTIVE_BALANCE_ELECTRA,
+        EFFECTIVE_BALANCE_INCREMENT,
+        out[0..],
+    ));
+
+    try std.testing.expectError(error.InvalidEffectiveBalanceIncrement, shuffle.computePtcIndicesInto(
+        good_seed[0..],
+        data.indices[0..],
+        data.increments[0..],
+        MAX_EFFECTIVE_BALANCE_ELECTRA,
+        0,
+        out[0..],
+    ));
+
+    // candidate index beyond the increments slice
+    const oob_indices = [_]u32{99};
+    const short_increments = [_]u16{32};
+    try std.testing.expectError(error.EffectiveBalanceIncrementsOutOfBounds, shuffle.computePtcIndicesInto(
+        good_seed[0..],
+        oob_indices[0..],
+        short_increments[0..],
+        MAX_EFFECTIVE_BALANCE_ELECTRA,
+        EFFECTIVE_BALANCE_INCREMENT,
+        out[0..],
+    ));
+
+    // an empty `out` is a no-op where the reference would loop forever
+    try shuffle.computePtcIndicesInto(
+        good_seed[0..],
+        data.indices[0..],
+        data.increments[0..],
+        MAX_EFFECTIVE_BALANCE_ELECTRA,
+        EFFECTIVE_BALANCE_INCREMENT,
+        out[0..0],
+    );
+}
+
+test "computePtcIndicesForEpochInto rejects invalid inputs gracefully" {
+    const epoch_seed = [_]u8{2} ** SEED_SIZE;
+    const data = testBalances(80);
+    var out: [4 * 8]u32 = undefined;
+
+    // too few offsets for the slot count
+    const short_offsets = [_]u32{ 0, 20 };
+    try std.testing.expectError(error.InvalidSlotOffsets, shuffle.computePtcIndicesForEpochInto(
+        epoch_seed[0..],
+        0,
+        4,
+        data.indices[0..],
+        short_offsets[0..],
+        data.increments[0..],
+        8,
+        MAX_EFFECTIVE_BALANCE_ELECTRA,
+        EFFECTIVE_BALANCE_INCREMENT,
+        out[0..],
+    ));
+
+    // offsets beyond the shuffling length
+    const oob_offsets = [_]u32{ 0, 20, 40, 60, 999 };
+    try std.testing.expectError(error.InvalidSlotOffsets, shuffle.computePtcIndicesForEpochInto(
+        epoch_seed[0..],
+        0,
+        4,
+        data.indices[0..],
+        oob_offsets[0..],
+        data.increments[0..],
+        8,
+        MAX_EFFECTIVE_BALANCE_ELECTRA,
+        EFFECTIVE_BALANCE_INCREMENT,
+        out[0..],
+    ));
+
+    // out length must match slots_per_epoch * ptc_size
+    const good_offsets = [_]u32{ 0, 20, 40, 60, 80 };
+    try std.testing.expectError(error.InvalidOutputLength, shuffle.computePtcIndicesForEpochInto(
+        epoch_seed[0..],
+        0,
+        4,
+        data.indices[0..],
+        good_offsets[0..],
+        data.increments[0..],
+        8,
+        MAX_EFFECTIVE_BALANCE_ELECTRA,
+        EFFECTIVE_BALANCE_INCREMENT,
+        out[0 .. out.len - 1],
+    ));
+}


### PR DESCRIPTION
## Summary

Adds payload timeliness committee (PTC) sampling to the Zig `swap_or_not_shuffle` module and its JS binding, so ChainSafe/lodestar#9263 can stop computing it in JS.

- Ports `compute_ptc_indices` and `compute_ptc_indices_for_epoch`, whose original implementation is ChainSafe/swap-or-not-shuffle#24 (`453b639b`).
- Exposes a per-slot entry point and a whole-epoch one that derives each slot's seed and returns the committees concatenated.
- Returns explicit errors for degenerate inputs that the reference package would crash or hang on.
- Runs the epoch variant sequentially where the Rust uses rayon; still roughly 287x the naive JS path Lodestar uses today.

## Testing

- Added Zig vectors generated from the naive Lodestar sampler, plus epoch/per-slot consistency and error-path coverage.
- Added JS tests comparing the binding against the naive sampler at full PTC size for one slot and across a full epoch.
- Added per-slot and per-epoch benches alongside the existing shuffle ones.

## Follow-ups

- The epoch variant can be parallelised if its sequential cost ever matters.

AI assistance was used for drafting and implementation support.


