### PR TITLE
fix(bindings): snapshot shared verifier message

### DIFF
--- a/bindings/napi/bls_verifier.zig
+++ b/bindings/napi/bls_verifier.zig
@@ -121,6 +121,7 @@ pub fn verifySignatureSetsSameMessage(sets: js.Array, message: js.Uint8Array) !j
 
     const message_slice = try message.toSlice();
     if (message_slice.len != 32) return error.InvalidMessageLength;
+    const exact_message = message_slice[0..32].*;
 
     if (!pubkeys.state.initialized) return error.PubkeyIndexNotInitialized;
 
@@ -142,7 +143,7 @@ pub fn verifySignatureSetsSameMessage(sets: js.Array, message: js.Uint8Array) !j
     try batch.verify(
         io,
         pool,
-        message_slice[0..32],
+        &exact_message,
         verification_results[0..count],
     );
 

--- a/bindings/napi/bls_verifier.zig
+++ b/bindings/napi/bls_verifier.zig
@@ -71,8 +71,10 @@ pub fn verifySignatureSets(sets: js.Array) !js.Boolean {
             else => return error.InvalidSetType,
         };
 
-        const message = try set.message.toSlice();
-        if (message.len != 32) return error.InvalidMessageLength;
+        const message_slice = try set.message.toSlice();
+        if (message_slice.len != 32) return error.InvalidMessageLength;
+        // Variant property reads below may execute JavaScript.
+        const message = message_slice[0..32].*;
 
         const public_key: bls.PublicKey = switch (set_type) {
             .indexed => blk: {

--- a/bindings/napi/blst.zig
+++ b/bindings/napi/blst.zig
@@ -418,6 +418,8 @@ pub fn aggregateVerify(msgs: js.Array, pks: js.Array, sig: Signature, pks_valida
 pub fn fastAggregateVerify(msg: js.Uint8Array, pks: js.Array, sig: Signature, sigs_groupcheck: ?js.Boolean) !js.Boolean {
     const msg_bytes = try msg.toSlice();
     if (msg_bytes.len != @sizeOf(SigningRoot)) return error.InvalidMessageLength;
+    // Array element reads below may execute JavaScript.
+    const message = msg_bytes[0..@sizeOf(SigningRoot)].*;
 
     const pks_len = try pks.length();
     if (pks_len == 0) return js.Boolean.from(false);
@@ -435,7 +437,7 @@ pub fn fastAggregateVerify(msg: js.Uint8Array, pks: js.Array, sig: Signature, si
     const result = sig.raw.fastAggregateVerify(
         try boolOrDefault(sigs_groupcheck, false),
         &pairing_buf,
-        msg_bytes[0..@sizeOf(SigningRoot)],
+        &message,
         DST,
         native_pks,
         false,
@@ -465,15 +467,27 @@ pub fn verifyMultipleAggregateSignatures(sets: js.Array, pks_validate: ?js.Boole
         break :blk buf;
     };
 
+    var messages_stack: [BATCH_VERIFY_SIZE]SigningRoot = undefined;
+    var messages_heap: ?[]SigningRoot = null;
+    defer if (messages_heap) |buf| allocator.free(buf);
+
+    const messages = if (n_elems <= BATCH_VERIFY_SIZE) messages_stack[0..n_elems] else blk: {
+        const buf = try allocator.alloc(SigningRoot, n_elems);
+        messages_heap = buf;
+        break :blk buf;
+    };
+
     for (0..n_elems) |i| {
         const set_value = try sets.get(@intCast(i));
         const set = try (try set_value.asObject(SignatureSetInput)).get();
         const message_bytes = try set.msg.toSlice();
         if (message_bytes.len != @sizeOf(SigningRoot)) return error.InvalidMessageLength;
+        // Keep native-owned storage across later array and property reads.
+        messages[i] = message_bytes[0..@sizeOf(SigningRoot)].*;
         const public_key = try unwrapClass(PublicKey, set.pk);
         const signature = try unwrapClass(Signature, set.sig);
         items[i] = .{
-            .message = message_bytes[0..@sizeOf(SigningRoot)],
+            .message = &messages[i],
             .public_key = &public_key.raw,
             .signature = &signature.raw,
             .randomness = undefined,

--- a/bindings/test/bls-verifier.test.ts
+++ b/bindings/test/bls-verifier.test.ts
@@ -71,6 +71,24 @@ describe("bls verifier", () => {
     ).toBe(false);
   });
 
+  it("snapshots a message before reading variant properties", () => {
+    const signingRoot = message(1);
+    const signature = keys[0].sign(signingRoot).toBytes();
+    const set = {
+      message: signingRoot,
+      signature,
+      type: BLS_VERIFIER_SET_TYPE.indexed,
+    } as BlsSignatureSet;
+    Object.defineProperty(set, "index", {
+      get() {
+        signingRoot.fill(2);
+        return 0;
+      },
+    });
+
+    expect(verifySignatureSets([set])).toBe(true);
+  });
+
   it("throws for a missing cached validator index", () => {
     const signingRoot = message(1);
     expect(() =>

--- a/bindings/test/bls-verifier.test.ts
+++ b/bindings/test/bls-verifier.test.ts
@@ -127,6 +127,20 @@ describe("bls verifier", () => {
     expect(verifySignatureSetsSameMessage(sets, signingRoot)).toEqual([true, false, true, true]);
   });
 
+  it("snapshots the shared message before reading set properties", () => {
+    const signingRoot = message(4);
+    const signature = keys[0].sign(signingRoot).toBytes();
+    const set = {index: 0, signature};
+    Object.defineProperty(set, "signature", {
+      get() {
+        signingRoot.fill(5);
+        return signature;
+      },
+    });
+
+    expect(verifySignatureSetsSameMessage([set], signingRoot)).toEqual([true]);
+  });
+
   it("rejects empty and oversized batches", () => {
     expect(verifySignatureSets([])).toBe(false);
     expect(verifySignatureSetsSameMessage([], message(1))).toEqual([]);

--- a/bindings/test/blst.test.ts
+++ b/bindings/test/blst.test.ts
@@ -311,6 +311,21 @@ describe("blst", () => {
       expect(result).toBe(true);
     });
 
+    it("snapshots the message before reading public keys", () => {
+      const message = Uint8Array.from(TEST_VECTORS.message);
+      const pk = PublicKey.fromHex(TEST_VECTORS.publicKey.compressed);
+      const sig = Signature.fromHex(TEST_VECTORS.signature.compressed);
+      const pks = [pk];
+      Object.defineProperty(pks, 0, {
+        get() {
+          message.fill(0);
+          return pk;
+        },
+      });
+
+      expect(fastAggregateVerify(message, pks, sig, false)).toBe(true);
+    });
+
     it("should return false for empty pubkeys", () => {
       const sig = Signature.fromHex(TEST_VECTORS.signature.compressed);
       const result = fastAggregateVerify(TEST_VECTORS.message, [], sig, false);
@@ -337,6 +352,19 @@ describe("blst", () => {
   describe("verifyMultipleAggregateSignatures", () => {
     it("should return true for valid sets", () => {
       expect(verifyMultipleAggregateSignatures(getTestSets(6), false, false)).to.be.true;
+    });
+
+    it("snapshots messages before reading later sets", () => {
+      const sets = getTestSets(2);
+      const second = sets[1];
+      Object.defineProperty(sets, 1, {
+        get() {
+          sets[0].msg.fill(0);
+          return second;
+        },
+      });
+
+      expect(verifyMultipleAggregateSignatures(sets, false, false)).toBe(true);
     });
 
     it("should return false for invalid sets", () => {


### PR DESCRIPTION
## Summary
- snapshot the 32-byte same-message signing root before reading per-set JS properties
- audit the BLS NAPI surface for typed-array slices retained across calls that can execute JavaScript
- snapshot messages in `verifySignatureSets`, `fastAggregateVerify`, and `verifyMultipleAggregateSignatures`
- add regressions where getters mutate the source message during each native call

## Audit result
The audit found four affected paths in total, including the originally reported same-message verifier path and three additional paths. Other `toSlice()` uses either copy/deserialize the bytes before another JavaScript-capable call, or consume them directly without retaining the backing-store pointer.

## Verification
- `pnpm vitest run bindings/test/bls-verifier.test.ts bindings/test/blst.test.ts` (173 passed)
- `zig build build-lib:bindings -Doptimize=ReleaseSafe -Dpreset=mainnet`
- `zig fmt --check bindings/napi/bls_verifier.zig bindings/napi/blst.zig`
- `pnpm exec biome check bindings/test/bls-verifier.test.ts bindings/test/blst.test.ts`

Addresses ChainSafe/lodestar-z#562 review feedback in https://github.com/ChainSafe/lodestar-z/pull/562#discussion_r3788923029.
