### PR TITLE
feat(discv5): add standalone discovery v5 module

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -231,6 +231,12 @@
                 .imports = .{.download_era_options},
             },
         },
+        .discv5_discover = .{
+            .root_module = .{
+                .root_source_file = "examples/discv5_discover.zig",
+                .imports = .{.discv5},
+            },
+        },
         // TODO: Re-enable metrics_stf once karlseguin/http.zig supports Zig 0.16.0.
         // See: https://github.com/karlseguin/http.zig/issues/175
         // .metrics_stf = .{

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -219,6 +219,10 @@
             .root_source_file = "src/beacon_node/root.zig",
             .imports = .{ .consensus_types, .state_transition, .persistent_merkle_tree, .testing_allocators, .metrics, .hex, .time },
         },
+        .discv5 = .{
+            .root_source_file = "src/discv5/root.zig",
+            .imports = .{.hex},
+        },
     },
     .executables = .{
         .download_era_files = .{
@@ -396,6 +400,7 @@
         .fork_choice = .{ .root_module = .fork_choice },
         .clock = .{ .root_module = .clock },
         .beacon_node = .{ .root_module = .beacon_node },
+        .discv5 = .{ .root_module = .discv5 },
 
         .int = .{
             .root_module = .{

--- a/examples/discv5_discover.zig
+++ b/examples/discv5_discover.zig
@@ -1,0 +1,356 @@
+//! End-to-end discv5 discovery smoke test.
+//!
+//! Run with:
+//!   zig build run:discv5_discover -- --timeout-ms 30000 --max-results 16
+
+const std = @import("std");
+const discv5 = @import("discv5");
+
+pub const std_options: std.Options = .{ .log_level = .info };
+
+const Allocator = std.mem.Allocator;
+const Address = discv5.Address;
+const NodeId = discv5.NodeId;
+
+// Source, fetched 2026-05-15:
+// https://github.com/eth-clients/eth2-networks/blob/master/shared/mainnet/bootstrap_nodes.txt
+const default_bootnodes = [_][]const u8{
+    "enr:-KG4QNTx85fjxABbSq_Rta9wy56nQ1fHK0PewJbGjLm1M4bMGx5-3Qq4ZX2-iFJ0pys_O90sVXNNOxp2E7afBsGsBrgDhGV0aDKQu6TalgMAAAD__________4JpZIJ2NIJpcIQEnfA2iXNlY3AyNTZrMaECGXWQ-rQ2KZKRH1aOW4IlPDBkY4XDphxg9pxKytFCkayDdGNwgiMog3VkcIIjKA",
+    "enr:-KG4QF4B5WrlFcRhUU6dZETwY5ZzAXnA0vGC__L1Kdw602nDZwXSTs5RFXFIFUnbQJmhNGVU6OIX7KVrCSTODsz1tK4DhGV0aDKQu6TalgMAAAD__________4JpZIJ2NIJpcIQExNYEiXNlY3AyNTZrMaECQmM9vp7KhaXhI-nqL_R0ovULLCFSFTa9CPPSdb1zPX6DdGNwgiMog3VkcIIjKA",
+    "enr:-Ku4QImhMc1z8yCiNJ1TyUxdcfNucje3BGwEHzodEZUan8PherEo4sF7pPHPSIB1NNuSg5fZy7qFsjmUKs2ea1Whi0EBh2F0dG5ldHOIAAAAAAAAAACEZXRoMpD1pf1CAAAAAP__________gmlkgnY0gmlwhBLf22SJc2VjcDI1NmsxoQOVphkDqal4QzPMksc5wnpuC3gvSC8AfbFOnZY_On34wIN1ZHCCIyg",
+    "enr:-Le4QPUXJS2BTORXxyx2Ia-9ae4YqA_JWX3ssj4E_J-3z1A-HmFGrU8BpvpqhNabayXeOZ2Nq_sbeDgtzMJpLLnXFgAChGV0aDKQtTA_KgEAAAAAIgEAAAAAAIJpZIJ2NIJpcISsaa0Zg2lwNpAkAIkHAAAAAPA8kv_-awoTiXNlY3AyNTZrMaEDHAD2JKYevx89W0CcFJFiskdcEzkH_Wdv9iW42qLK79ODdWRwgiMohHVkcDaCI4I",
+    "enr:-Le4QLHZDSvkLfqgEo8IWGG96h6mxwe_PsggC20CL3neLBjfXLGAQFOPSltZ7oP6ol54OvaNqO02Rnvb8YmDR274uq8ChGV0aDKQtTA_KgEAAAAAIgEAAAAAAIJpZIJ2NIJpcISLosQxg2lwNpAqAX4AAAAAAPA8kv_-ax65iXNlY3AyNTZrMaEDBJj7_dLFACaxBfaI8KZTh_SSJUjhyAyfshimvSqo22WDdWRwgiMohHVkcDaCI4I",
+    "enr:-Le4QH6LQrusDbAHPjU_HcKOuMeXfdEB5NJyXgHWFadfHgiySqeDyusQMvfphdYWOzuSZO9Uq2AMRJR5O4ip7OvVma8BhGV0aDKQtTA_KgEAAAAAIgEAAAAAAIJpZIJ2NIJpcISLY9ncg2lwNpAkAh8AgQIBAAAAAAAAAAmXiXNlY3AyNTZrMaECDYCZTZEksF-kmgPholqgVt8IXr-8L7Nu7YrZ7HUpgxmDdWRwgiMohHVkcDaCI4I",
+    "enr:-Ku4QHqVeJ8PPICcWk1vSn_XcSkjOkNiTg6Fmii5j6vUQgvzMc9L1goFnLKgXqBJspJjIsB91LTOleFmyWWrFVATGngBh2F0dG5ldHOIAAAAAAAAAACEZXRoMpC1MD8qAAAAAP__________gmlkgnY0gmlwhAMRHkWJc2VjcDI1NmsxoQKLVXFOhp2uX6jeT0DvvDpPcU8FWMjQdR4wMuORMhpX24N1ZHCCIyg",
+    "enr:-LK4QA8FfhaAjlb_BXsXxSfiysR7R52Nhi9JBt4F8SPssu8hdE1BXQQEtVDC3qStCW60LSO7hEsVHv5zm8_6Vnjhcn0Bh2F0dG5ldHOIAAAAAAAAAACEZXRoMpC1MD8qAAAAAP__________gmlkgnY0gmlwhAN4aBKJc2VjcDI1NmsxoQJerDhsJ-KxZ8sHySMOCmTO6sHM3iCFQ6VMvLTe948MyYN0Y3CCI4yDdWRwgiOM",
+};
+
+const Options = struct {
+    timeout_ms: u64 = 30_000,
+    max_results: usize = 16,
+    use_default_bootnodes: bool = true,
+    target: ?NodeId = null,
+    extra_bootnodes: std.ArrayListUnmanaged([]u8) = .empty,
+
+    fn deinit(self: *Options, alloc: Allocator) void {
+        for (self.extra_bootnodes.items) |bootnode| alloc.free(bootnode);
+        self.extra_bootnodes.deinit(alloc);
+    }
+
+    fn appendBootnode(self: *Options, alloc: Allocator, bootnode: []const u8) !void {
+        const owned = try alloc.dupe(u8, bootnode);
+        errdefer alloc.free(owned);
+        try self.extra_bootnodes.append(alloc, owned);
+    }
+};
+
+pub fn main(init: std.process.Init) !void {
+    var gpa: std.heap.DebugAllocator(.{}) = .init;
+    defer std.debug.assert(gpa.deinit() == .ok);
+
+    const alloc = gpa.allocator();
+    const output_io = init.io;
+
+    var options = (try parseOptions(alloc, init.minimal.args)) orelse {
+        var stdout_buf: [8192]u8 = undefined;
+        var stdout_file_writer = std.Io.File.stdout().writer(output_io, &stdout_buf);
+        const stdout = &stdout_file_writer.interface;
+        try printUsage(stdout);
+        try stdout.flush();
+        return;
+    };
+    defer options.deinit(alloc);
+
+    var runtime = std.Io.Threaded.init(alloc, .{});
+    defer runtime.deinit();
+
+    try runDiscovery(alloc, runtime.io(), output_io, &options);
+}
+
+fn runDiscovery(alloc: Allocator, io: std.Io, output_io: std.Io, options: *const Options) !void {
+    var stdout_buf: [8192]u8 = undefined;
+    var stdout_file_writer = std.Io.File.stdout().writer(output_io, &stdout_buf);
+    const stdout = &stdout_file_writer.interface;
+    defer stdout.flush() catch {};
+
+    const target = options.target orelse blk: {
+        var random_target: NodeId = undefined;
+        io.random(&random_target);
+        break :blk random_target;
+    };
+
+    const key_pair = discv5.secp256k1.KeyPair.generate(io);
+    const pubkey = discv5.secp256k1.compressedPubkey(&key_pair);
+    const local_node_id = discv5.enr.nodeIdFromCompressedPubkey(&pubkey);
+
+    const service_config = discv5.service.Config{
+        .bind_addresses = .{
+            .ip4 = .{ .ip4 = .{ .bytes = .{ 0, 0, 0, 0 }, .port = 0 } },
+        },
+        .protocol_config = .{
+            .local_key_pair = key_pair,
+            .local_node_id = local_node_id,
+            .request_timeout_ms = 2_000,
+            .request_retries = 1,
+        },
+        .lookup_num_results = options.max_results,
+        .lookup_timeout_ms = options.timeout_ms,
+        .receive_timeout_ms = 5,
+    };
+    const runtime_options = discv5.RuntimeService.Options{
+        .command_queue_capacity = 1024,
+        .event_queue_capacity = 1024,
+        .maintenance_interval_ms = 100,
+    };
+
+    var runtime_service = try discv5.RuntimeService.initWithOptions(io, alloc, service_config, runtime_options);
+    var runtime_group: std.Io.Group = .init;
+    runtime_group.concurrent(io, runRuntimeService, .{ &runtime_service, runtime_options }) catch |err| {
+        runtime_service.deinit();
+        return err;
+    };
+    defer {
+        runtime_service.stop();
+        runtime_group.await(io) catch {};
+        runtime_service.deinit();
+    }
+
+    try waitForRuntime(&runtime_service);
+    try setLocalEnr(alloc, &runtime_service, key_pair);
+
+    var added_bootnodes: usize = 0;
+    if (options.use_default_bootnodes) {
+        for (default_bootnodes) |bootnode| {
+            if (try addBootnode(alloc, &runtime_service, bootnode)) added_bootnodes += 1;
+        }
+    }
+    for (options.extra_bootnodes.items) |bootnode| {
+        if (try addBootnode(alloc, &runtime_service, bootnode)) added_bootnodes += 1;
+    }
+    if (added_bootnodes == 0) return error.NoBootnodes;
+
+    const lookup_id = try runtime_service.startLookup(&target);
+    try stdout.print("discv5 discovery lookup {d}\n", .{lookup_id});
+    try stdout.print("bound: ", .{});
+    if (runtime_service.boundAddress(.ip4)) |addr| {
+        try addr.format(stdout);
+    } else {
+        try stdout.print("<none>", .{});
+    }
+    try stdout.print("\nbootnodes: {d}\ntarget: ", .{added_bootnodes});
+    try printNodeId(stdout, &target);
+    try stdout.print("\n\n", .{});
+    try stdout.flush();
+
+    var seen = std.AutoHashMap(NodeId, void).init(alloc);
+    defer seen.deinit();
+
+    var found: usize = 0;
+    var finished = false;
+    var lookup_timed_out = false;
+
+    while (!finished) {
+        const event_value = runtime_service.nextEvent() catch |err| switch (err) {
+            error.Closed => break,
+            error.Canceled => return err,
+        };
+        var event = event_value;
+        defer event.deinit(alloc);
+
+        switch (event) {
+            .discovered_enr => |discovered| {
+                if (found >= options.max_results) {
+                    finished = true;
+                    continue;
+                }
+                if (try printFoundParsedEnr(alloc, stdout, &seen, discovered.raw.slice(), &discovered.enr)) {
+                    found += 1;
+                    try stdout.flush();
+                }
+                if (found >= options.max_results) finished = true;
+            },
+            .lookup_finished => |lookup_finished| {
+                if (lookup_finished.lookup_id != lookup_id) continue;
+                lookup_timed_out = lookup_finished.timed_out;
+                for (lookup_finished.enrs) |raw_enr| {
+                    if (found >= options.max_results) break;
+                    if (try printFoundEnr(alloc, stdout, &seen, raw_enr)) found += 1;
+                }
+                finished = true;
+                try stdout.flush();
+            },
+            else => {},
+        }
+    }
+
+    if (!finished and found < options.max_results) lookup_timed_out = true;
+
+    try stdout.print("\nsummary: {d} ENRs printed; lookup {s}\n", .{
+        found,
+        if (lookup_timed_out) "timed out" else "finished",
+    });
+}
+
+fn runRuntimeService(runtime_service: *discv5.RuntimeService, options: discv5.RuntimeService.Options) void {
+    runtime_service.run(options) catch |err| std.debug.print("runtime service stopped with {}\n", .{err});
+}
+
+fn waitForRuntime(runtime_service: *const discv5.RuntimeService) !void {
+    while (!runtime_service.isRunning()) {
+        if (runtime_service.isClosed()) return error.ServiceStopped;
+        try std.Thread.yield();
+    }
+}
+
+fn setLocalEnr(
+    alloc: Allocator,
+    runtime_service: *discv5.RuntimeService,
+    key_pair: discv5.secp256k1.KeyPair,
+) !void {
+    var builder = discv5.enr.Builder.init(alloc, key_pair, 1);
+    if (runtime_service.boundAddress(.ip4)) |addr| {
+        builder.udp = addr.getPort();
+    }
+
+    const local_enr = try builder.encode();
+    defer alloc.free(local_enr);
+
+    try runtime_service.setLocalEnr(local_enr);
+}
+
+fn parseOptions(alloc: Allocator, args_value: std.process.Args) !?Options {
+    var options = Options{};
+    errdefer options.deinit(alloc);
+
+    var args = try std.process.Args.Iterator.initAllocator(args_value, alloc);
+    defer args.deinit();
+
+    _ = args.next();
+    while (args.next()) |arg_z| {
+        const arg = arg_z[0..arg_z.len];
+
+        if (std.mem.eql(u8, arg, "--help") or std.mem.eql(u8, arg, "-h")) {
+            options.deinit(alloc);
+            return null;
+        } else if (std.mem.eql(u8, arg, "--timeout-ms")) {
+            const value = args.next() orelse return error.MissingTimeout;
+            options.timeout_ms = try parsePositiveInt(u64, value);
+        } else if (std.mem.eql(u8, arg, "--max-results")) {
+            const value = args.next() orelse return error.MissingMaxResults;
+            options.max_results = try parsePositiveInt(usize, value);
+            if (options.max_results > discv5.service.MAX_LOOKUP_RESULTS) return error.TooManyResults;
+        } else if (std.mem.eql(u8, arg, "--target")) {
+            const value = args.next() orelse return error.MissingTarget;
+            options.target = try parseNodeId(value);
+        } else if (std.mem.eql(u8, arg, "--bootnode")) {
+            const value = args.next() orelse return error.MissingBootnode;
+            try options.appendBootnode(alloc, value);
+        } else if (std.mem.eql(u8, arg, "--no-default-bootnodes")) {
+            options.use_default_bootnodes = false;
+        } else if (std.mem.startsWith(u8, arg, "enr:")) {
+            try options.appendBootnode(alloc, arg);
+        } else {
+            std.debug.print("unknown argument: {s}\n", .{arg});
+            return error.InvalidArgument;
+        }
+    }
+
+    return options;
+}
+
+fn parsePositiveInt(comptime T: type, text: []const u8) !T {
+    const value = try std.fmt.parseUnsigned(T, text, 10);
+    if (value == 0) return error.ValueMustBePositive;
+    return value;
+}
+
+fn parseNodeId(text: []const u8) !NodeId {
+    if (text.len != 64 and text.len != 66) return error.InvalidNodeId;
+    if (text.len == 66 and !std.mem.startsWith(u8, text, "0x")) return error.InvalidNodeId;
+
+    var node_id: NodeId = undefined;
+    _ = discv5.hex.hexToBytes(&node_id, text) catch return error.InvalidNodeId;
+    return node_id;
+}
+
+fn addBootnode(alloc: Allocator, runtime_service: *discv5.RuntimeService, bootnode: []const u8) !bool {
+    const raw = discv5.enr.decodeText(alloc, bootnode) catch |err| {
+        std.debug.print("skipping invalid bootnode: {}\n", .{err});
+        return false;
+    };
+    defer alloc.free(raw);
+
+    if (!try runtime_service.addEnr(raw)) {
+        std.debug.print("skipping unusable bootnode ENR\n", .{});
+        return false;
+    }
+    return true;
+}
+
+fn printFoundEnr(
+    alloc: Allocator,
+    stdout: *std.Io.Writer,
+    seen: *std.AutoHashMap(NodeId, void),
+    raw_enr: []const u8,
+) !bool {
+    const parsed = discv5.enr.decode(raw_enr) catch return false;
+    return try printFoundParsedEnr(alloc, stdout, seen, raw_enr, &parsed);
+}
+
+fn printFoundParsedEnr(
+    alloc: Allocator,
+    stdout: *std.Io.Writer,
+    seen: *std.AutoHashMap(NodeId, void),
+    raw_enr: []const u8,
+    parsed: *const discv5.Enr,
+) !bool {
+    const node_id = parsed.nodeId() orelse return false;
+    const seen_entry = try seen.getOrPut(node_id);
+    if (seen_entry.found_existing) return false;
+
+    const text = try discv5.enr.encodeText(alloc, raw_enr);
+    defer alloc.free(text);
+
+    try stdout.print("found ", .{});
+    try printNodeId(stdout, &node_id);
+    try printEnrAddresses(stdout, parsed);
+    try stdout.print("\n{s}\n", .{text});
+    return true;
+}
+
+fn printNodeId(stdout: *std.Io.Writer, node_id: *const NodeId) !void {
+    try stdout.print("0x{x}", .{node_id});
+}
+
+fn printEnrAddresses(stdout: *std.Io.Writer, parsed: *const discv5.Enr) !void {
+    if (parsed.ip) |ip| {
+        if (parsed.udp) |port| {
+            const addr = Address{ .ip4 = .{ .bytes = ip, .port = port } };
+            try stdout.print(" ", .{});
+            try addr.format(stdout);
+        }
+    }
+    if (parsed.ip6) |ip6| {
+        if (parsed.udp6) |port| {
+            const addr = Address{ .ip6 = .{ .bytes = ip6, .port = port } };
+            try stdout.print(" ", .{});
+            try addr.format(stdout);
+        }
+    }
+}
+
+fn printUsage(stdout: *std.Io.Writer) !void {
+    try stdout.print(
+        \\Usage:
+        \\  zig build run:discv5_discover -- [options] [enr:...]
+        \\
+        \\Options:
+        \\  --timeout-ms N            Stop after N milliseconds (default: 30000)
+        \\  --max-results N           Stop after N printed ENRs, max 16 (default: 16)
+        \\  --target 0xHEX            Lookup a specific 32-byte node id; random by default
+        \\  --bootnode enr:...        Add an extra bootnode ENR
+        \\  --no-default-bootnodes    Use only bootnodes passed on the command line
+        \\  -h, --help                Show this help
+        \\
+    , .{});
+}

--- a/src/discv5/enr.zig
+++ b/src/discv5/enr.zig
@@ -1,0 +1,688 @@
+//! Ethereum Node Record (ENR) — EIP-778
+//!
+//! An ENR encodes node identity and contact information.
+//! Format: `[signature, seq, k, v, k, v, ...]` RLP list.
+//! Identity scheme "v4": secp256k1 key pair, NodeId = keccak256(uncompressed pubkey)
+
+const std = @import("std");
+const Allocator = std.mem.Allocator;
+const rlp = @import("rlp.zig");
+const secp = @import("secp256k1.zig");
+const Keccak256 = std.crypto.hash.sha3.Keccak256;
+const Address = std.Io.net.IpAddress;
+
+pub const NodeId = [32]u8;
+
+/// Maximum ENR size in bytes (per spec)
+pub const MAX_ENR_SIZE = 300;
+
+/// Owned ENR bytes. ENRs are strictly bounded by EIP-778, so long-lived
+/// protocol storage can keep them inline instead of allocating per record.
+pub const RawEnr = struct {
+    buf: [MAX_ENR_SIZE]u8 = undefined,
+    len: u16 = 0,
+
+    pub fn init(data: []const u8) Error!RawEnr {
+        if (data.len > MAX_ENR_SIZE) return Error.InvalidEnr;
+        var raw = RawEnr{ .len = @intCast(data.len) };
+        @memcpy(raw.buf[0..data.len], data);
+        return raw;
+    }
+
+    pub fn slice(self: *const RawEnr) []const u8 {
+        return self.buf[0..@as(usize, self.len)];
+    }
+};
+
+pub const Error = error{
+    InvalidEnr,
+    InvalidSignature,
+    InvalidPublicKey,
+    UnsupportedScheme,
+    OutOfMemory,
+    BufferTooSmall,
+};
+
+/// A parsed ENR (Ethereum Node Record)
+pub const Enr = struct {
+    seq: u64,
+    /// Compressed secp256k1 public key (33 bytes), or null if not present
+    pubkey: ?[33]u8,
+    /// IPv4 address (4 bytes), or null
+    ip: ?[4]u8,
+    /// UDP port
+    udp: ?u16,
+    /// TCP port
+    tcp: ?u16,
+    /// IPv6 address (16 bytes), or null
+    ip6: ?[16]u8,
+    /// UDP6 port
+    udp6: ?u16,
+    /// TCP6 port
+    tcp6: ?u16,
+    quic: ?u16,
+    quic6: ?u16,
+    /// Fork digest from eth2 ENR field (first 4 bytes of ENRForkID SSZ)
+    eth2_fork_digest: ?[4]u8,
+    /// Full eth2 ENR field (16 bytes: fork_digest + next_fork_version + next_fork_epoch)
+    eth2_raw: ?[16]u8,
+    /// Attestation subnet bitfield (8 bytes = 64 subnets)
+    attnets: ?[8]u8,
+    /// Sync committee subnet bitfield (1 byte = 4 sync committees)
+    syncnets: ?[1]u8,
+    /// PeerDAS custody group count (`cgc` ENR field).
+    custody_group_count: ?u64,
+
+    /// Compute NodeId from ENR public key
+    pub fn nodeId(self: *const Enr) ?NodeId {
+        const pk = self.pubkey orelse return null;
+        return nodeIdFromCompressedPubkey(&pk);
+    }
+
+    /// The advertised IPv4 UDP endpoint, or null if either ip/udp is absent.
+    pub fn udpAddress4(self: *const Enr) ?Address {
+        const ip = self.ip orelse return null;
+        const port = self.udp orelse return null;
+        return .{ .ip4 = .{ .bytes = ip, .port = port } };
+    }
+
+    /// The advertised IPv6 UDP endpoint, or null if either ip6/udp6 is absent.
+    pub fn udpAddress6(self: *const Enr) ?Address {
+        const ip6 = self.ip6 orelse return null;
+        const port = self.udp6 orelse return null;
+        return .{ .ip6 = .{ .bytes = ip6, .port = port } };
+    }
+
+    /// Preferred UDP endpoint, IPv4 first then IPv6.
+    pub fn udpAddress(self: *const Enr) ?Address {
+        return self.udpAddress4() orelse self.udpAddress6();
+    }
+};
+
+/// Compute NodeId = keccak256(uncompressed pubkey[1..]) from compressed pubkey
+pub fn nodeIdFromCompressedPubkey(compressed: *const [33]u8) NodeId {
+    // Per discv5/v4 identity scheme:
+    //   node-id = keccak256(uncompressed_pubkey[1..65])
+    // Reuse the thread-local secp256k1 context from secp256k1.zig to avoid
+    // allocating a new context on every call.
+    const uncompressed = secp.uncompressedFromCompressed(compressed) catch {
+        // Invalid key — return zeroed node id
+        return [_]u8{0} ** 32;
+    };
+    var node_id: NodeId = undefined;
+    Keccak256.hash(uncompressed[1..65], &node_id, .{});
+    return node_id;
+}
+
+/// Decode an ENR from RLP-encoded bytes
+pub fn decode(data: []const u8) Error!Enr {
+    if (data.len > MAX_ENR_SIZE) return Error.InvalidEnr;
+
+    var r = rlp.Reader.init(data);
+    var list = r.readList() catch return Error.InvalidEnr;
+    if (!r.atEnd()) return Error.InvalidEnr;
+
+    const signature_bytes = list.readBytes() catch return Error.InvalidEnr;
+    if (signature_bytes.len != 64) return Error.InvalidSignature;
+    const content_payload = list.data[list.pos..];
+
+    // seq
+    const seq = list.readUint64() catch return Error.InvalidEnr;
+
+    var enr = Enr{
+        .seq = seq,
+        .pubkey = null,
+        .ip = null,
+        .udp = null,
+        .tcp = null,
+        .ip6 = null,
+        .udp6 = null,
+        .tcp6 = null,
+        .quic = null,
+        .quic6 = null,
+        .eth2_fork_digest = null,
+        .eth2_raw = null,
+        .attnets = null,
+        .syncnets = null,
+        .custody_group_count = null,
+    };
+    var saw_id_v4 = false;
+    var previous_key: ?[]const u8 = null;
+
+    // Parse key-value pairs
+    while (!list.atEnd()) {
+        const key = list.readBytes() catch return Error.InvalidEnr;
+        if (list.atEnd()) return Error.InvalidEnr;
+        if (previous_key) |previous| {
+            if (std.mem.order(u8, previous, key) != .lt) return Error.InvalidEnr;
+        }
+        previous_key = key;
+
+        if (std.mem.eql(u8, key, "secp256k1")) {
+            const val = list.readBytes() catch return Error.InvalidEnr;
+            if (readFixed(33, val)) |v| enr.pubkey = v;
+        } else if (std.mem.eql(u8, key, "id")) {
+            const val = list.readBytes() catch return Error.InvalidEnr;
+            if (!std.mem.eql(u8, val, "v4")) return Error.UnsupportedScheme;
+            saw_id_v4 = true;
+        } else if (std.mem.eql(u8, key, "ip")) {
+            const val = list.readBytes() catch return Error.InvalidEnr;
+            if (readFixed(4, val)) |v| enr.ip = v;
+        } else if (std.mem.eql(u8, key, "udp")) {
+            const val = list.readBytes() catch return Error.InvalidEnr;
+            if (readPort(val)) |v| enr.udp = v;
+        } else if (std.mem.eql(u8, key, "tcp")) {
+            const val = list.readBytes() catch return Error.InvalidEnr;
+            if (readPort(val)) |v| enr.tcp = v;
+        } else if (std.mem.eql(u8, key, "ip6")) {
+            const val = list.readBytes() catch return Error.InvalidEnr;
+            if (readFixed(16, val)) |v| enr.ip6 = v;
+        } else if (std.mem.eql(u8, key, "udp6")) {
+            const val = list.readBytes() catch return Error.InvalidEnr;
+            if (readPort(val)) |v| enr.udp6 = v;
+        } else if (std.mem.eql(u8, key, "tcp6")) {
+            const val = list.readBytes() catch return Error.InvalidEnr;
+            if (readPort(val)) |v| enr.tcp6 = v;
+        } else if (std.mem.eql(u8, key, "quic")) {
+            const val = list.readBytes() catch return Error.InvalidEnr;
+            if (readPort(val)) |v| enr.quic = v;
+        } else if (std.mem.eql(u8, key, "quic6")) {
+            const val = list.readBytes() catch return Error.InvalidEnr;
+            if (readPort(val)) |v| enr.quic6 = v;
+        } else if (std.mem.eql(u8, key, "eth2")) {
+            const val = list.readBytes() catch return Error.InvalidEnr;
+            // ENRForkID SSZ: fork_digest(4) + next_fork_version(4) + next_fork_epoch(8) = 16 bytes
+            if (val.len >= 4) enr.eth2_fork_digest = val[0..4].*;
+            if (val.len >= 16) enr.eth2_raw = val[0..16].*;
+        } else if (std.mem.eql(u8, key, "attnets")) {
+            const val = list.readBytes() catch return Error.InvalidEnr;
+            if (readFixed(8, val)) |v| enr.attnets = v;
+        } else if (std.mem.eql(u8, key, "cgc")) {
+            const val = list.readBytes() catch return Error.InvalidEnr;
+            if (readCanonicalUint(u64, val, 8)) |v| enr.custody_group_count = v;
+        } else if (std.mem.eql(u8, key, "syncnets")) {
+            const val = list.readBytes() catch return Error.InvalidEnr;
+            if (readFixed(1, val)) |v| enr.syncnets = v;
+        } else {
+            // Skip unknown key value
+            list.skipItem() catch return Error.InvalidEnr;
+        }
+    }
+
+    if (!saw_id_v4) return Error.UnsupportedScheme;
+    const pubkey = enr.pubkey orelse return Error.InvalidPublicKey;
+
+    var sig_hash: [32]u8 = undefined;
+    hashSignedPortion(content_payload, &sig_hash);
+    const signature: [64]u8 = signature_bytes[0..64].*;
+    secp.verify(&sig_hash, &signature, &pubkey) catch return Error.InvalidSignature;
+
+    return enr;
+}
+
+/// Decode an RLP byte string of exactly `N` bytes into a fixed array, or null on length mismatch.
+fn readFixed(comptime N: usize, val: []const u8) ?[N]u8 {
+    return if (val.len == N) val[0..N].* else null;
+}
+
+/// Decode a minimal big-endian unsigned integer (1..=`max_len` bytes) from an RLP byte string,
+/// or null if the value is empty or wider than `max_len`.
+fn readBoundedUint(comptime T: type, val: []const u8, max_len: usize) ?T {
+    if (val.len == 0 or val.len > max_len) return null;
+    if (val[0] == 0) return null;
+    var n: T = 0;
+    for (val) |b| n = (n << 8) | b;
+    return n;
+}
+
+/// Decode a canonical RLP unsigned integer, where zero is the empty byte string.
+fn readCanonicalUint(comptime T: type, val: []const u8, max_len: usize) ?T {
+    if (val.len == 0) return 0;
+    return readBoundedUint(T, val, max_len);
+}
+
+/// Decode an ENR port (`u16`, 1..=2 minimal big-endian bytes), or null if absent/invalid.
+fn readPort(val: []const u8) ?u16 {
+    return readBoundedUint(u16, val, 2);
+}
+
+/// Encode raw ENR RLP bytes in the EIP-778 text form:
+/// `enr:` + URL-safe base64 without padding.
+pub fn encodeText(alloc: Allocator, data: []const u8) Error![]u8 {
+    if (data.len > MAX_ENR_SIZE) return Error.InvalidEnr;
+
+    const b64_len = std.base64.url_safe_no_pad.Encoder.calcSize(data.len);
+    const result = try alloc.alloc(u8, "enr:".len + b64_len);
+    @memcpy(result[0.."enr:".len], "enr:");
+    _ = std.base64.url_safe_no_pad.Encoder.encode(result["enr:".len..], data);
+    return result;
+}
+
+/// Decode and validate an ENR from its EIP-778 text form.
+/// Caller owns the returned raw RLP bytes.
+pub fn decodeText(alloc: Allocator, text: []const u8) Error![]u8 {
+    if (!std.mem.startsWith(u8, text, "enr:")) return Error.InvalidEnr;
+
+    const encoded = text["enr:".len..];
+    const raw_len = std.base64.url_safe_no_pad.Decoder.calcSizeForSlice(encoded) catch return Error.InvalidEnr;
+    if (raw_len > MAX_ENR_SIZE) return Error.InvalidEnr;
+
+    const raw = try alloc.alloc(u8, raw_len);
+    errdefer alloc.free(raw);
+    std.base64.url_safe_no_pad.Decoder.decode(raw, encoded) catch return Error.InvalidEnr;
+
+    _ = try decode(raw);
+    return raw;
+}
+
+fn hashSignedPortion(content_payload: []const u8, out: *[32]u8) void {
+    var hasher = Keccak256.init(.{});
+    updateListPrefix(&hasher, content_payload.len);
+    hasher.update(content_payload);
+    hasher.final(out);
+}
+
+fn updateListPrefix(hasher: *Keccak256, payload_len: usize) void {
+    if (payload_len <= 55) {
+        hasher.update(&[_]u8{@as(u8, 0xc0) + @as(u8, @intCast(payload_len))});
+        return;
+    }
+
+    var len_bytes: [8]u8 = undefined;
+    var count: usize = 0;
+    var tmp = payload_len;
+    while (tmp > 0) : (tmp >>= 8) {
+        len_bytes[len_bytes.len - 1 - count] = @intCast(tmp & 0xff);
+        count += 1;
+    }
+    hasher.update(&[_]u8{@as(u8, 0xf7) + @as(u8, @intCast(count))});
+    hasher.update(len_bytes[len_bytes.len - count ..]);
+}
+
+/// Build and sign an ENR
+pub const Builder = struct {
+    alloc: Allocator,
+    seq: u64,
+    key_pair: secp.KeyPair,
+    ip: ?[4]u8 = null,
+    udp: ?u16 = null,
+    tcp: ?u16 = null,
+    quic: ?u16 = null,
+    ip6: ?[16]u8 = null,
+    udp6: ?u16 = null,
+    tcp6: ?u16 = null,
+    quic6: ?u16 = null,
+    /// eth2 ENR field: ENRForkID SSZ = fork_digest(4) + next_fork_version(4) + next_fork_epoch(8)
+    eth2: ?[16]u8 = null,
+    /// Attestation subnet bitfield (8 bytes = 64 bits for 64 subnets)
+    attnets: ?[8]u8 = null,
+    /// PeerDAS custody group count.
+    custody_group_count: ?u64 = null,
+    /// Sync committee subnet bitfield (1 byte = 4 bits for 4 sync committees)
+    syncnets: ?[1]u8 = null,
+
+    pub fn init(alloc: Allocator, key_pair: secp.KeyPair, seq: u64) Builder {
+        return .{
+            .alloc = alloc,
+            .seq = seq,
+            .key_pair = key_pair,
+        };
+    }
+
+    /// Set the eth2 ENR field from fork digest, next fork version, and next fork epoch.
+    pub fn setEth2(self: *Builder, fork_digest: [4]u8, next_fork_version: [4]u8, next_fork_epoch: u64) void {
+        var eth2_val: [16]u8 = undefined;
+        @memcpy(eth2_val[0..4], &fork_digest);
+        @memcpy(eth2_val[4..8], &next_fork_version);
+        std.mem.writeInt(u64, eth2_val[8..16], next_fork_epoch, .little);
+        self.eth2 = eth2_val;
+    }
+
+    /// Write an unsigned integer as minimal-length big-endian bytes.
+    fn writeUint64Minimal(writer: *rlp.Writer, value: u64) !void {
+        if (value == 0) return writer.writeBytesBounded("");
+
+        var bytes: [8]u8 = undefined;
+        std.mem.writeInt(u64, &bytes, value, .big);
+
+        var start: usize = 0;
+        while (start < bytes.len - 1 and bytes[start] == 0) : (start += 1) {}
+        try writer.writeBytesBounded(bytes[start..]);
+    }
+
+    /// Write all key-value pairs in alphabetical order to an RLP writer.
+    /// EIP-778 requires keys to be sorted.
+    fn writeKVPairs(self: *const Builder, writer: *rlp.Writer, pubkey: *const [33]u8) !void {
+        // Alphabetical order: attnets, cgc, eth2, id, ip, ip6, quic, quic6,
+        //                     secp256k1, syncnets, tcp, tcp6, udp, udp6
+        if (self.attnets) |attnets| {
+            try writer.writeBytesBounded("attnets");
+            try writer.writeBytesBounded(&attnets);
+        }
+        if (self.custody_group_count) |count| {
+            try writer.writeBytesBounded("cgc");
+            try writeUint64Minimal(writer, count);
+        }
+        if (self.eth2) |eth2_val| {
+            try writer.writeBytesBounded("eth2");
+            try writer.writeBytesBounded(&eth2_val);
+        }
+        try writer.writeBytesBounded("id");
+        try writer.writeBytesBounded("v4");
+        if (self.ip) |ip| {
+            try writer.writeBytesBounded("ip");
+            try writer.writeBytesBounded(&ip);
+        }
+        if (self.ip6) |ip6| {
+            try writer.writeBytesBounded("ip6");
+            try writer.writeBytesBounded(&ip6);
+        }
+        if (self.quic) |port| {
+            try writer.writeBytesBounded("quic");
+            try writeUint64Minimal(writer, port);
+        }
+        if (self.quic6) |port| {
+            try writer.writeBytesBounded("quic6");
+            try writeUint64Minimal(writer, port);
+        }
+        try writer.writeBytesBounded("secp256k1");
+        try writer.writeBytesBounded(pubkey);
+        if (self.syncnets) |syncnets| {
+            try writer.writeBytesBounded("syncnets");
+            try writer.writeBytesBounded(&syncnets);
+        }
+        if (self.tcp) |port| {
+            try writer.writeBytesBounded("tcp");
+            try writeUint64Minimal(writer, port);
+        }
+        if (self.tcp6) |port| {
+            try writer.writeBytesBounded("tcp6");
+            try writeUint64Minimal(writer, port);
+        }
+        if (self.udp) |port| {
+            try writer.writeBytesBounded("udp");
+            try writeUint64Minimal(writer, port);
+        }
+        if (self.udp6) |port| {
+            try writer.writeBytesBounded("udp6");
+            try writeUint64Minimal(writer, port);
+        }
+    }
+
+    /// Encode and sign the ENR, returning owned bytes.
+    pub fn encode(self: *const Builder) ![]u8 {
+        const pubkey = secp.compressedPubkey(&self.key_pair);
+
+        // Build the content (without signature) for signing.
+        // Per EIP-778: sig = sign(keccak256(RLP([seq, k, v, ...])))
+        var content_buf: [MAX_ENR_SIZE]u8 = undefined;
+        var content_writer = rlp.Writer.initBuffer(&content_buf);
+
+        const content_list_start = try content_writer.beginListBounded();
+        try content_writer.writeUint64Bounded(self.seq);
+        try self.writeKVPairs(&content_writer, &pubkey);
+        try content_writer.finishList(content_list_start);
+        const content_rlp = content_writer.bytes();
+
+        var hash: [32]u8 = undefined;
+        Keccak256.hash(content_rlp, &hash, .{});
+        const sig = try secp.sign(&hash, &self.key_pair);
+
+        // Build full ENR: RLP([sig, seq, k, v, ...])
+        var full_buf: [MAX_ENR_SIZE]u8 = undefined;
+        var full_writer = rlp.Writer.initBuffer(&full_buf);
+
+        const list_start = try full_writer.beginListBounded();
+        try full_writer.writeBytesBounded(&sig);
+        try full_writer.writeUint64Bounded(self.seq);
+        try self.writeKVPairs(&full_writer, &pubkey);
+        try full_writer.finishList(list_start);
+
+        return try self.alloc.dupe(u8, full_writer.bytes());
+    }
+
+    /// Encode the ENR and return as a base64url string with "enr:" prefix.
+    /// Caller owns the returned slice.
+    pub fn encodeToString(self: *const Builder) ![]u8 {
+        const raw = try self.encode();
+        defer self.alloc.free(raw);
+
+        return try encodeText(self.alloc, raw);
+    }
+};
+
+/// Check if a subnet bit is set in an attnets bitfield.
+pub fn isSubnetSet(attnets: [8]u8, subnet_id: u6) bool {
+    const byte_idx = subnet_id / 8;
+    const bit_idx: u3 = @intCast(subnet_id % 8);
+    return (attnets[byte_idx] & (@as(u8, 1) << bit_idx)) != 0;
+}
+
+/// Count the number of set subnet bits in an attnets bitfield.
+pub fn countSubnets(attnets: [8]u8) u32 {
+    var count: u32 = 0;
+    for (attnets) |byte| {
+        count += @popCount(byte);
+    }
+    return count;
+}
+
+test "ENR nodeIdFromCompressedPubkey" {
+    // Test that we correctly compute NodeId from a compressed pubkey
+    const hex = @import("hex");
+    // node-a-key from test vectors
+    const secret_key = hex.hexToBytesComptime(32, "eef77acb6c6a6eebc5b363a475ac583ec7eccdb42b6481424c60f59aa326547f");
+    const key_pair = try secp.keyPairFromSecret(&secret_key);
+    const pubkey = secp.compressedPubkey(&key_pair);
+    const node_id = nodeIdFromCompressedPubkey(&pubkey);
+
+    // Expected from test vectors: node-a-id = 0xaaaa8419e9f49d0083561b48287df592939a8d19947d8c0ef88f2a4856a69fbb
+    const expected = hex.hexToBytesComptime(32, "aaaa8419e9f49d0083561b48287df592939a8d19947d8c0ef88f2a4856a69fbb");
+    try std.testing.expectEqualSlices(u8, &expected, &node_id);
+}
+
+test "ENR bounded integers require minimal big-endian encoding" {
+    try std.testing.expectEqual(@as(?u16, null), readBoundedUint(u16, &.{}, 2));
+    try std.testing.expectEqual(@as(?u16, null), readBoundedUint(u16, &.{0}, 2));
+    try std.testing.expectEqual(@as(?u16, null), readBoundedUint(u16, &.{ 0, 1 }, 2));
+    try std.testing.expectEqual(@as(?u16, 1), readBoundedUint(u16, &.{1}, 2));
+    try std.testing.expectEqual(@as(?u16, 256), readBoundedUint(u16, &.{ 1, 0 }, 2));
+    try std.testing.expectEqual(@as(?u16, null), readBoundedUint(u16, &.{ 1, 0, 0 }, 2));
+}
+
+test "ENR builder round-trips zero custody group count" {
+    const sk = [_]u8{0x44} ** 32;
+    const key_pair = try secp.keyPairFromSecret(&sk);
+    var builder = Builder.init(std.testing.allocator, key_pair, 1);
+    builder.custody_group_count = 0;
+    const encoded = try builder.encode();
+    defer std.testing.allocator.free(encoded);
+
+    const decoded = try decode(encoded);
+    try std.testing.expectEqual(@as(?u64, 0), decoded.custody_group_count);
+}
+
+test "ENR decode rejects unsorted and duplicate keys" {
+    const Fixture = struct {
+        fn encode(alloc: Allocator, second_key: []const u8) ![]u8 {
+            var writer = rlp.Writer.init();
+            defer writer.deinit(alloc);
+
+            const list = try writer.beginList(alloc);
+            try writer.writeBytes(alloc, &([_]u8{0} ** 64));
+            try writer.writeUint64(alloc, 1);
+            try writer.writeBytes(alloc, "secp256k1");
+            try writer.writeBytes(alloc, &([_]u8{2} ** 33));
+            try writer.writeBytes(alloc, second_key);
+            try writer.writeBytes(alloc, "v4");
+            try writer.finishList(list);
+            return writer.toOwnedSlice(alloc);
+        }
+    };
+
+    const alloc = std.testing.allocator;
+    const unsorted = try Fixture.encode(alloc, "id");
+    defer alloc.free(unsorted);
+    try std.testing.expectError(Error.InvalidEnr, decode(unsorted));
+
+    const duplicate = try Fixture.encode(alloc, "secp256k1");
+    defer alloc.free(duplicate);
+    try std.testing.expectError(Error.InvalidEnr, decode(duplicate));
+}
+
+test "ENR Builder: key-value pairs sorted alphabetically (EIP-778)" {
+    // Regression test: ENR keys must be sorted alphabetically per EIP-778.
+    // Correct order: id, ip, secp256k1, udp
+    // Previous bug: id, secp256k1, ip, udp — produced an invalid signature.
+    //
+    // Test vector from https://github.com/ethereum/devp2p/blob/master/enr.md:
+    //   private key: b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291
+    //   seq: 1, ip: 127.0.0.1, udp: 30303
+    //   expected node-id: a448f24c6d18e575453db13171562b71999873db5b286df957af199ec94617f7
+    const hex_mod = @import("hex");
+    const alloc = std.testing.allocator;
+
+    const secret_key = hex_mod.hexToBytesComptime(32, "b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291");
+    const key_pair = try secp.keyPairFromSecret(&secret_key);
+    var builder = Builder.init(alloc, key_pair, 1);
+    builder.ip = [4]u8{ 127, 0, 0, 1 };
+    builder.udp = 30303;
+    const enr_bytes = try builder.encode();
+    defer alloc.free(enr_bytes);
+
+    // Re-parse and check the node ID is the expected one (proves the pubkey is embedded correctly)
+    const parsed = try decode(enr_bytes);
+
+    const expected_node_id = hex_mod.hexToBytesComptime(32, "a448f24c6d18e575453db13171562b71999873db5b286df957af199ec94617f7");
+    const node_id = parsed.nodeId() orelse return error.NoNodeId;
+    try std.testing.expectEqualSlices(u8, &expected_node_id, &node_id);
+}
+
+test "ENR Builder: encode with eth2 and attnets" {
+    const hex_mod = @import("hex");
+    const alloc = std.testing.allocator;
+
+    const secret_key = hex_mod.hexToBytesComptime(32, "b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291");
+    const key_pair = try secp.keyPairFromSecret(&secret_key);
+    var builder = Builder.init(alloc, key_pair, 1);
+    builder.ip = [4]u8{ 127, 0, 0, 1 };
+    builder.udp = 9000;
+    builder.tcp = 9000;
+    builder.quic = 9001;
+    builder.setEth2([4]u8{ 0x6a, 0x95, 0xa1, 0xb0 }, [4]u8{ 0, 0, 0, 0 }, 0xffffffffffffffff);
+    builder.attnets = [8]u8{ 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff };
+
+    const enr_bytes = try builder.encode();
+    defer alloc.free(enr_bytes);
+
+    // Re-parse and verify fields are present
+    const parsed = try decode(enr_bytes);
+
+    try std.testing.expect(parsed.ip != null);
+    try std.testing.expectEqual([4]u8{ 127, 0, 0, 1 }, parsed.ip.?);
+    try std.testing.expectEqual(@as(?u16, 9000), parsed.udp);
+    try std.testing.expectEqual(@as(?u16, 9000), parsed.tcp);
+    try std.testing.expectEqual(@as(?u16, 9001), parsed.quic);
+    try std.testing.expect(parsed.eth2_fork_digest != null);
+    try std.testing.expectEqual([4]u8{ 0x6a, 0x95, 0xa1, 0xb0 }, parsed.eth2_fork_digest.?);
+    try std.testing.expect(parsed.attnets != null);
+    try std.testing.expectEqual([8]u8{ 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff }, parsed.attnets.?);
+}
+
+test "ENR Builder: encode with custody group count" {
+    const hex_mod = @import("hex");
+    const alloc = std.testing.allocator;
+
+    const secret_key = hex_mod.hexToBytesComptime(32, "b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291");
+    const key_pair = try secp.keyPairFromSecret(&secret_key);
+    var builder = Builder.init(alloc, key_pair, 1);
+    builder.ip = [4]u8{ 127, 0, 0, 1 };
+    builder.udp = 9000;
+    builder.custody_group_count = 12;
+
+    const enr_bytes = try builder.encode();
+    defer alloc.free(enr_bytes);
+
+    const parsed = try decode(enr_bytes);
+
+    try std.testing.expectEqual(@as(?u64, 12), parsed.custody_group_count);
+}
+
+test "ENR Builder: encodeToString produces valid enr: prefix" {
+    const hex_mod = @import("hex");
+    const alloc = std.testing.allocator;
+
+    const secret_key = hex_mod.hexToBytesComptime(32, "b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291");
+    const key_pair = try secp.keyPairFromSecret(&secret_key);
+    var builder = Builder.init(alloc, key_pair, 1);
+    builder.ip = [4]u8{ 127, 0, 0, 1 };
+    builder.udp = 9000;
+
+    const enr_str = try builder.encodeToString();
+    defer alloc.free(enr_str);
+
+    try std.testing.expect(std.mem.startsWith(u8, enr_str, "enr:"));
+}
+
+test "ENR text form round-trips raw bytes" {
+    const hex_mod = @import("hex");
+    const alloc = std.testing.allocator;
+
+    const secret_key = hex_mod.hexToBytesComptime(32, "b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291");
+    const key_pair = try secp.keyPairFromSecret(&secret_key);
+    var builder = Builder.init(alloc, key_pair, 1);
+    builder.ip = [4]u8{ 127, 0, 0, 1 };
+    builder.udp = 9000;
+
+    const enr_bytes = try builder.encode();
+    defer alloc.free(enr_bytes);
+    const enr_text = try encodeText(alloc, enr_bytes);
+    defer alloc.free(enr_text);
+    const decoded = try decodeText(alloc, enr_text);
+    defer alloc.free(decoded);
+
+    try std.testing.expectEqualSlices(u8, enr_bytes, decoded);
+}
+
+test "ENR text form rejects wrong prefix" {
+    try std.testing.expectError(Error.InvalidEnr, decodeText(std.testing.allocator, "not-enr"));
+}
+
+test "ENR decode rejects tampered signature" {
+    const hex_mod = @import("hex");
+    const alloc = std.testing.allocator;
+
+    const secret_key = hex_mod.hexToBytesComptime(32, "b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291");
+    const key_pair = try secp.keyPairFromSecret(&secret_key);
+    var builder = Builder.init(alloc, key_pair, 1);
+    builder.ip = [4]u8{ 127, 0, 0, 1 };
+    builder.udp = 9000;
+
+    const enr_bytes = try builder.encode();
+    defer alloc.free(enr_bytes);
+
+    const tampered = try alloc.dupe(u8, enr_bytes);
+    defer alloc.free(tampered);
+    tampered[tampered.len - 1] ^= 0x01;
+
+    try std.testing.expectError(Error.InvalidSignature, decode(tampered));
+}
+
+test "isSubnetSet and countSubnets" {
+    // All subnets set
+    const all = [8]u8{ 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff };
+    try std.testing.expectEqual(@as(u32, 64), countSubnets(all));
+    try std.testing.expect(isSubnetSet(all, 0));
+    try std.testing.expect(isSubnetSet(all, 63));
+
+    // Only subnet 0 set
+    const one = [8]u8{ 0x01, 0, 0, 0, 0, 0, 0, 0 };
+    try std.testing.expectEqual(@as(u32, 1), countSubnets(one));
+    try std.testing.expect(isSubnetSet(one, 0));
+    try std.testing.expect(!isSubnetSet(one, 1));
+
+    // Subnet 8 set (bit 0 of byte 1)
+    const s8 = [8]u8{ 0, 0x01, 0, 0, 0, 0, 0, 0 };
+    try std.testing.expect(isSubnetSet(s8, 8));
+    try std.testing.expect(!isSubnetSet(s8, 0));
+}

--- a/src/discv5/event_queue.zig
+++ b/src/discv5/event_queue.zig
@@ -1,0 +1,143 @@
+//! FIFO queue of owned events, shared by the protocol and service layers.
+//!
+//! Backed by an `ArrayList` with a moving head index so `pop` is O(1) without
+//! shifting on every read. Consumed entries are reclaimed lazily by `compact`,
+//! which only shifts once the consumed prefix is large enough that copying is
+//! cheaper than the space it reclaims.
+
+const std = @import("std");
+const Allocator = std.mem.Allocator;
+
+/// Only shift live entries to the front once at least this many have been
+/// consumed; below the threshold the wasted slots are cheaper than the copy.
+const compact_min_head = 64;
+const default_max_pending = 1024;
+
+pub const PushError = Allocator.Error || error{QueueFull};
+
+/// `T` must expose `pub fn deinit(self: *T, alloc: Allocator) void` so the queue
+/// can release any events still buffered when it is torn down.
+pub fn EventQueue(comptime T: type) type {
+    return struct {
+        const Self = @This();
+
+        events: std.ArrayListUnmanaged(T) = .empty,
+        head: usize = 0,
+        max_pending: usize = default_max_pending,
+
+        pub fn deinit(self: *Self, alloc: Allocator) void {
+            for (self.events.items[self.head..]) |*event| event.deinit(alloc);
+            self.events.deinit(alloc);
+        }
+
+        pub fn push(self: *Self, alloc: Allocator, event: T) PushError!void {
+            if (self.pending() >= self.max_pending) return error.QueueFull;
+            try self.events.append(alloc, event);
+        }
+
+        pub fn pop(self: *Self) ?T {
+            if (self.head >= self.events.items.len) {
+                self.events.clearRetainingCapacity();
+                self.head = 0;
+                return null;
+            }
+
+            const event = self.events.items[self.head];
+            self.head += 1;
+            self.compact();
+            return event;
+        }
+
+        /// Number of events pushed but not yet popped.
+        pub fn pending(self: *const Self) usize {
+            return self.events.items.len - self.head;
+        }
+
+        fn compact(self: *Self) void {
+            if (self.head == 0) return;
+            const remaining = self.events.items.len - self.head;
+            if (remaining == 0) {
+                self.events.clearRetainingCapacity();
+                self.head = 0;
+                return;
+            }
+            if (self.head < compact_min_head and self.head * 2 < self.events.items.len) return;
+
+            std.mem.copyForwards(
+                T,
+                self.events.items[0..remaining],
+                self.events.items[self.head..],
+            );
+            self.events.items.len = remaining;
+            self.head = 0;
+        }
+    };
+}
+
+const TestEvent = struct {
+    value: u32,
+    deinit_calls: *usize,
+
+    fn deinit(self: *TestEvent, _: Allocator) void {
+        self.deinit_calls.* += 1;
+    }
+};
+
+test "EventQueue preserves FIFO order" {
+    const alloc = std.testing.allocator;
+    var calls: usize = 0;
+    var queue: EventQueue(TestEvent) = .{};
+    defer queue.deinit(alloc);
+
+    try queue.push(alloc, .{ .value = 1, .deinit_calls = &calls });
+    try queue.push(alloc, .{ .value = 2, .deinit_calls = &calls });
+    try std.testing.expectEqual(@as(usize, 2), queue.pending());
+
+    try std.testing.expectEqual(@as(u32, 1), queue.pop().?.value);
+    try std.testing.expectEqual(@as(u32, 2), queue.pop().?.value);
+    try std.testing.expect(queue.pop() == null);
+    try std.testing.expectEqual(@as(usize, 0), queue.pending());
+}
+
+test "EventQueue deinit releases buffered events" {
+    const alloc = std.testing.allocator;
+    var calls: usize = 0;
+    var queue: EventQueue(TestEvent) = .{};
+
+    try queue.push(alloc, .{ .value = 1, .deinit_calls = &calls });
+    try queue.push(alloc, .{ .value = 2, .deinit_calls = &calls });
+    _ = queue.pop();
+    queue.deinit(alloc);
+
+    // Only the un-popped event should be released by the queue.
+    try std.testing.expectEqual(@as(usize, 1), calls);
+}
+
+test "EventQueue compacts after consuming a large prefix" {
+    const alloc = std.testing.allocator;
+    var calls: usize = 0;
+    var queue: EventQueue(TestEvent) = .{};
+    defer queue.deinit(alloc);
+
+    var i: u32 = 0;
+    while (i < compact_min_head * 2) : (i += 1) {
+        try queue.push(alloc, .{ .value = i, .deinit_calls = &calls });
+    }
+    i = 0;
+    while (i < compact_min_head) : (i += 1) _ = queue.pop();
+
+    // Head has been folded back to the front; remaining items stay in order.
+    try std.testing.expectEqual(@as(usize, compact_min_head), queue.pending());
+    try std.testing.expectEqual(@as(u32, compact_min_head), queue.pop().?.value);
+}
+
+test "EventQueue bounds pending events" {
+    const alloc = std.testing.allocator;
+    var calls: usize = 0;
+    var queue: EventQueue(TestEvent) = .{ .max_pending = 1 };
+    defer queue.deinit(alloc);
+
+    try queue.push(alloc, .{ .value = 1, .deinit_calls = &calls });
+    try std.testing.expectError(error.QueueFull, queue.push(alloc, .{ .value = 2, .deinit_calls = &calls }));
+    try std.testing.expectEqual(@as(usize, 1), queue.pending());
+}

--- a/src/discv5/kbucket.zig
+++ b/src/discv5/kbucket.zig
@@ -1,0 +1,513 @@
+//! Kademlia k-bucket routing table for discv5
+
+const std = @import("std");
+const enr_mod = @import("enr.zig");
+const NodeId = enr_mod.NodeId;
+const Address = std.Io.net.IpAddress;
+
+pub const K = 16;
+pub const NUM_BUCKETS = 256;
+pub const BUCKET_PENDING_TIMEOUT_MS: u64 = 60_000;
+
+/// Connectivity state used for bucket ordering and eviction.
+pub const EntryStatus = enum {
+    connected,
+    disconnected,
+    pending,
+};
+
+pub const Entry = struct {
+    node_id: NodeId,
+    pubkey: [33]u8 = [_]u8{0} ** 33,
+    addr: Address,
+    enr: enr_mod.RawEnr = .{},
+    enr_seq: u64 = 0,
+    last_seen: i64,
+    status: EntryStatus,
+    /// Whether this ENR may be relayed in FINDNODE responses. Set for locally
+    /// trusted entries and after authenticated traffic verifies a discovered peer.
+    relay_eligible: bool = false,
+    /// Set when the embedding application explicitly configured this node.
+    locally_trusted: bool = false,
+
+    pub fn enrBytes(self: *const Entry) []const u8 {
+        return self.enr.slice();
+    }
+};
+
+pub const InsertOutcome = struct {
+    inserted: bool,
+    pending_eviction: ?Entry = null,
+};
+
+pub const KBucket = struct {
+    entries: [K]Entry,
+    count: usize,
+    first_connected_index: ?usize,
+    pending: ?Entry,
+    pending_inserted_at_ns: i64,
+
+    pub fn init() KBucket {
+        return .{
+            .entries = undefined,
+            .count = 0,
+            .first_connected_index = null,
+            .pending = null,
+            .pending_inserted_at_ns = 0,
+        };
+    }
+
+    pub fn insert(self: *KBucket, entry: Entry) bool {
+        return self.insertDetailed(entry).inserted;
+    }
+
+    pub fn insertDetailed(self: *KBucket, entry: Entry) InsertOutcome {
+        if (self.pending) |pending| {
+            if (std.mem.eql(u8, &pending.node_id, &entry.node_id)) {
+                self.pending = entry;
+                self.pending_inserted_at_ns = entry.last_seen;
+                return .{ .inserted = true };
+            }
+        }
+
+        for (self.entries[0..self.count], 0..) |existing, i| {
+            if (!std.mem.eql(u8, &existing.node_id, &entry.node_id)) continue;
+            if (i == 0 and entry.status == .connected) {
+                self.clearPending();
+            }
+            _ = self.removeAt(i);
+            self.insertOrdered(entry);
+            return .{ .inserted = true };
+        }
+
+        if (self.count < K) {
+            self.insertOrdered(entry);
+            return .{ .inserted = true };
+        }
+
+        if (entry.status == .connected or entry.status == .pending) {
+            if (self.first_connected_index != 0 and self.pending == null) {
+                const pending_eviction = self.entries[0];
+                self.pending = entry;
+                self.pending_inserted_at_ns = entry.last_seen;
+                return .{ .inserted = false, .pending_eviction = pending_eviction };
+            }
+        }
+
+        return .{ .inserted = false };
+    }
+
+    pub fn remove(self: *KBucket, node_id: *const NodeId) bool {
+        if (self.pending) |pending| {
+            if (std.mem.eql(u8, &pending.node_id, node_id)) {
+                self.clearPending();
+                return true;
+            }
+        }
+
+        for (self.entries[0..self.count], 0..) |e, i| {
+            if (!std.mem.eql(u8, &e.node_id, node_id)) continue;
+            _ = self.removeAt(i);
+            self.maybeInsertPending();
+            return true;
+        }
+        return false;
+    }
+
+    pub fn get(self: *const KBucket, node_id: *const NodeId) ?*const Entry {
+        for (self.entries[0..self.count]) |*entry| {
+            if (std.mem.eql(u8, &entry.node_id, node_id)) return entry;
+        }
+        return null;
+    }
+
+    pub fn getWithPending(self: *const KBucket, node_id: *const NodeId) ?*const Entry {
+        if (self.get(node_id)) |entry| return entry;
+        if (self.pending) |*pending| {
+            if (std.mem.eql(u8, &pending.node_id, node_id)) return pending;
+        }
+        return null;
+    }
+
+    pub fn applyPendingIfExpired(self: *KBucket, now_ns: i64, timeout_ms: u64) bool {
+        const pending = self.pending orelse return false;
+        const elapsed_ns: i128 = @as(i128, now_ns) - @as(i128, self.pending_inserted_at_ns);
+        const timeout_ns: i128 = @as(i128, timeout_ms) * std.time.ns_per_ms;
+        if (elapsed_ns < timeout_ns) return false;
+
+        self.clearPending();
+
+        if (self.count < K) {
+            self.insertOrdered(pending);
+            return true;
+        }
+
+        if (self.first_connected_index == 0) {
+            return false;
+        }
+
+        _ = self.removeAt(0);
+        self.insertOrdered(pending);
+        return true;
+    }
+
+    fn clearPending(self: *KBucket) void {
+        self.pending = null;
+        self.pending_inserted_at_ns = 0;
+    }
+
+    fn maybeInsertPending(self: *KBucket) void {
+        if (self.count >= K) return;
+        const pending = self.pending orelse return;
+        self.clearPending();
+        self.insertOrdered(pending);
+    }
+
+    fn removeAt(self: *KBucket, index: usize) Entry {
+        const removed = self.entries[index];
+        if (index + 1 < self.count) {
+            @memmove(self.entries[index .. self.count - 1], self.entries[index + 1 .. self.count]);
+        }
+        self.count -= 1;
+
+        switch (removed.status) {
+            .connected => {
+                if (self.first_connected_index) |first| {
+                    if (first >= self.count) self.first_connected_index = null;
+                }
+            },
+            .disconnected, .pending => {
+                if (self.first_connected_index) |*first| {
+                    first.* -= 1;
+                }
+            },
+        }
+
+        return removed;
+    }
+
+    fn insertOrdered(self: *KBucket, entry: Entry) void {
+        switch (entry.status) {
+            .connected => {
+                self.entries[self.count] = entry;
+                if (self.first_connected_index == null) {
+                    self.first_connected_index = self.count;
+                }
+            },
+            .disconnected, .pending => {
+                const insert_at = self.first_connected_index orelse self.count;
+                if (insert_at < self.count) {
+                    @memmove(self.entries[insert_at + 1 .. self.count + 1], self.entries[insert_at..self.count]);
+                }
+                self.entries[insert_at] = entry;
+                if (self.first_connected_index) |*first| {
+                    first.* += 1;
+                }
+                self.count += 1;
+                return;
+            },
+        }
+        self.count += 1;
+    }
+};
+
+/// XOR distance bit index: returns 0..255 or null if equal
+pub fn logDistance(a: *const NodeId, b: *const NodeId) ?u8 {
+    for (a, b, 0..) |ab, bb, i| {
+        const xor = ab ^ bb;
+        if (xor != 0) {
+            const bit = @as(u8, 7) - @as(u8, @intCast(@clz(xor)));
+            return @as(u8, @intCast((31 - i) * 8)) + bit;
+        }
+    }
+    return null;
+}
+
+/// Raw XOR of two NodeIds
+pub fn xorDistance(a: *const NodeId, b: *const NodeId) NodeId {
+    var result: NodeId = undefined;
+    for (result[0..], a, b) |*r, aa, bb| {
+        r.* = aa ^ bb;
+    }
+    return result;
+}
+
+pub const RoutingTable = struct {
+    local_id: NodeId,
+    buckets: *[NUM_BUCKETS]KBucket,
+
+    pub fn init(alloc: std.mem.Allocator, local_id: NodeId) !RoutingTable {
+        const buckets = try alloc.create([NUM_BUCKETS]KBucket);
+        for (buckets) |*bucket| {
+            bucket.* = KBucket.init();
+        }
+        return .{
+            .local_id = local_id,
+            .buckets = buckets,
+        };
+    }
+
+    pub fn deinit(self: *RoutingTable, alloc: std.mem.Allocator) void {
+        alloc.destroy(self.buckets);
+        self.* = undefined;
+    }
+
+    pub fn insert(self: *RoutingTable, entry: Entry) bool {
+        return self.insertDetailed(entry).inserted;
+    }
+
+    pub fn insertDetailed(self: *RoutingTable, entry: Entry) InsertOutcome {
+        const dist = logDistance(&self.local_id, &entry.node_id) orelse return .{ .inserted = false };
+        return self.buckets[dist].insertDetailed(entry);
+    }
+
+    pub fn remove(self: *RoutingTable, node_id: *const NodeId) bool {
+        const dist = logDistance(&self.local_id, node_id) orelse return false;
+        return self.buckets[dist].remove(node_id);
+    }
+
+    pub fn getEntry(self: *const RoutingTable, node_id: *const NodeId) ?*const Entry {
+        const dist = logDistance(&self.local_id, node_id) orelse return null;
+        return self.buckets[dist].get(node_id);
+    }
+
+    pub fn getEntryWithPending(self: *const RoutingTable, node_id: *const NodeId) ?*const Entry {
+        const dist = logDistance(&self.local_id, node_id) orelse return null;
+        return self.buckets[dist].getWithPending(node_id);
+    }
+
+    pub fn prunePending(self: *RoutingTable, now_ns: i64, timeout_ms: u64) void {
+        for (self.buckets) |*bucket| {
+            _ = bucket.applyPendingIfExpired(now_ns, timeout_ms);
+        }
+    }
+
+    pub fn findClosest(self: *const RoutingTable, target: *const NodeId, comptime n: usize, out: *[n]Entry) usize {
+        var count: usize = 0;
+        if (n == 0) return 0;
+
+        for (self.buckets) |*bucket| {
+            for (bucket.entries[0..bucket.count]) |e| {
+                insertClosest(target, e, out[0..], &count);
+            }
+        }
+
+        return count;
+    }
+
+    pub fn getBucket(self: *const RoutingTable, distance: u8) []const Entry {
+        return self.buckets[distance].entries[0..self.buckets[distance].count];
+    }
+
+    pub fn nodeCount(self: *const RoutingTable) usize {
+        var total: usize = 0;
+        for (self.buckets) |*b| total += b.count;
+        return total;
+    }
+};
+
+fn insertClosest(target: *const NodeId, candidate: Entry, out: []Entry, count: *usize) void {
+    const candidate_distance = xorDistance(target, &candidate.node_id);
+
+    var insert_at = count.*;
+    for (out[0..count.*], 0..) |entry, i| {
+        const entry_distance = xorDistance(target, &entry.node_id);
+        if (std.mem.lessThan(u8, &candidate_distance, &entry_distance)) {
+            insert_at = i;
+            break;
+        }
+    }
+
+    if (insert_at >= out.len) return;
+
+    const new_count = if (count.* < out.len) count.* + 1 else count.*;
+    if (insert_at + 1 < new_count) {
+        @memmove(out[insert_at + 1 .. new_count], out[insert_at .. new_count - 1]);
+    }
+    out[insert_at] = candidate;
+    count.* = new_count;
+}
+
+// =========== Tests ===========
+
+test "kbucket: logDistance" {
+    const a: NodeId = [_]u8{0} ** 32;
+    var b: NodeId = [_]u8{0} ** 32;
+
+    try std.testing.expect(logDistance(&a, &b) == null);
+
+    b[31] = 1;
+    try std.testing.expectEqual(@as(?u8, 0), logDistance(&a, &b));
+
+    b[31] = 0x80;
+    try std.testing.expectEqual(@as(?u8, 7), logDistance(&a, &b));
+
+    b = [_]u8{0} ** 32;
+    b[0] = 0x80;
+    try std.testing.expectEqual(@as(?u8, 255), logDistance(&a, &b));
+}
+
+test "kbucket: routing table insert/find" {
+    const alloc = std.testing.allocator;
+    const local: NodeId = [_]u8{0xaa} ** 32;
+    var rt = try RoutingTable.init(alloc, local);
+    defer rt.deinit(alloc);
+
+    for (1..10) |i| {
+        var node_id: NodeId = [_]u8{0xaa} ** 32;
+        node_id[31] = @intCast(i);
+        const entry = Entry{
+            .node_id = node_id,
+            .addr = .{ .ip4 = .{ .bytes = .{ 127, 0, 0, 1 }, .port = 0x2328 } },
+            .last_seen = 0,
+            .status = .connected,
+        };
+        _ = rt.insert(entry);
+    }
+
+    try std.testing.expectEqual(@as(usize, 9), rt.nodeCount());
+
+    const target: NodeId = [_]u8{0xbb} ** 32;
+    var out: [5]Entry = undefined;
+    const found = rt.findClosest(&target, 5, &out);
+    try std.testing.expect(found <= 5);
+}
+
+test "kbucket: routing table findClosest uses bounded stack storage" {
+    const alloc = std.testing.allocator;
+    const local: NodeId = [_]u8{0xff} ** 32;
+    var rt = try RoutingTable.init(alloc, local);
+    defer rt.deinit(alloc);
+
+    for ([_]u8{ 4, 1, 3, 2 }) |last_byte| {
+        var node_id: NodeId = [_]u8{0} ** 32;
+        node_id[31] = last_byte;
+        try std.testing.expect(rt.insert(.{
+            .node_id = node_id,
+            .addr = .{ .ip4 = .{ .bytes = .{ 127, 0, 0, 1 }, .port = last_byte } },
+            .last_seen = 0,
+            .status = .connected,
+        }));
+    }
+
+    const target: NodeId = [_]u8{0} ** 32;
+    var out: [3]Entry = undefined;
+    const found = rt.findClosest(&target, 3, &out);
+
+    try std.testing.expectEqual(@as(usize, 3), found);
+    try std.testing.expectEqual(@as(u8, 1), out[0].node_id[31]);
+    try std.testing.expectEqual(@as(u8, 2), out[1].node_id[31]);
+    try std.testing.expectEqual(@as(u8, 3), out[2].node_id[31]);
+}
+
+test "kbucket: full bucket stores pending connected entry until timeout" {
+    var bucket = KBucket.init();
+
+    for (0..K) |i| {
+        var node_id: NodeId = [_]u8{0} ** 32;
+        node_id[31] = @intCast(i);
+        _ = bucket.insert(Entry{
+            .node_id = node_id,
+            .addr = .{ .ip4 = .{ .bytes = .{ 127, 0, 0, 1 }, .port = 0 } },
+            .last_seen = @intCast(i),
+            .status = .disconnected,
+        });
+    }
+    try std.testing.expectEqual(@as(usize, K), bucket.count);
+
+    const inserted = bucket.insert(Entry{
+        .node_id = [_]u8{0xff} ** 32,
+        .addr = .{ .ip4 = .{ .bytes = .{ 127, 0, 0, 1 }, .port = 1 } },
+        .last_seen = std.time.ns_per_ms,
+        .status = .connected,
+    });
+    try std.testing.expect(!inserted);
+    try std.testing.expect(bucket.pending != null);
+    try std.testing.expectEqualDeep([_]u8{0xff} ** 32, bucket.pending.?.node_id);
+
+    try std.testing.expect(bucket.applyPendingIfExpired(std.time.ns_per_ms * 2, 1));
+    try std.testing.expect(bucket.pending == null);
+    try std.testing.expectEqualDeep([_]u8{0xff} ** 32, bucket.entries[K - 1].node_id);
+    try std.testing.expectEqual(@as(usize, K), bucket.count);
+}
+
+test "kbucket: full bucket does not evict connected peers" {
+    var bucket = KBucket.init();
+
+    for (0..K) |i| {
+        var node_id: NodeId = [_]u8{0} ** 32;
+        node_id[31] = @intCast(i);
+        _ = bucket.insert(Entry{
+            .node_id = node_id,
+            .addr = .{ .ip4 = .{ .bytes = .{ 10, 0, 0, 1 }, .port = 0 } },
+            .last_seen = @intCast(i),
+            .status = .connected,
+        });
+    }
+
+    const inserted = bucket.insert(Entry{
+        .node_id = [_]u8{0xee} ** 32,
+        .addr = .{ .ip4 = .{ .bytes = .{ 10, 0, 0, 2 }, .port = 0 } },
+        .last_seen = -1,
+        .status = .pending,
+    });
+    try std.testing.expect(!inserted);
+    try std.testing.expect(bucket.pending == null);
+}
+
+test "kbucket: updating existing node does not grow bucket" {
+    var bucket = KBucket.init();
+    const node_id: NodeId = [_]u8{0x42} ** 32;
+
+    try std.testing.expect(bucket.insert(.{
+        .node_id = node_id,
+        .addr = .{ .ip4 = .{ .bytes = .{ 127, 0, 0, 1 }, .port = 0x2328 } },
+        .last_seen = 1,
+        .status = .pending,
+    }));
+    try std.testing.expect(bucket.insert(.{
+        .node_id = node_id,
+        .addr = .{ .ip4 = .{ .bytes = .{ 127, 0, 0, 2 }, .port = 0x2329 } },
+        .last_seen = 2,
+        .status = .connected,
+    }));
+
+    try std.testing.expectEqual(@as(usize, 1), bucket.count);
+    try std.testing.expectEqualDeep(@as(Address, .{ .ip4 = .{ .bytes = .{ 127, 0, 0, 2 }, .port = 0x2329 } }), bucket.entries[0].addr);
+    try std.testing.expectEqual(EntryStatus.connected, bucket.entries[0].status);
+}
+
+test "kbucket: reconnecting oldest entry clears pending replacement" {
+    var bucket = KBucket.init();
+
+    for (0..K) |i| {
+        var node_id: NodeId = [_]u8{0} ** 32;
+        node_id[31] = @intCast(i);
+        _ = bucket.insert(Entry{
+            .node_id = node_id,
+            .addr = .{ .ip4 = .{ .bytes = .{ 127, 0, 0, 1 }, .port = 0 } },
+            .last_seen = @intCast(i),
+            .status = .disconnected,
+        });
+    }
+
+    const pending_id: NodeId = [_]u8{0xaa} ** 32;
+    try std.testing.expect(!bucket.insert(.{
+        .node_id = pending_id,
+        .addr = .{ .ip4 = .{ .bytes = .{ 127, 0, 0, 2 }, .port = 1 } },
+        .last_seen = 100,
+        .status = .connected,
+    }));
+    try std.testing.expect(bucket.pending != null);
+
+    const oldest_id = bucket.entries[0].node_id;
+    try std.testing.expect(bucket.insert(.{
+        .node_id = oldest_id,
+        .addr = .{ .ip4 = .{ .bytes = .{ 127, 0, 0, 3 }, .port = 2 } },
+        .last_seen = 101,
+        .status = .connected,
+    }));
+
+    try std.testing.expect(bucket.pending == null);
+    try std.testing.expectEqual(EntryStatus.connected, bucket.entries[K - 1].status);
+}

--- a/src/discv5/lru.zig
+++ b/src/discv5/lru.zig
@@ -1,0 +1,309 @@
+const std = @import("std");
+const Allocator = std.mem.Allocator;
+
+pub const Error = Allocator.Error || error{
+    CapacityTooLarge,
+    ZeroCapacity,
+};
+
+pub fn LruCacheWithContext(comptime K: type, comptime V: type, comptime Context: type) type {
+    return struct {
+        map: std.HashMapUnmanaged(K, usize, Context, std.hash_map.default_max_load_percentage) = .empty,
+        nodes: []Node,
+        free_head: ?usize,
+        head: ?usize = null,
+        tail: ?usize = null,
+        len: usize = 0,
+
+        const Self = @This();
+
+        const Node = struct {
+            key: K,
+            value: V,
+            expires_at_ns: i64,
+            prev: ?usize = null,
+            next: ?usize = null,
+            free_next: ?usize = null,
+        };
+
+        pub fn init(alloc: Allocator, capacity_value: usize) Error!Self {
+            if (capacity_value == 0) return error.ZeroCapacity;
+            if (capacity_value > std.math.maxInt(u32)) return error.CapacityTooLarge;
+
+            var map: std.HashMapUnmanaged(K, usize, Context, std.hash_map.default_max_load_percentage) = .empty;
+            errdefer map.deinit(alloc);
+            try map.ensureTotalCapacity(alloc, @intCast(capacity_value));
+
+            const nodes = try alloc.alloc(Node, capacity_value);
+            errdefer alloc.free(nodes);
+            for (nodes, 0..) |*node, i| {
+                node.free_next = if (i + 1 < nodes.len) i + 1 else null;
+            }
+
+            return .{
+                .map = map,
+                .nodes = nodes,
+                .free_head = 0,
+            };
+        }
+
+        pub fn deinit(self: *Self, alloc: Allocator) void {
+            self.map.deinit(alloc);
+            alloc.free(self.nodes);
+            self.* = undefined;
+        }
+
+        pub fn count(self: *const Self) usize {
+            return self.len;
+        }
+
+        pub fn capacity(self: *const Self) usize {
+            return self.nodes.len;
+        }
+
+        pub fn get(self: *Self, key: K, now_ns: i64) ?V {
+            const index = self.map.get(key) orelse return null;
+            if (self.isExpired(index, now_ns)) {
+                self.removeIndex(index);
+                return null;
+            }
+            self.moveToFront(index);
+            return self.nodes[index].value;
+        }
+
+        pub fn put(self: *Self, key: K, value: V, ttl_ms: u64, now_ns: i64) void {
+            if (self.map.get(key)) |index| {
+                const node = &self.nodes[index];
+                node.key = key;
+                node.value = value;
+                node.expires_at_ns = expiresAt(now_ns, ttl_ms);
+                self.moveToFront(index);
+                return;
+            }
+
+            const index = self.free_head orelse self.evictTailForReuse();
+            self.free_head = self.nodes[index].free_next;
+            self.nodes[index] = .{
+                .key = key,
+                .value = value,
+                .expires_at_ns = expiresAt(now_ns, ttl_ms),
+            };
+            self.linkFront(index);
+            self.map.putAssumeCapacityNoClobber(key, index);
+            self.len += 1;
+        }
+
+        pub fn remove(self: *Self, key: K) bool {
+            const removed = self.map.fetchRemove(key) orelse return false;
+            self.unlink(removed.value);
+            self.releaseNode(removed.value);
+            self.len -= 1;
+            return true;
+        }
+
+        pub fn pruneExpired(self: *Self, now_ns: i64) void {
+            var current = self.head;
+            while (current) |index| {
+                const next = self.nodes[index].next;
+                if (self.isExpired(index, now_ns)) self.removeIndex(index);
+                current = next;
+            }
+        }
+
+        fn isExpired(self: *const Self, index: usize, now_ns: i64) bool {
+            return now_ns >= self.nodes[index].expires_at_ns;
+        }
+
+        fn removeIndex(self: *Self, index: usize) void {
+            std.debug.assert(self.map.remove(self.nodes[index].key));
+            self.unlink(index);
+            self.releaseNode(index);
+            self.len -= 1;
+        }
+
+        fn evictTailForReuse(self: *Self) usize {
+            const index = self.tail.?;
+            std.debug.assert(self.map.remove(self.nodes[index].key));
+            self.unlink(index);
+            self.len -= 1;
+            return index;
+        }
+
+        fn releaseNode(self: *Self, index: usize) void {
+            self.nodes[index].free_next = self.free_head;
+            self.nodes[index].prev = null;
+            self.nodes[index].next = null;
+            self.free_head = index;
+        }
+
+        fn moveToFront(self: *Self, index: usize) void {
+            if (self.head == index) return;
+            self.unlink(index);
+            self.linkFront(index);
+        }
+
+        fn linkFront(self: *Self, index: usize) void {
+            self.nodes[index].prev = null;
+            self.nodes[index].next = self.head;
+            if (self.head) |old_head| {
+                self.nodes[old_head].prev = index;
+            } else {
+                self.tail = index;
+            }
+            self.head = index;
+        }
+
+        fn unlink(self: *Self, index: usize) void {
+            const prev = self.nodes[index].prev;
+            const next = self.nodes[index].next;
+
+            if (prev) |prev_index| {
+                self.nodes[prev_index].next = next;
+            } else {
+                self.head = next;
+            }
+
+            if (next) |next_index| {
+                self.nodes[next_index].prev = prev;
+            } else {
+                self.tail = prev;
+            }
+
+            self.nodes[index].prev = null;
+            self.nodes[index].next = null;
+        }
+
+        fn assertInvariants(self: *const Self) void {
+            std.debug.assert(self.len == self.map.count());
+            std.debug.assert((self.len == 0) == (self.head == null));
+            std.debug.assert((self.len == 0) == (self.tail == null));
+            if (self.head) |head| std.debug.assert(self.nodes[head].prev == null);
+            if (self.tail) |tail| std.debug.assert(self.nodes[tail].next == null);
+
+            var live_count: usize = 0;
+            var previous: ?usize = null;
+            var current = self.head;
+            while (current) |index| {
+                std.debug.assert(index < self.nodes.len);
+                std.debug.assert(self.nodes[index].prev == previous);
+                std.debug.assert(self.map.get(self.nodes[index].key).? == index);
+                previous = index;
+                current = self.nodes[index].next;
+                live_count += 1;
+                std.debug.assert(live_count <= self.nodes.len);
+            }
+            std.debug.assert(live_count == self.len);
+            std.debug.assert(previous == self.tail);
+
+            var free_count: usize = 0;
+            current = self.free_head;
+            while (current) |index| {
+                std.debug.assert(index < self.nodes.len);
+                current = self.nodes[index].free_next;
+                free_count += 1;
+                std.debug.assert(free_count <= self.nodes.len);
+            }
+            std.debug.assert(live_count + free_count == self.nodes.len);
+        }
+
+        fn expectOrder(self: *const Self, expected: []const K) !void {
+            try std.testing.expectEqual(expected.len, self.len);
+            var current = self.head;
+            for (expected) |key| {
+                const index = current orelse return error.MissingLruNode;
+                try std.testing.expectEqual(key, self.nodes[index].key);
+                current = self.nodes[index].next;
+            }
+            try std.testing.expect(current == null);
+        }
+    };
+}
+
+pub fn LruCache(comptime K: type, comptime V: type) type {
+    return LruCacheWithContext(K, V, std.hash_map.AutoContext(K));
+}
+
+fn expiresAt(now_ns: i64, ttl_ms: u64) i64 {
+    const expires_at = @as(i128, now_ns) + @as(i128, ttl_ms) * std.time.ns_per_ms;
+    return if (expires_at > std.math.maxInt(i64)) std.math.maxInt(i64) else @intCast(expires_at);
+}
+
+test "lru rejects zero capacity" {
+    const Cache = LruCache(u8, u8);
+    try std.testing.expectError(error.ZeroCapacity, Cache.init(std.testing.allocator, 0));
+}
+
+test "lru get promotes and put evicts least recently used" {
+    const Cache = LruCache(u8, u64);
+    var cache = try Cache.init(std.testing.allocator, 2);
+    defer cache.deinit(std.testing.allocator);
+
+    cache.put(1, 10, 100, 0);
+    cache.put(2, 20, 100, 0);
+    cache.assertInvariants();
+    try cache.expectOrder(&.{ 2, 1 });
+
+    try std.testing.expectEqual(@as(?u64, 10), cache.get(1, 1));
+    cache.assertInvariants();
+    try cache.expectOrder(&.{ 1, 2 });
+
+    cache.put(3, 30, 100, 2);
+    cache.assertInvariants();
+    try cache.expectOrder(&.{ 3, 1 });
+    try std.testing.expectEqual(@as(?u64, null), cache.get(2, 3));
+    try std.testing.expectEqual(@as(?u64, 10), cache.get(1, 3));
+    try std.testing.expectEqual(@as(?u64, 30), cache.get(3, 3));
+}
+
+test "lru replacing a key updates value ttl and recency without growing" {
+    const Cache = LruCache(u8, u64);
+    var cache = try Cache.init(std.testing.allocator, 2);
+    defer cache.deinit(std.testing.allocator);
+
+    cache.put(1, 10, 1, 0);
+    cache.put(2, 20, 100, 0);
+    cache.put(1, 11, 100, 1);
+    cache.assertInvariants();
+
+    try std.testing.expectEqual(@as(usize, 2), cache.count());
+    try cache.expectOrder(&.{ 1, 2 });
+    try std.testing.expectEqual(@as(?u64, 11), cache.get(1, 2 * std.time.ns_per_ms));
+}
+
+test "lru expired entries are removed by get and prune" {
+    const Cache = LruCache(u8, u64);
+    var cache = try Cache.init(std.testing.allocator, 3);
+    defer cache.deinit(std.testing.allocator);
+
+    cache.put(1, 10, 1, 0);
+    cache.put(2, 20, 10, 0);
+    cache.put(3, 30, 1, 0);
+    cache.assertInvariants();
+
+    try std.testing.expectEqual(@as(?u64, null), cache.get(1, std.time.ns_per_ms));
+    cache.assertInvariants();
+    try cache.expectOrder(&.{ 3, 2 });
+
+    cache.pruneExpired(std.time.ns_per_ms);
+    cache.assertInvariants();
+    try cache.expectOrder(&.{2});
+}
+
+test "lru remove unlinks map and recency list" {
+    const Cache = LruCache(u8, u64);
+    var cache = try Cache.init(std.testing.allocator, 3);
+    defer cache.deinit(std.testing.allocator);
+
+    cache.put(1, 10, 100, 0);
+    cache.put(2, 20, 100, 0);
+    cache.put(3, 30, 100, 0);
+
+    try std.testing.expect(cache.remove(2));
+    try std.testing.expect(!cache.remove(2));
+    cache.assertInvariants();
+    try cache.expectOrder(&.{ 3, 1 });
+
+    cache.put(4, 40, 100, 0);
+    cache.assertInvariants();
+    try cache.expectOrder(&.{ 4, 3, 1 });
+}

--- a/src/discv5/metrics.zig
+++ b/src/discv5/metrics.zig
@@ -1,0 +1,101 @@
+const std = @import("std");
+const messages = @import("protocol/message.zig");
+
+/// Standalone in-memory discv5 metrics surface mirroring the ChainSafe TS
+/// `IDiscv5Metrics` names. The carve-out intentionally does not depend on a
+/// process-wide Prometheus registry; embedders can poll `MetricsSnapshot` and
+/// export these values under the documented `discv5_*` metric names.
+pub const MessageType = enum(u8) {
+    ping = messages.MSG_PING,
+    pong = messages.MSG_PONG,
+    findnode = messages.MSG_FINDNODE,
+    nodes = messages.MSG_NODES,
+    talkreq = messages.MSG_TALKREQ,
+    talkresp = messages.MSG_TALKRESP,
+
+    pub fn fromByte(byte: u8) ?MessageType {
+        // The enum is backed by the wire message-type bytes, so a valid byte
+        // maps straight to its tag.
+        return std.enums.fromInt(MessageType, byte);
+    }
+
+    pub fn label(self: MessageType) []const u8 {
+        return switch (self) {
+            .ping => "PING",
+            .pong => "PONG",
+            .findnode => "FINDNODE",
+            .nodes => "NODES",
+            .talkreq => "TALKREQ",
+            .talkresp => "TALKRESP",
+        };
+    }
+
+    pub fn index(self: MessageType) usize {
+        return switch (self) {
+            .ping => 0,
+            .pong => 1,
+            .findnode => 2,
+            .nodes => 3,
+            .talkreq => 4,
+            .talkresp => 5,
+        };
+    }
+};
+
+/// Human-readable wire name for a message-type byte, or "unknown".
+pub fn messageLabel(byte: u8) []const u8 {
+    return if (MessageType.fromByte(byte)) |t| t.label() else "unknown";
+}
+
+pub const message_type_count = @typeInfo(MessageType).@"enum".fields.len;
+
+pub const ProtocolMetrics = struct {
+    sent_message_count: [message_type_count]u64 = [_]u64{0} ** message_type_count,
+    rcvd_message_count: [message_type_count]u64 = [_]u64{0} ** message_type_count,
+
+    pub fn incSent(self: *ProtocolMetrics, message_type: MessageType) void {
+        self.sent_message_count[message_type.index()] += 1;
+    }
+
+    pub fn incReceived(self: *ProtocolMetrics, message_type: MessageType) void {
+        self.rcvd_message_count[message_type.index()] += 1;
+    }
+};
+
+pub const MetricsSnapshot = struct {
+    /// TS: discv5_kad_table_size
+    kad_table_size: usize = 0,
+    /// TS: discv5_active_session_count
+    active_session_count: usize = 0,
+    /// TS: discv5_connected_peer_count
+    connected_peer_count: usize = 0,
+    /// TS: discv5_lookup_count
+    lookup_count: u64 = 0,
+    /// TS: discv5_rate_limit_hit_ip
+    rate_limit_hit_ip: u64 = 0,
+    /// TS: discv5_rate_limit_hit_total
+    rate_limit_hit_total: u64 = 0,
+    /// TS: discv5_sent_message_count{type}
+    sent_message_count: [message_type_count]u64 = [_]u64{0} ** message_type_count,
+    /// TS: discv5_rcvd_message_count{type}
+    rcvd_message_count: [message_type_count]u64 = [_]u64{0} ** message_type_count,
+    /// Completed events dropped before reaching consumers (allocation pressure).
+    dropped_event_count: u64 = 0,
+
+    pub fn sentMessageCount(self: *const MetricsSnapshot, message_type: MessageType) u64 {
+        return self.sent_message_count[message_type.index()];
+    }
+
+    pub fn rcvdMessageCount(self: *const MetricsSnapshot, message_type: MessageType) u64 {
+        return self.rcvd_message_count[message_type.index()];
+    }
+};
+
+test "discv5 metrics message labels mirror ChainSafe TS enum labels" {
+    try std.testing.expectEqualStrings("PING", MessageType.ping.label());
+    try std.testing.expectEqualStrings("PONG", MessageType.pong.label());
+    try std.testing.expectEqualStrings("FINDNODE", MessageType.findnode.label());
+    try std.testing.expectEqualStrings("NODES", MessageType.nodes.label());
+    try std.testing.expectEqualStrings("TALKREQ", MessageType.talkreq.label());
+    try std.testing.expectEqualStrings("TALKRESP", MessageType.talkresp.label());
+}

--- a/src/discv5/protocol.zig
+++ b/src/discv5/protocol.zig
@@ -1,0 +1,2770 @@
+//! Discovery v5 protocol handler
+
+const std = @import("std");
+const scoped_log = std.log.scoped(.discv5_protocol);
+const Allocator = std.mem.Allocator;
+const NodeId = @import("enr.zig").NodeId;
+const kbucket = @import("kbucket.zig");
+const packet = @import("protocol/packet.zig");
+const session_mod = @import("protocol/session.zig");
+const messages = @import("protocol/message.zig");
+const metrics_mod = @import("metrics.zig");
+const secp = @import("secp256k1.zig");
+const protocol_events = @import("protocol/events.zig");
+const request_tracker = @import("protocol/request_tracker.zig");
+const protocol_state = @import("protocol/state.zig");
+const event_queue_mod = @import("event_queue.zig");
+const session_store_mod = @import("protocol/session_store.zig");
+const contact_book_mod = @import("protocol/contact_book.zig");
+const handshake_mod = @import("protocol/handshake.zig");
+const util = @import("util.zig");
+const Io = std.Io;
+const net = Io.net;
+const Address = net.IpAddress;
+const enr_mod = @import("enr.zig");
+
+const bindDatagramSocket = util.bindDatagramSocket;
+const shortNodeId = util.shortNodeId;
+
+pub const CHALLENGE_DATA_SIZE = packet.WHOAREYOU_CHALLENGE_DATA_SIZE;
+pub const SEEN_NONCES_CAP: usize = protocol_state.SEEN_NONCES_CAP;
+pub const SeenNonces = protocol_state.SeenNonces;
+pub const SessionRecord = protocol_state.SessionRecord;
+pub const ActiveChallenge = protocol_state.ActiveChallenge;
+pub const RequestKind = request_tracker.RequestKind;
+pub const RequestTracker = request_tracker.RequestTracker;
+pub const PongEvent = protocol_events.PongEvent;
+pub const NodesEvent = protocol_events.NodesEvent;
+pub const TalkReqEvent = protocol_events.TalkReqEvent;
+pub const TalkRespEvent = protocol_events.TalkRespEvent;
+pub const RequestTimeoutEvent = protocol_events.RequestTimeoutEvent;
+pub const Event = protocol_events.Event;
+
+const ActiveFindNodeRequest = request_tracker.ActiveFindNodeRequest;
+const ContactBook = contact_book_mod.ContactBook;
+const Endpoint = request_tracker.Endpoint;
+const PendingSessionKeys = protocol_state.PendingSessionKeys;
+const ExpiredRequest = request_tracker.ExpiredRequest;
+const SessionStore = session_store_mod.SessionStore;
+
+/// Maximum packet size per discv5 spec (IPv6 minimum MTU).
+/// Packets larger than this are dropped to prevent amplification (CL-2020-06).
+pub const MAX_PACKET_SIZE: usize = packet.MAX_PACKET_SIZE;
+
+/// Maximum number of concurrent sessions. Bounded to prevent memory exhaustion (CL-2020-01).
+pub const MAX_SESSIONS: u32 = 2_000;
+
+/// Maximum WHOAREYOU packets sent per source IP per second.
+/// Limits amplification when an attacker floods us with garbage from spoofed IPs (CL-2020-08).
+pub const MAX_WHOAREYOU_PER_SEC: u32 = 5;
+
+/// Maximum ENRs returned in a single NODES response per the discv5 spec.
+pub const MAX_NODES_RESPONSE: usize = 16;
+const MAX_NODES_ENRS_PER_PACKET: usize = @max((MAX_PACKET_SIZE - 92) / enr_mod.MAX_ENR_SIZE, 1);
+const MAX_NODES_RESPONSE_CHUNKS: usize = std.math.divCeil(usize, MAX_NODES_RESPONSE, MAX_NODES_ENRS_PER_PACKET) catch unreachable;
+const SMALL_MESSAGE_BUFFER_SIZE: usize = 128;
+const FINDNODE_MESSAGE_BUFFER_SIZE: usize = 512;
+const MAX_HANDSHAKE_AUTHDATA_SIZE: usize = 34 + 64 + 33 + enr_mod.MAX_ENR_SIZE;
+
+pub const Config = struct {
+    local_key_pair: secp.KeyPair,
+    local_node_id: NodeId,
+    /// Pre-encoded local ENR (RLP bytes). Included in handshake when remote
+    /// has a stale enr-seq.
+    local_enr: ?[]const u8 = null,
+    /// Sequence number of our local ENR.
+    local_enr_seq: u64 = 0,
+    /// Time after which outbound requests are considered failed and removed.
+    request_timeout_ms: u64 = 1_000,
+    /// Number of retry intervals before a request is failed.
+    request_retries: u32 = 1,
+    /// Maximum number of on-wire requests retained for retry/response matching.
+    max_active_requests: usize = 1024,
+    /// Maximum number of queued requests waiting behind session establishment.
+    max_queued_requests: usize = 1024,
+    /// Maximum queued requests for a single peer endpoint.
+    max_queued_requests_per_endpoint: usize = 16,
+    /// Maximum number of established sessions retained in the TTL/LRU cache.
+    session_cache_capacity: u32 = MAX_SESSIONS,
+    /// Time an established session remains in the TTL/LRU cache.
+    session_timeout_ms: u64 = 86_400_000,
+    /// Maximum number of active WHOAREYOU challenges retained for incoming handshakes.
+    challenge_cache_capacity: usize = 1_024,
+    /// Time a WHOAREYOU challenge remains usable for an incoming handshake.
+    /// TS keeps active challenges for requestTimeout * 2 by default.
+    challenge_timeout_ms: u64 = 2_000,
+    /// Maximum distinct source IPs retained by the WHOAREYOU rate limiter.
+    whoareyou_rate_capacity: usize = 4_096,
+    /// Time source IP rate-limit state remains live after its most recent attempt.
+    whoareyou_rate_ttl_ms: u64 = 60_000,
+    /// Permit sessions from peers without a verified ENR/static key. Defaults to TS behavior.
+    allow_unverified_sessions: bool = false,
+    /// Time a replacement node waits before evicting the stalest disconnected bucket entry.
+    bucket_pending_timeout_ms: u64 = kbucket.BUCKET_PENDING_TIMEOUT_MS,
+};
+
+pub const Protocol = struct {
+    alloc: Allocator,
+    io: Io,
+    config: Config,
+    routing_table: kbucket.RoutingTable,
+    session_store: SessionStore,
+    requests: RequestTracker,
+    /// Peers with enough identity/contact information to send handshakes, but
+    /// without a verified ENR suitable for the routing table.
+    contacts: ContactBook,
+    event_queue: event_queue_mod.EventQueue(Event) = .{},
+    metrics: metrics_mod.ProtocolMetrics = .{},
+
+    pub fn init(io: Io, alloc: Allocator, config: Config) !Protocol {
+        if (config.session_cache_capacity == 0 or config.session_cache_capacity > MAX_SESSIONS) {
+            return error.InvalidSessionCacheCapacity;
+        }
+
+        var routing_table = try kbucket.RoutingTable.init(alloc, config.local_node_id);
+        errdefer routing_table.deinit(alloc);
+        var session_store = try SessionStore.init(alloc, .{
+            .session_cache_capacity = config.session_cache_capacity,
+            .session_timeout_ms = config.session_timeout_ms,
+            .challenge_cache_capacity = config.challenge_cache_capacity,
+            .challenge_timeout_ms = config.challenge_timeout_ms,
+            .whoareyou_rate_capacity = config.whoareyou_rate_capacity,
+            .whoareyou_rate_ttl_ms = config.whoareyou_rate_ttl_ms,
+            .max_whoareyou_per_sec = MAX_WHOAREYOU_PER_SEC,
+        });
+        errdefer session_store.deinit(alloc);
+
+        scoped_log.debug(
+            "protocol init node={s} sessions={d} challenges={d} active_requests={d} queued_requests={d}",
+            .{
+                &shortNodeId(&config.local_node_id),
+                config.session_cache_capacity,
+                config.challenge_cache_capacity,
+                config.max_active_requests,
+                config.max_queued_requests,
+            },
+        );
+
+        return .{
+            .alloc = alloc,
+            .io = io,
+            .config = config,
+            .routing_table = routing_table,
+            .session_store = session_store,
+            .requests = RequestTracker.init(alloc, .{
+                .max_active_requests = config.max_active_requests,
+                .max_queued_requests = config.max_queued_requests,
+                .max_queued_requests_per_endpoint = config.max_queued_requests_per_endpoint,
+            }),
+            .contacts = ContactBook.init(alloc, config.local_node_id, config.session_cache_capacity),
+            .event_queue = .{},
+            .metrics = .{},
+        };
+    }
+
+    pub fn deinit(self: *Protocol) void {
+        self.requests.deinit();
+        self.session_store.deinit(self.alloc);
+        self.contacts.deinit();
+        self.event_queue.deinit(self.alloc);
+        self.routing_table.deinit(self.alloc);
+    }
+
+    pub fn metricsSnapshot(self: *const Protocol) metrics_mod.ProtocolMetrics {
+        return self.metrics;
+    }
+
+    fn noteSentMessage(self: *Protocol, msg_bytes: []const u8) void {
+        if (msg_bytes.len == 0) return;
+        if (metrics_mod.MessageType.fromByte(msg_bytes[0])) |message_type| {
+            self.metrics.incSent(message_type);
+        }
+    }
+
+    fn noteReceivedMessage(self: *Protocol, msg_bytes: []const u8) void {
+        if (msg_bytes.len == 0) return;
+        if (metrics_mod.MessageType.fromByte(msg_bytes[0])) |message_type| {
+            self.metrics.incReceived(message_type);
+        }
+    }
+
+    fn getSessionCopy(self: *Protocol, node_id: *const NodeId, addr: Address) ?SessionRecord {
+        return self.session_store.getSession(.{ .node_id = node_id.*, .addr = addr }, self.currentTimestampNs());
+    }
+
+    fn putSession(self: *Protocol, node_id: *const NodeId, addr: Address, session: SessionRecord) void {
+        self.session_store.putSession(.{ .node_id = node_id.*, .addr = addr }, session, self.currentTimestampNs());
+    }
+
+    pub fn activeSessionCount(self: *Protocol) usize {
+        return self.session_store.sessionCount(self.currentTimestampNs());
+    }
+
+    fn getChallengeCopy(self: *Protocol, node_id: *const NodeId, addr: Address) ?ActiveChallenge {
+        return self.session_store.getChallenge(.{ .node_id = node_id.*, .addr = addr }, self.currentTimestampNs());
+    }
+
+    fn putChallenge(self: *Protocol, node_id: *const NodeId, addr: Address, challenge: ActiveChallenge) void {
+        self.session_store.putChallenge(.{ .node_id = node_id.*, .addr = addr }, challenge, self.currentTimestampNs());
+    }
+
+    fn deleteChallenge(self: *Protocol, node_id: *const NodeId, addr: Address) bool {
+        return self.session_store.removeChallenge(.{ .node_id = node_id.*, .addr = addr });
+    }
+
+    pub fn randomNonce(self: *Protocol) [12]u8 {
+        var nonce: [12]u8 = undefined;
+        self.io.random(&nonce);
+        return nonce;
+    }
+
+    pub fn randomReqId(self: *Protocol) messages.ReqId {
+        var id: messages.ReqId = .{ .bytes = [_]u8{0} ** 8, .len = 4 };
+        self.io.random(id.bytes[0..4]);
+        return id;
+    }
+
+    pub fn popEvent(self: *Protocol) ?Event {
+        return self.event_queue.pop();
+    }
+
+    pub const KnownNode = struct {
+        node_id: NodeId,
+        pubkey: [33]u8,
+        addr: Address,
+    };
+
+    pub fn getKnownNode(self: *const Protocol, node_id: *const NodeId) ?KnownNode {
+        if (self.routing_table.getEntryWithPending(node_id)) |entry| {
+            return .{
+                .node_id = entry.node_id,
+                .pubkey = entry.pubkey,
+                .addr = entry.addr,
+            };
+        }
+        if (self.contacts.get(node_id.*)) |contact| {
+            return .{
+                .node_id = node_id.*,
+                .pubkey = contact.pubkey,
+                .addr = contact.addr,
+            };
+        }
+        return null;
+    }
+
+    pub fn findEnr(self: *const Protocol, node_id: *const NodeId) ?[]const u8 {
+        const entry = self.routing_table.getEntryWithPending(node_id) orelse return null;
+        return entry.enr.slice();
+    }
+
+    pub fn hasActiveFindNodeRequest(self: *const Protocol, peer_id: *const NodeId) bool {
+        return self.requests.hasActiveFindNodeRequest(peer_id);
+    }
+
+    pub fn pruneExpiredState(self: *Protocol) void {
+        const now_ns = self.currentTimestampNs();
+        self.pruneExpiredRequests(now_ns);
+        self.routing_table.prunePending(now_ns, self.config.bucket_pending_timeout_ms);
+    }
+
+    pub fn sendPing(
+        self: *Protocol,
+        dest_node_id: *const NodeId,
+        dest_pubkey: *const [33]u8,
+        dest_addr: Address,
+        enr_seq: u64,
+        socket: *const net.Socket,
+    ) !messages.ReqId {
+        self.pruneExpiredState();
+        const req_id = self.randomReqId();
+        const ping = messages.Ping{
+            .req_id = req_id,
+            .enr_seq = enr_seq,
+        };
+        var ping_buf: [SMALL_MESSAGE_BUFFER_SIZE]u8 = undefined;
+        const ping_bytes = try ping.encodeInto(&ping_buf);
+
+        try self.sendRequest(dest_node_id, dest_pubkey, dest_addr, req_id, .ping, &.{}, ping_bytes, socket);
+        return req_id;
+    }
+
+    pub fn sendFindNode(
+        self: *Protocol,
+        dest_node_id: *const NodeId,
+        dest_pubkey: *const [33]u8,
+        dest_addr: Address,
+        distances: []const u16,
+        socket: *const net.Socket,
+    ) !messages.ReqId {
+        self.pruneExpiredState();
+        const req_id = self.randomReqId();
+        const find_node = messages.FindNode{
+            .req_id = req_id,
+            .distances = distances,
+        };
+        var find_node_buf: [FINDNODE_MESSAGE_BUFFER_SIZE]u8 = undefined;
+        const find_node_bytes = try find_node.encodeInto(&find_node_buf);
+
+        try self.sendRequest(dest_node_id, dest_pubkey, dest_addr, req_id, .findnode, distances, find_node_bytes, socket);
+        return req_id;
+    }
+
+    pub fn sendTalkRequest(
+        self: *Protocol,
+        dest_node_id: *const NodeId,
+        dest_pubkey: *const [33]u8,
+        dest_addr: Address,
+        protocol_name: []const u8,
+        request: []const u8,
+        socket: *const net.Socket,
+    ) !messages.ReqId {
+        self.pruneExpiredState();
+        const req_id = self.randomReqId();
+        const talk_req = messages.TalkReq{
+            .req_id = req_id,
+            .protocol = protocol_name,
+            .request = request,
+        };
+        var talk_req_buf: [MAX_PACKET_SIZE]u8 = undefined;
+        const talk_req_bytes = try talk_req.encodeInto(&talk_req_buf);
+
+        try self.sendRequest(dest_node_id, dest_pubkey, dest_addr, req_id, .talkreq, &.{}, talk_req_bytes, socket);
+        return req_id;
+    }
+
+    pub fn sendTalkResponse(
+        self: *Protocol,
+        peer_id: NodeId,
+        peer_addr: Address,
+        req_id: messages.ReqId,
+        response: []const u8,
+        socket: *const net.Socket,
+    ) !void {
+        const talk_resp = messages.TalkResp{
+            .req_id = req_id,
+            .response = response,
+        };
+        var talk_resp_buf: [MAX_PACKET_SIZE]u8 = undefined;
+        const talk_resp_bytes = try talk_resp.encodeInto(&talk_resp_buf);
+        try self.sendResponseMessage(peer_id, peer_addr, talk_resp_bytes, socket);
+    }
+
+    /// Send a request to a remote node. If we have an established session,
+    /// the message is encrypted and sent immediately. Otherwise, we send an
+    /// ordinary message (which will likely be challenged with WHOAREYOU) and
+    /// store the request as pending so we can re-send it in the handshake.
+    pub fn sendRequest(
+        self: *Protocol,
+        dest_node_id: *const NodeId,
+        dest_pubkey: *const [33]u8,
+        dest_addr: Address,
+        req_id: messages.ReqId,
+        request_kind: RequestKind,
+        distances: []const u16,
+        msg_bytes: []const u8,
+        socket: *const net.Socket,
+    ) !void {
+        const endpoint = Endpoint{ .node_id = dest_node_id.*, .addr = dest_addr };
+
+        // If a session is already being established for this endpoint, queue the
+        // request behind it instead of opening a second handshake.
+        if (self.getSessionCopy(dest_node_id, dest_addr) == null and self.requests.shouldQueueForEndpoint(endpoint)) {
+            scoped_log.debug("queueing {s} request req_id={x} to {any}; session establishment already in progress", .{
+                @tagName(request_kind),
+                req_id.slice(),
+                dest_addr,
+            });
+            try self.requests.queueRequest(
+                endpoint,
+                dest_pubkey,
+                req_id,
+                request_kind,
+                distances,
+                msg_bytes,
+                self.currentTimestampNs(),
+            );
+            return;
+        }
+
+        try self.dispatchOutbound(endpoint, dest_pubkey, req_id, request_kind, distances, msg_bytes, socket);
+    }
+
+    /// Encode, track, and transmit a request to `endpoint`: an authenticated
+    /// ordinary message when a session exists, otherwise an unauthenticated probe
+    /// to provoke a WHOAREYOU. On any failure the active-request entry is rolled
+    /// back and the error is propagated so the caller can apply its own policy
+    /// (fail-fast for fresh sends, re-queue for drained sends).
+    fn dispatchOutbound(
+        self: *Protocol,
+        endpoint: Endpoint,
+        dest_pubkey: *const [33]u8,
+        req_id: messages.ReqId,
+        request_kind: RequestKind,
+        distances: []const u16,
+        msg_bytes: []const u8,
+        socket: *const net.Socket,
+    ) !void {
+        var pkt_buf: [MAX_PACKET_SIZE]u8 = undefined;
+        if (self.getSessionCopy(&endpoint.node_id, endpoint.addr)) |s| {
+            scoped_log.debug("sending {s} request req_id={x} to {any} using established session", .{
+                @tagName(request_kind),
+                req_id.slice(),
+                endpoint.addr,
+            });
+            const encoded = try self.encodeMessageInto(&pkt_buf, &endpoint.node_id, &s.initiator_key, msg_bytes);
+            try self.requests.putActiveAwaitingResponseWithChallenge(
+                endpoint,
+                req_id,
+                request_kind,
+                distances,
+                socket,
+                encoded.pkt,
+                self.currentTimestampNs(),
+                encoded.nonce,
+                dest_pubkey,
+                msg_bytes,
+            );
+            errdefer self.requests.cancelActive(endpoint, req_id);
+            try socket.send(self.io, &endpoint.addr, encoded.pkt);
+            self.noteSentMessage(msg_bytes);
+            return;
+        }
+
+        // No established session — send an unauthenticated probe to provoke a
+        // WHOAREYOU; the original plaintext is retransmitted in the handshake.
+        const probe = try self.encodeProbePacketInto(&pkt_buf, &endpoint.node_id, msg_bytes);
+        try self.requests.putActiveProbe(
+            endpoint,
+            req_id,
+            request_kind,
+            distances,
+            socket,
+            probe.pkt,
+            self.currentTimestampNs(),
+            probe.nonce,
+            dest_pubkey,
+            msg_bytes,
+        );
+        errdefer self.requests.cancelActive(endpoint, req_id);
+        try socket.send(self.io, &endpoint.addr, probe.pkt);
+        scoped_log.debug("sent unauthenticated {s} probe req_id={x} to {any} (msg_len={d})", .{
+            @tagName(request_kind),
+            req_id.slice(),
+            endpoint.addr,
+            msg_bytes.len,
+        });
+    }
+
+    /// Handle an incoming raw UDP packet.
+    /// Packet decoding unmasks the header in `raw` in place; callers should not
+    /// reuse the same buffer expecting the original masked wire bytes.
+    pub fn handlePacket(
+        self: *Protocol,
+        raw: []u8,
+        from: Address,
+        socket: *const net.Socket,
+    ) !void {
+        // Drop oversized packets before any decoding work (CL-2020-06, spec max = IPv6 min MTU).
+        if (raw.len > MAX_PACKET_SIZE) {
+            scoped_log.debug("dropping oversized packet len={d} from {any}", .{ raw.len, from });
+            return;
+        }
+
+        var parsed = packet.decode(raw, &self.config.local_node_id) catch |err| {
+            scoped_log.debug("dropping undecodable packet len={d} from {any}: {}", .{ raw.len, from, err });
+            return;
+        };
+
+        switch (parsed.static_header.flag) {
+            packet.FLAG_MESSAGE => try self.handleMessage(&parsed, from, socket),
+            packet.FLAG_WHOAREYOU => try self.handleWhoareyou(&parsed, from, socket),
+            packet.FLAG_HANDSHAKE => try self.handleHandshake(&parsed, from, socket),
+            else => scoped_log.debug("dropping packet with unknown flag={d} from {any}", .{ parsed.static_header.flag, from }),
+        }
+    }
+
+    fn handleMessage(
+        self: *Protocol,
+        parsed: *packet.ParsedPacket,
+        from: Address,
+        socket: *const net.Socket,
+    ) !void {
+        const authdata = parsed.authdata_raw;
+        if (authdata.len < 32) {
+            scoped_log.debug("dropping MESSAGE with short authdata len={d} from {any}", .{ authdata.len, from });
+            return;
+        }
+        const src_id: NodeId = authdata[0..32].*;
+
+        if (self.getSessionCopy(&src_id, from)) |session_copy| {
+            var s = session_copy;
+            // Replay protection: drop packets with a nonce we've already processed.
+            if (s.seen_nonces.contains(&parsed.static_header.nonce)) {
+                scoped_log.debug("dropping replayed MESSAGE nonce from node={s} addr={any}", .{
+                    &shortNodeId(&src_id),
+                    from,
+                });
+                return;
+            }
+            var plaintext_buf: [MAX_PACKET_SIZE]u8 = undefined;
+            var ad_buf: [MAX_PACKET_SIZE]u8 = undefined;
+            const decrypt_result = packet.decryptMessageInto(
+                &plaintext_buf,
+                &ad_buf,
+                &s.recipient_key,
+                &parsed.static_header.nonce,
+                parsed.message_ciphertext,
+                &parsed.masking_iv,
+                parsed.header_raw,
+            ) catch blk: {
+                if (s.awaiting_recipient_key) |awaiting_key| {
+                    const pt2 = packet.decryptMessageInto(
+                        &plaintext_buf,
+                        &ad_buf,
+                        &awaiting_key,
+                        &parsed.static_header.nonce,
+                        parsed.message_ciphertext,
+                        &parsed.masking_iv,
+                        parsed.header_raw,
+                    ) catch break :blk null;
+                    s.recipient_key = awaiting_key;
+                    if (s.awaiting_initiator_key) |awaiting_initiator| s.initiator_key = awaiting_initiator;
+                    s.awaiting_recipient_key = null;
+                    s.awaiting_initiator_key = null;
+                    scoped_log.debug("activated pending session keys for node={s} addr={any}", .{
+                        &shortNodeId(&src_id),
+                        from,
+                    });
+                    break :blk pt2;
+                }
+                break :blk null;
+            };
+            const pt = decrypt_result orelse {
+                scoped_log.debug("failed to decrypt MESSAGE from node={s} addr={any}; sending WHOAREYOU", .{
+                    &shortNodeId(&src_id),
+                    from,
+                });
+                try self.sendWhoareyou(src_id, &parsed.static_header.nonce, from, socket);
+                return;
+            };
+            // Record nonce only after successful decryption.
+            s.seen_nonces.insert(&parsed.static_header.nonce);
+            self.putSession(&src_id, from, s);
+            self.markNodeSeenAndPingEvictionCandidate(src_id, from, socket);
+            try self.dispatchMessage(pt, src_id, from, socket);
+            return;
+        }
+
+        const endpoint = Endpoint{ .node_id = src_id, .addr = from };
+        if (self.requests.pendingSessionKeysForEndpoint(endpoint)) |pending_session| {
+            var plaintext_buf: [MAX_PACKET_SIZE]u8 = undefined;
+            var ad_buf: [MAX_PACKET_SIZE]u8 = undefined;
+            const pt = packet.decryptMessageInto(
+                &plaintext_buf,
+                &ad_buf,
+                &pending_session.recipient_key,
+                &parsed.static_header.nonce,
+                parsed.message_ciphertext,
+                &parsed.masking_iv,
+                parsed.header_raw,
+            ) catch null;
+            if (pt) |plaintext| {
+                var s = SessionRecord{
+                    .node_id = src_id,
+                    .initiator_key = pending_session.initiator_key,
+                    .recipient_key = pending_session.recipient_key,
+                    .seen_nonces = SeenNonces.init(),
+                };
+                s.seen_nonces.insert(&parsed.static_header.nonce);
+                self.putSession(&src_id, from, s);
+                self.markNodeSeenAndPingEvictionCandidate(src_id, from, socket);
+                scoped_log.debug("accepted first response with pending session keys from node={s} addr={any}", .{
+                    &shortNodeId(&src_id),
+                    from,
+                });
+                try self.dispatchMessage(plaintext, src_id, from, socket);
+                return;
+            }
+        }
+
+        scoped_log.debug("MESSAGE from node={s} addr={any} has no usable session; sending WHOAREYOU", .{
+            &shortNodeId(&src_id),
+            from,
+        });
+        try self.sendWhoareyou(src_id, &parsed.static_header.nonce, from, socket);
+    }
+
+    /// Handle a WHOAREYOU challenge from a remote node.
+    ///
+    /// When we send an ordinary message to a node that has no session with us,
+    /// it responds with WHOAREYOU. We respond with a Handshake packet containing:
+    ///
+    ///   1. `id-signature` over SHA256(prefix || challenge_data || eph_pubkey || dest_node_id)
+    ///   2. `eph-pubkey` — an ephemeral secp256k1 public key
+    ///   3. Optional ENR if the remote's `enr-seq` field is stale
+    ///   4. The original message, encrypted with newly derived session keys
+    fn handleWhoareyou(
+        self: *Protocol,
+        parsed: *packet.ParsedPacket,
+        from: Address,
+        socket: *const net.Socket,
+    ) !void {
+        const authdata = parsed.authdata_raw;
+        // WHOAREYOU authdata = id_nonce (16) || enr_seq (8).
+        if (authdata.len != packet.WHOAREYOU_AUTHDATA_SIZE) {
+            scoped_log.debug("dropping WHOAREYOU with bad authdata len={d} from {any}", .{ authdata.len, from });
+            return;
+        }
+
+        // The nonce in the WHOAREYOU static header is the nonce of the message
+        // packet that triggered the challenge — use it to find our pending request.
+        const request_nonce = parsed.static_header.nonce;
+
+        const probe = self.requests.probeForChallenge(&request_nonce, from) orelse {
+            scoped_log.debug("WHOAREYOU for unknown nonce (pending={d}, nonce={s}, from={any})", .{
+                self.requests.pendingCount(),
+                &std.fmt.bytesToHex(request_nonce, .lower),
+                from,
+            });
+            return;
+        };
+        const probe_node_id = probe.endpoint.node_id;
+        const probe_addr = probe.endpoint.addr;
+
+        // Parse enr_seq from authdata to validate the WHOAREYOU layout.
+        const remote_enr_seq = std.mem.readInt(u64, authdata[16..24], .big);
+        scoped_log.debug("accepted WHOAREYOU for {s} req_id={x} from {any} remote_enr_seq={d}", .{
+            @tagName(probe.request_kind),
+            probe.req_id.slice(),
+            from,
+            remote_enr_seq,
+        });
+
+        // challenge_data = masking_iv || plaintext_static_header || plaintext_authdata.
+        var challenge_data: [CHALLENGE_DATA_SIZE]u8 = undefined;
+        @memcpy(challenge_data[0..16], &parsed.masking_iv);
+        @memcpy(challenge_data[16..], parsed.header_raw);
+
+        const eph_key_pair = secp.KeyPair.generate(self.io);
+        const eph_pubkey = secp.compressedPubkey(&eph_key_pair);
+
+        // Derive session keys: ECDH(ephemeral keypair, dest_pubkey) -> HKDF
+        // node_id_a = our node_id (initiator), node_id_b = dest_node_id
+        const keys = session_mod.deriveKeys(
+            &eph_key_pair,
+            probe.dest_pubkey,
+            &self.config.local_node_id,
+            &probe_node_id,
+            &challenge_data,
+        ) catch |err| {
+            scoped_log.debug("failed to derive initiator session keys for {any}: {}", .{ from, err });
+            return;
+        };
+
+        // Compute id-nonce signature.
+        const id_sig = session_mod.signIdNonce(
+            &self.config.local_key_pair,
+            &challenge_data,
+            &eph_pubkey,
+            &probe_node_id,
+        ) catch |err| {
+            scoped_log.debug("failed to sign id nonce for {any}: {}", .{ from, err });
+            return;
+        };
+
+        // Include our ENR only when the remote says it is stale, matching the TS session service.
+        const include_enr = self.config.local_enr != null and remote_enr_seq < self.config.local_enr_seq;
+        const enr_bytes: []const u8 = if (include_enr) self.config.local_enr.? else &[_]u8{};
+
+        var handshake_authdata_buf: [MAX_HANDSHAKE_AUTHDATA_SIZE]u8 = undefined;
+        const handshake_authdata = handshake_mod.buildAuthdata(
+            &handshake_authdata_buf,
+            self.config.local_node_id,
+            &id_sig,
+            &eph_pubkey,
+            enr_bytes,
+        ) catch |err| {
+            scoped_log.debug("failed to build handshake authdata for {any}: {}", .{ from, err });
+            return err;
+        };
+
+        const nonce = self.randomNonce();
+        var masking_iv: [16]u8 = undefined;
+        self.io.random(&masking_iv);
+
+        var handshake_pkt_buf: [MAX_PACKET_SIZE]u8 = undefined;
+        const handshake_pkt = try packet.encodeMessagePacketInto(&handshake_pkt_buf, .{
+            .kind = .handshake,
+            .masking_iv = &masking_iv,
+            .recipient_node_id = &probe_node_id,
+            .nonce = &nonce,
+            .authdata = handshake_authdata,
+            .write_key = &keys.initiator_key,
+            .plaintext = probe.plaintext,
+        });
+
+        const pending_session = PendingSessionKeys{
+            .initiator_key = keys.initiator_key,
+            .recipient_key = keys.recipient_key,
+        };
+
+        var restore_session: ?SessionRecord = null;
+        if (self.getSessionCopy(&probe_node_id, probe_addr)) |existing_session| {
+            restore_session = existing_session;
+            var session = existing_session;
+            session.awaiting_initiator_key = keys.initiator_key;
+            session.awaiting_recipient_key = keys.recipient_key;
+            self.putSession(&probe_node_id, probe_addr, session);
+        }
+        errdefer if (restore_session) |session| {
+            self.putSession(&probe_node_id, probe_addr, session);
+        };
+
+        try socket.send(self.io, &from, handshake_pkt);
+        self.requests.acceptChallenge(
+            probe.key,
+            &request_nonce,
+            from,
+            handshake_pkt,
+            pending_session,
+            self.currentTimestampNs(),
+        ) catch |err| {
+            scoped_log.debug("failed to accept WHOAREYOU challenge from {any}: {}", .{ from, err });
+            return err;
+        };
+        scoped_log.debug("sent handshake to {any} for {s} req_id={x} include_enr={}", .{
+            from,
+            @tagName(probe.request_kind),
+            probe.req_id.slice(),
+            include_enr,
+        });
+    }
+
+    fn handleHandshake(
+        self: *Protocol,
+        parsed: *packet.ParsedPacket,
+        from: Address,
+        socket: *const net.Socket,
+    ) !void {
+        const ad = handshake_mod.parseAuthdata(parsed.authdata_raw) catch |err| {
+            scoped_log.debug("dropping malformed HANDSHAKE from {any}: {}", .{ from, err });
+            return;
+        };
+        const src_id = ad.src_id;
+
+        const active_challenge = self.getChallengeCopy(&src_id, from) orelse {
+            scoped_log.debug("dropping HANDSHAKE with no active challenge from node={s} addr={any}", .{
+                &shortNodeId(&src_id),
+                from,
+            });
+            return;
+        };
+
+        const challenge = active_challenge.challenge_data[0..];
+        const maybe_enr = ad.maybe_enr;
+
+        // Resolve the sender's static public key: prefer a known peer, otherwise
+        // the optional ENR appended to the handshake authdata.
+        const sender_pubkey: [33]u8 = if (self.getKnownNode(&src_id)) |known| known.pubkey else blk: {
+            const enr_bytes = maybe_enr orelse {
+                scoped_log.debug("handshake from unknown peer {any} with no ENR, rejecting", .{src_id});
+                return;
+            };
+            const pk = handshake_mod.pubkeyFromEnr(enr_bytes, src_id) catch |err| {
+                scoped_log.debug("handshake ENR from {any} rejected: {}", .{ src_id, err });
+                return;
+            };
+            handshake_mod.verifyEnrEndpoint(enr_bytes, src_id, from, self.config.allow_unverified_sessions) catch |err| {
+                scoped_log.debug("handshake ENR endpoint check for {any} failed: {}", .{ src_id, err });
+                return;
+            };
+            break :blk pk;
+        };
+
+        // Endpoint-verify the advertised ENR (the optional record, else the one
+        // cached with the challenge) regardless of whether the sender was known.
+        if (maybe_enr) |enr_bytes| {
+            handshake_mod.verifyEnrEndpoint(enr_bytes, src_id, from, self.config.allow_unverified_sessions) catch |err| {
+                scoped_log.debug("handshake optional ENR endpoint check for node={s} addr={any} failed: {}", .{ &shortNodeId(&src_id), from, err });
+                return;
+            };
+        } else if (active_challenge.remote_enr) |remote_enr| {
+            handshake_mod.verifyEnrEndpoint(remote_enr[0..active_challenge.remote_enr_len], src_id, from, self.config.allow_unverified_sessions) catch |err| {
+                scoped_log.debug("cached challenge ENR endpoint check for node={s} addr={any} failed: {}", .{ &shortNodeId(&src_id), from, err });
+                return;
+            };
+        }
+
+        // Verify id-signature: SHA256("discovery v5 identity proof" || challenge_data || eph_pubkey || local_node_id)
+        session_mod.verifyIdSignature(ad.id_sig, &sender_pubkey, challenge, ad.eph_pubkey, &self.config.local_node_id) catch {
+            scoped_log.debug("handshake id-signature verification failed for {any}, rejecting", .{src_id});
+            return;
+        };
+
+        const keys = session_mod.deriveKeys(
+            &self.config.local_key_pair,
+            ad.eph_pubkey,
+            &src_id,
+            &self.config.local_node_id,
+            challenge,
+        ) catch |err| {
+            scoped_log.debug("failed to derive recipient session keys for node={s} addr={any}: {}", .{
+                &shortNodeId(&src_id),
+                from,
+                err,
+            });
+            return;
+        };
+
+        const existing_session = self.getSessionCopy(&src_id, from);
+
+        var plaintext_buf: [MAX_PACKET_SIZE]u8 = undefined;
+        var ad_buf: [MAX_PACKET_SIZE]u8 = undefined;
+        const pt = packet.decryptMessageInto(
+            &plaintext_buf,
+            &ad_buf,
+            &keys.initiator_key,
+            &parsed.static_header.nonce,
+            parsed.message_ciphertext,
+            &parsed.masking_iv,
+            parsed.header_raw,
+        ) catch |err| {
+            scoped_log.debug("failed to decrypt HANDSHAKE message from node={s} addr={any}: {}", .{
+                &shortNodeId(&src_id),
+                from,
+                err,
+            });
+            return;
+        };
+
+        var new_session = existing_session orelse SessionRecord{
+            .node_id = src_id,
+            .initiator_key = keys.recipient_key,
+            .recipient_key = keys.initiator_key,
+            .seen_nonces = SeenNonces.init(),
+        };
+        if (new_session.seen_nonces.contains(&parsed.static_header.nonce)) {
+            scoped_log.debug("dropping replayed HANDSHAKE nonce from node={s} addr={any}", .{
+                &shortNodeId(&src_id),
+                from,
+            });
+            return;
+        }
+        new_session.initiator_key = keys.recipient_key;
+        new_session.recipient_key = keys.initiator_key;
+        new_session.awaiting_initiator_key = null;
+        new_session.awaiting_recipient_key = null;
+        new_session.seen_nonces.insert(&parsed.static_header.nonce);
+
+        _ = self.deleteChallenge(&src_id, from);
+        self.putSession(&src_id, from, new_session);
+
+        if (maybe_enr) |enr_bytes| {
+            const entry = self.entryFromEnr(enr_bytes, .connected, from);
+            if (entry) |routing_entry| {
+                _ = self.insertEnrEntry(routing_entry);
+            } else {
+                self.contacts.remember(src_id, &sender_pubkey, from);
+            }
+        } else {
+            self.contacts.remember(src_id, &sender_pubkey, from);
+        }
+        self.markNodeSeenAndPingEvictionCandidate(src_id, from, socket);
+        scoped_log.debug("handshake established with node={s} addr={any} supplied_enr={}", .{
+            &shortNodeId(&src_id),
+            from,
+            maybe_enr != null,
+        });
+        try self.dispatchMessage(pt, src_id, from, socket);
+    }
+
+    fn allowWhoareyou(self: *Protocol, dest: Address) bool {
+        return self.session_store.allowWhoareyou(dest, self.currentTimestampNs());
+    }
+
+    fn sendWhoareyou(
+        self: *Protocol,
+        src_id: NodeId,
+        request_nonce: *const [12]u8,
+        dest: Address,
+        socket: *const net.Socket,
+    ) !void {
+        // Keep the first live challenge for an endpoint. Replacing it based on
+        // another unauthenticated packet lets source-spoofed traffic invalidate
+        // the legitimate peer's in-flight identity proof.
+        if (self.getChallengeCopy(&src_id, dest) != null) return;
+        if (!self.allowWhoareyou(dest)) return;
+
+        // Established-session capacity and tail eviction are handled by the session LRU.
+        var id_nonce: [16]u8 = undefined;
+        self.io.random(&id_nonce);
+
+        var masking_iv: [16]u8 = undefined;
+        self.io.random(&masking_iv);
+
+        var challenge = ActiveChallenge{ .challenge_data = undefined };
+
+        var remote_enr_seq: u64 = 0;
+        if (self.routing_table.getEntry(&src_id)) |entry| {
+            const remote_enr = entry.enrBytes();
+            remote_enr_seq = entry.enr_seq;
+            if (remote_enr.len <= enr_mod.MAX_ENR_SIZE) {
+                var copy: [enr_mod.MAX_ENR_SIZE]u8 = undefined;
+                @memcpy(copy[0..remote_enr.len], remote_enr);
+                challenge.remote_enr = copy;
+                challenge.remote_enr_len = @intCast(remote_enr.len);
+            }
+        }
+
+        var whoareyou_buf: [packet.WHOAREYOU_CHALLENGE_DATA_SIZE]u8 = undefined;
+        const whoareyou_packet = try packet.encodeWhoareyouPacketInto(&whoareyou_buf, .{
+            .masking_iv = &masking_iv,
+            .recipient_node_id = &src_id,
+            .request_nonce = request_nonce,
+            .id_nonce = &id_nonce,
+            .enr_seq = remote_enr_seq,
+        }, &challenge.challenge_data);
+        self.putChallenge(&src_id, dest, challenge);
+
+        try socket.send(self.io, &dest, whoareyou_packet);
+        scoped_log.debug("sent WHOAREYOU to node={s} addr={any} known_enr_seq={d}", .{
+            &shortNodeId(&src_id),
+            dest,
+            remote_enr_seq,
+        });
+    }
+
+    fn sendOrdinaryMessage(
+        self: *Protocol,
+        dest_node_id: *const NodeId,
+        write_key: *const [16]u8,
+        dest_addr: Address,
+        msg_bytes: []const u8,
+        socket: *const net.Socket,
+    ) !void {
+        var pkt_buf: [MAX_PACKET_SIZE]u8 = undefined;
+        const encoded = try self.encodeMessageInto(&pkt_buf, dest_node_id, write_key, msg_bytes);
+
+        try socket.send(self.io, &dest_addr, encoded.pkt);
+        self.noteSentMessage(msg_bytes);
+    }
+
+    const EncodedMessage = struct {
+        pkt: []u8,
+        nonce: [packet.NONCE_SIZE]u8,
+    };
+
+    /// Encode an ordinary message packet under `write_key` into `out`, returning
+    /// the packet bytes and the message nonce.
+    fn encodeMessageInto(
+        self: *Protocol,
+        out: []u8,
+        dest_node_id: *const NodeId,
+        write_key: *const [16]u8,
+        msg_bytes: []const u8,
+    ) !EncodedMessage {
+        const nonce = self.randomNonce();
+        var masking_iv: [16]u8 = undefined;
+        self.io.random(&masking_iv);
+        const authdata: [32]u8 = self.config.local_node_id;
+
+        const pkt = try packet.encodeMessagePacketInto(out, .{
+            .kind = .ordinary,
+            .masking_iv = &masking_iv,
+            .recipient_node_id = dest_node_id,
+            .nonce = &nonce,
+            .authdata = &authdata,
+            .write_key = write_key,
+            .plaintext = msg_bytes,
+        });
+        return .{ .pkt = pkt, .nonce = nonce };
+    }
+
+    /// Encode an unauthenticated probe: the real request encrypted under a
+    /// random throwaway key. The peer cannot decrypt it and should answer with
+    /// WHOAREYOU, after which the original plaintext is retransmitted inside the
+    /// authenticated handshake. The returned nonce is recorded to match the
+    /// WHOAREYOU challenge.
+    fn encodeProbePacketInto(
+        self: *Protocol,
+        out: []u8,
+        dest_node_id: *const NodeId,
+        msg_bytes: []const u8,
+    ) !EncodedMessage {
+        var fake_key: [16]u8 = undefined;
+        self.io.random(&fake_key);
+        return self.encodeMessageInto(out, dest_node_id, &fake_key, msg_bytes);
+    }
+
+    fn entryFromEnr(
+        self: *Protocol,
+        enr_bytes: []const u8,
+        status: kbucket.EntryStatus,
+        contact_addr: ?Address,
+    ) ?kbucket.Entry {
+        const parsed_enr = enr_mod.decode(enr_bytes) catch return null;
+        const node_id = parsed_enr.nodeId() orelse return null;
+        if (std.mem.eql(u8, &node_id, &self.config.local_node_id)) return null;
+        const pubkey = parsed_enr.pubkey orelse return null;
+        const addr = contact_addr orelse parsed_enr.udpAddress() orelse return null;
+        const raw = enr_mod.RawEnr.init(enr_bytes) catch return null;
+
+        return .{
+            .node_id = node_id,
+            .pubkey = pubkey,
+            .addr = addr,
+            .enr = raw,
+            .enr_seq = parsed_enr.seq,
+            .last_seen = self.currentTimestampNs(),
+            .status = status,
+        };
+    }
+
+    fn insertEnrEntry(self: *Protocol, incoming: kbucket.Entry) ?kbucket.Entry {
+        var entry = incoming;
+        if (self.routing_table.getEntryWithPending(&entry.node_id)) |existing| {
+            if (existing.enr_seq >= entry.enr_seq) {
+                scoped_log.debug("ignored stale ENR for node={s} known_seq={d} incoming_seq={d}", .{
+                    &shortNodeId(&entry.node_id),
+                    existing.enr_seq,
+                    entry.enr_seq,
+                });
+                return null;
+            }
+            // Local trust applies to the node identity, so preserve it when a
+            // newer, correctly signed ENR is learned through the network.
+            entry.locally_trusted = existing.locally_trusted;
+        }
+        self.contacts.forget(entry.node_id);
+        scoped_log.debug("inserted ENR for node={s} addr={any} seq={d} status={s}", .{
+            &shortNodeId(&entry.node_id),
+            entry.addr,
+            entry.enr_seq,
+            @tagName(entry.status),
+        });
+        return self.routing_table.insertDetailed(entry).pending_eviction;
+    }
+
+    fn appendRequestTimeout(self: *Protocol, expired: ExpiredRequest) void {
+        scoped_log.debug("request timed out kind={s} req_id={x} node={s} addr={any}", .{
+            @tagName(expired.kind),
+            expired.req_id.slice(),
+            &shortNodeId(&expired.endpoint.node_id),
+            expired.endpoint.addr,
+        });
+        self.event_queue.push(self.alloc, .{
+            .request_timeout = .{
+                .peer_id = expired.endpoint.node_id,
+                .req_id = expired.req_id,
+                .kind = expired.kind,
+            },
+        }) catch {};
+    }
+
+    fn pruneExpiredRequests(self: *Protocol, now_ns: i64) void {
+        var expired: std.ArrayListUnmanaged(ExpiredRequest) = .empty;
+        defer expired.deinit(self.alloc);
+
+        self.requests.pruneExpiredActive(
+            self.io,
+            now_ns,
+            self.config.request_timeout_ms,
+            self.config.request_retries,
+            &expired,
+        ) catch |err| {
+            scoped_log.debug("failed to prune active requests: {}", .{err});
+            return;
+        };
+
+        const active_expired_len = expired.items.len;
+        var i: usize = 0;
+        while (i < active_expired_len) : (i += 1) {
+            if (expired.items[i].socket) |socket| {
+                const endpoint = expired.items[i].endpoint;
+                self.sendNextQueuedRequest(&endpoint.node_id, endpoint.addr, socket);
+            }
+        }
+
+        self.requests.pruneExpiredQueued(now_ns, self.config.request_timeout_ms, &expired) catch |err| {
+            scoped_log.debug("failed to prune queued requests: {}", .{err});
+            return;
+        };
+
+        for (expired.items) |request| self.appendRequestTimeout(request);
+    }
+
+    fn restoreQueuedRequest(self: *Protocol, intent: request_tracker.RequestIntent) void {
+        self.requests.pushFrontQueued(intent) catch {
+            scoped_log.debug("failed to restore queued request kind={s} req_id={x} node={s} addr={any}; timing out", .{
+                @tagName(intent.request_kind),
+                intent.req_id.slice(),
+                &shortNodeId(&intent.endpoint.node_id),
+                intent.endpoint.addr,
+            });
+            self.appendRequestTimeout(.{
+                .endpoint = intent.endpoint,
+                .req_id = intent.req_id,
+                .kind = intent.request_kind,
+            });
+        };
+    }
+
+    fn sendNextQueuedRequest(self: *Protocol, peer_id: *const NodeId, peer_addr: Address, socket: *const net.Socket) void {
+        const endpoint = Endpoint{ .node_id = peer_id.*, .addr = peer_addr };
+        const intent = (self.requests.popNextQueued(endpoint) catch |err| {
+            scoped_log.debug("failed to pop queued request for node={s} addr={any}: {}", .{
+                &shortNodeId(peer_id),
+                peer_addr,
+                err,
+            });
+            return;
+        }) orelse return;
+
+        // A drained request has nowhere left to wait: on any failure, push it back
+        // to the front of the queue (or time it out) rather than dropping it.
+        self.dispatchOutbound(
+            intent.endpoint,
+            &intent.dest_pubkey,
+            intent.req_id,
+            intent.request_kind,
+            intent.distances(),
+            intent.plaintextSlice(),
+            socket,
+        ) catch |err| {
+            scoped_log.debug("failed to dispatch queued {s} request req_id={x} to {any}: {}", .{
+                @tagName(intent.request_kind),
+                intent.req_id.slice(),
+                peer_addr,
+                err,
+            });
+            self.restoreQueuedRequest(intent);
+        };
+    }
+
+    fn currentTimestampNs(self: *const Protocol) i64 {
+        return util.nowNs(self.io);
+    }
+
+    fn markNodeSeen(self: *Protocol, node_id: NodeId, addr: Address, status: kbucket.EntryStatus) ?kbucket.Entry {
+        var entry = (self.routing_table.getEntryWithPending(&node_id) orelse return null).*;
+        entry.addr = addr;
+        entry.last_seen = self.currentTimestampNs();
+        entry.status = status;
+        const parsed = enr_mod.decode(entry.enrBytes()) catch return null;
+        const advertised_addr = switch (addr) {
+            .ip4 => parsed.udpAddress4(),
+            .ip6 => parsed.udpAddress6(),
+        };
+        entry.relay_eligible = if (advertised_addr) |advertised| Address.eql(&advertised, &addr) else false;
+        return self.routing_table.insertDetailed(entry).pending_eviction;
+    }
+
+    fn markNodeSeenAndPingEvictionCandidate(
+        self: *Protocol,
+        node_id: NodeId,
+        addr: Address,
+        socket: *const net.Socket,
+    ) void {
+        const candidate = self.markNodeSeen(node_id, addr, .connected) orelse return;
+        const known = self.getKnownNode(&candidate.node_id) orelse return;
+        scoped_log.debug("node={s} addr={any} became connected; pinging pending eviction candidate node={s} addr={any}", .{
+            &shortNodeId(&node_id),
+            addr,
+            &shortNodeId(&candidate.node_id),
+            candidate.addr,
+        });
+        _ = self.sendPing(&known.node_id, &known.pubkey, candidate.addr, self.config.local_enr_seq, socket) catch {};
+    }
+
+    fn rememberEnr(self: *Protocol, enr_bytes: []const u8) void {
+        const entry = self.entryFromEnr(enr_bytes, .disconnected, null) orelse return;
+        _ = self.insertEnrEntry(entry);
+    }
+
+    fn enrMatchesFindNodeRequest(
+        enr_bytes: []const u8,
+        responder_id: *const NodeId,
+        request: *const ActiveFindNodeRequest,
+    ) bool {
+        const parsed_enr = enr_mod.decode(enr_bytes) catch return false;
+        const node_id = parsed_enr.nodeId() orelse return false;
+        const wire_distance: u16 = if (kbucket.logDistance(&node_id, responder_id)) |distance|
+            @as(u16, distance) + 1
+        else
+            0;
+        for (request.requested_distances[0..request.requested_distances_len]) |requested| {
+            if (requested == wire_distance) return true;
+        }
+        return false;
+    }
+
+    fn knownEnrSeq(self: *Protocol, peer_id: NodeId) ?u64 {
+        const entry = self.routing_table.getEntry(&peer_id) orelse return null;
+        return entry.enr_seq;
+    }
+
+    fn maybeRequestEnrUpdate(
+        self: *Protocol,
+        peer_id: NodeId,
+        peer_addr: Address,
+        advertised_seq: u64,
+        socket: *const net.Socket,
+    ) void {
+        const known_seq = self.knownEnrSeq(peer_id) orelse return;
+        if (known_seq >= advertised_seq) return;
+        if (self.hasActiveFindNodeRequest(&peer_id)) return;
+        const known = self.getKnownNode(&peer_id) orelse return;
+        const distances = [_]u16{0};
+        scoped_log.debug("peer node={s} advertised newer ENR seq known={d} advertised={d}; requesting ENR", .{
+            &shortNodeId(&peer_id),
+            known_seq,
+            advertised_seq,
+        });
+        _ = self.sendFindNode(&peer_id, &known.pubkey, peer_addr, &distances, socket) catch {};
+    }
+
+    fn sendResponseMessage(
+        self: *Protocol,
+        peer_id: NodeId,
+        peer_addr: Address,
+        plaintext: []const u8,
+        socket: *const net.Socket,
+    ) !void {
+        const s = self.getSessionCopy(&peer_id, peer_addr) orelse return;
+        scoped_log.debug("sending {s} response to node={s} addr={any}", .{
+            if (plaintext.len == 0) "empty" else metrics_mod.messageLabel(plaintext[0]),
+            &shortNodeId(&peer_id),
+            peer_addr,
+        });
+        try self.sendOrdinaryMessage(&peer_id, &s.initiator_key, peer_addr, plaintext, socket);
+    }
+
+    fn dispatchMessage(
+        self: *Protocol,
+        pt: []const u8,
+        from: NodeId,
+        from_addr: Address,
+        socket: *const net.Socket,
+    ) !void {
+        if (pt.len == 0) {
+            scoped_log.debug("dropping empty plaintext message from node={s} addr={any}", .{
+                &shortNodeId(&from),
+                from_addr,
+            });
+            return;
+        }
+        scoped_log.debug("dispatching {s} from node={s} addr={any} len={d}", .{
+            metrics_mod.messageLabel(pt[0]),
+            &shortNodeId(&from),
+            from_addr,
+            pt.len,
+        });
+        switch (pt[0]) {
+            messages.MSG_PING => try self.handlePing(pt, from, from_addr, socket),
+            messages.MSG_PONG => self.handlePong(pt, from, from_addr, socket),
+            messages.MSG_FINDNODE => try self.handleFindNode(pt, from, from_addr, socket),
+            messages.MSG_NODES => self.handleNodes(pt, from, from_addr, socket),
+            messages.MSG_TALKREQ => self.handleTalkReq(pt, from, from_addr, socket),
+            messages.MSG_TALKRESP => self.handleTalkResp(pt, from, from_addr, socket),
+            else => scoped_log.debug("ignoring unknown message type=0x{x:0>2} from node={s} addr={any}", .{
+                pt[0],
+                &shortNodeId(&from),
+                from_addr,
+            }),
+        }
+    }
+
+    fn handlePing(
+        self: *Protocol,
+        pt: []const u8,
+        from: NodeId,
+        from_addr: Address,
+        socket: *const net.Socket,
+    ) !void {
+        const ping = messages.Ping.decode(pt) catch |err| {
+            scoped_log.debug("failed to decode PING from node={s} addr={any}: {}", .{
+                &shortNodeId(&from),
+                from_addr,
+                err,
+            });
+            return;
+        };
+        self.noteReceivedMessage(pt);
+        scoped_log.debug("received PING req_id={x} from node={s} addr={any} enr_seq={d}", .{
+            ping.req_id.slice(),
+            &shortNodeId(&from),
+            from_addr,
+            ping.enr_seq,
+        });
+        self.maybeRequestEnrUpdate(from, from_addr, ping.enr_seq, socket);
+
+        const pong = messages.Pong{
+            .req_id = ping.req_id,
+            .enr_seq = self.config.local_enr_seq,
+            .recipient_ip = switch (from_addr) {
+                .ip4 => |ip4| .{ .ip4 = ip4.bytes },
+                .ip6 => |ip6| .{ .ip6 = ip6.bytes },
+            },
+            .recipient_port = from_addr.getPort(),
+        };
+
+        var pong_buf: [SMALL_MESSAGE_BUFFER_SIZE]u8 = undefined;
+        const pong_bytes = try pong.encodeInto(&pong_buf);
+        try self.sendResponseMessage(from, from_addr, pong_bytes, socket);
+    }
+
+    fn handlePong(
+        self: *Protocol,
+        pt: []const u8,
+        from: NodeId,
+        from_addr: Address,
+        socket: *const net.Socket,
+    ) void {
+        const pong = messages.Pong.decode(pt) catch |err| {
+            scoped_log.debug("failed to decode PONG from node={s} addr={any}: {}", .{
+                &shortNodeId(&from),
+                from_addr,
+                err,
+            });
+            return;
+        };
+        self.noteReceivedMessage(pt);
+        const endpoint = Endpoint{ .node_id = from, .addr = from_addr };
+        var request = self.requests.finishActiveExpectingKind(endpoint, pong.req_id, .ping) orelse {
+            scoped_log.debug("received PONG with no matching PING request req_id={x} from node={s} addr={any}", .{
+                pong.req_id.slice(),
+                &shortNodeId(&from),
+                from_addr,
+            });
+            return;
+        };
+        defer request.deinit(self.alloc);
+
+        self.markNodeSeenAndPingEvictionCandidate(from, from_addr, socket);
+        scoped_log.debug("received PONG req_id={x} from node={s} addr={any} enr_seq={d}", .{
+            pong.req_id.slice(),
+            &shortNodeId(&from),
+            from_addr,
+            pong.enr_seq,
+        });
+        self.event_queue.push(self.alloc, .{
+            .pong = .{
+                .peer_id = from,
+                .peer_addr = from_addr,
+                .req_id = pong.req_id,
+                .enr_seq = pong.enr_seq,
+                .recipient_ip = pong.recipient_ip,
+                .recipient_port = pong.recipient_port,
+            },
+        }) catch {};
+        self.sendNextQueuedRequest(&from, from_addr, socket);
+    }
+
+    fn handleFindNode(
+        self: *Protocol,
+        pt: []const u8,
+        from: NodeId,
+        from_addr: Address,
+        socket: *const net.Socket,
+    ) !void {
+        var distances_buf: [127]u16 = undefined;
+        const fn_msg = messages.FindNode.decodeInto(pt, &distances_buf) catch |err| {
+            scoped_log.debug("failed to decode FINDNODE from node={s} addr={any}: {}", .{
+                &shortNodeId(&from),
+                from_addr,
+                err,
+            });
+            return;
+        };
+        self.noteReceivedMessage(pt);
+
+        var seen_distances = [_]bool{false} ** 257;
+        var enr_refs_buf: [MAX_NODES_RESPONSE][]const u8 = undefined;
+        var enr_refs = std.ArrayListUnmanaged([]const u8).initBuffer(&enr_refs_buf);
+        for (fn_msg.distances) |dist| {
+            if (!markFindNodeDistance(&seen_distances, dist)) continue;
+            if (enr_refs.items.len >= enr_refs.capacity) break;
+            if (dist == 0) {
+                if (self.config.local_enr) |local_enr| {
+                    enr_refs.appendAssumeCapacity(local_enr);
+                }
+                continue;
+            }
+            if (dist > 256) continue;
+            const entries = self.routing_table.getBucket(@intCast(dist - 1));
+            for (entries) |*entry| {
+                if (!entry.locally_trusted and !entry.relay_eligible) continue;
+                enr_refs.appendAssumeCapacity(entry.enrBytes());
+                if (enr_refs.items.len >= enr_refs.capacity) break;
+            }
+        }
+
+        const total_chunks: u64 = @max(@as(u64, @intCast(std.math.divCeil(usize, enr_refs.items.len, MAX_NODES_ENRS_PER_PACKET) catch 0)), 1);
+        scoped_log.debug("received FINDNODE req_id={x} from node={s} addr={any} distances={d} response_enrs={d} chunks={d}", .{
+            fn_msg.req_id.slice(),
+            &shortNodeId(&from),
+            from_addr,
+            fn_msg.distances.len,
+            enr_refs.items.len,
+            total_chunks,
+        });
+        var chunk_index: usize = 0;
+        while (chunk_index < total_chunks) : (chunk_index += 1) {
+            const start = chunk_index * MAX_NODES_ENRS_PER_PACKET;
+            const end = @min(start + MAX_NODES_ENRS_PER_PACKET, enr_refs.items.len);
+            const nodes_msg = messages.Nodes{
+                .req_id = fn_msg.req_id,
+                .total = total_chunks,
+                .enrs = enr_refs.items[start..end],
+            };
+            var nodes_buf: [MAX_PACKET_SIZE]u8 = undefined;
+            const nodes_bytes = try nodes_msg.encodeInto(&nodes_buf);
+            try self.sendResponseMessage(from, from_addr, nodes_bytes, socket);
+        }
+    }
+
+    fn handleNodes(
+        self: *Protocol,
+        pt: []const u8,
+        from: NodeId,
+        from_addr: Address,
+        socket: *const net.Socket,
+    ) void {
+        var enrs_buf: [MAX_NODES_RESPONSE][]const u8 = undefined;
+        const decoded = messages.Nodes.decodeInto(pt, &enrs_buf) catch |err| {
+            scoped_log.debug("failed to decode NODES from node={s} addr={any}: {}", .{
+                &shortNodeId(&from),
+                from_addr,
+                err,
+            });
+            return;
+        };
+
+        if (decoded.total == 0) {
+            scoped_log.debug("dropping NODES with total=0 from node={s} addr={any}", .{
+                &shortNodeId(&from),
+                from_addr,
+            });
+            return;
+        }
+        self.noteReceivedMessage(pt);
+
+        const endpoint = Endpoint{ .node_id = from, .addr = from_addr };
+        const request = self.requests.getActivePtr(endpoint, decoded.req_id) orelse {
+            scoped_log.debug("received NODES for unknown request req_id={x} from node={s} addr={any}", .{
+                decoded.req_id.slice(),
+                &shortNodeId(&from),
+                from_addr,
+            });
+            return;
+        };
+        if (request.kind != .findnode) {
+            scoped_log.debug("received NODES for non-FINDNODE request req_id={x} from node={s} addr={any}", .{
+                decoded.req_id.slice(),
+                &shortNodeId(&from),
+                from_addr,
+            });
+            return;
+        }
+
+        var findnode = &request.kind.findnode;
+        const accepted_total = @min(decoded.total, @as(u64, MAX_NODES_RESPONSE_CHUNKS));
+        if (findnode.total_responses == null) {
+            findnode.total_responses = accepted_total;
+        } else if (findnode.total_responses.? != accepted_total) {
+            scoped_log.debug("dropping NODES with inconsistent total req_id={x} from node={s} addr={any} expected={d} got={d}", .{
+                decoded.req_id.slice(),
+                &shortNodeId(&from),
+                from_addr,
+                findnode.total_responses.?,
+                accepted_total,
+            });
+            return;
+        }
+
+        var accepted_enrs: usize = 0;
+        for (decoded.enrs) |enr| {
+            if (findnode.enrs.items.len >= MAX_NODES_RESPONSE) break;
+            if (!enrMatchesFindNodeRequest(enr, &from, findnode)) continue;
+            self.rememberEnr(enr);
+            const enr_copy = self.alloc.dupe(u8, enr) catch continue;
+            findnode.enrs.append(self.alloc, enr_copy) catch {
+                self.alloc.free(enr_copy);
+                continue;
+            };
+            accepted_enrs += 1;
+        }
+        findnode.responses_received += 1;
+        self.markNodeSeenAndPingEvictionCandidate(from, from_addr, socket);
+        scoped_log.debug("received NODES chunk {d}/{d} req_id={x} from node={s} addr={any} decoded_enrs={d} accepted_enrs={d}", .{
+            findnode.responses_received,
+            findnode.total_responses.?,
+            decoded.req_id.slice(),
+            &shortNodeId(&from),
+            from_addr,
+            decoded.enrs.len,
+            accepted_enrs,
+        });
+
+        if (findnode.responses_received < findnode.total_responses.?) return;
+
+        var completed = self.requests.finishActive(endpoint, decoded.req_id) orelse return;
+        defer completed.deinit(self.alloc);
+        if (completed.kind != .findnode) return;
+
+        const owned_enrs = completed.kind.findnode.enrs.toOwnedSlice(self.alloc) catch return;
+        completed.kind.findnode.enrs = .empty;
+        self.event_queue.push(self.alloc, .{
+            .nodes = .{
+                .peer_id = from,
+                .peer_addr = from_addr,
+                .req_id = decoded.req_id,
+                .enrs = owned_enrs,
+            },
+        }) catch {
+            for (owned_enrs) |enr| self.alloc.free(enr);
+            self.alloc.free(owned_enrs);
+        };
+        self.sendNextQueuedRequest(&from, from_addr, socket);
+        scoped_log.debug("completed NODES response req_id={x} from node={s} addr={any} with {d} ENRs", .{
+            decoded.req_id.slice(),
+            &shortNodeId(&from),
+            from_addr,
+            owned_enrs.len,
+        });
+    }
+
+    fn handleTalkReq(
+        self: *Protocol,
+        pt: []const u8,
+        from: NodeId,
+        from_addr: Address,
+        socket: *const net.Socket,
+    ) void {
+        const talk_req = messages.TalkReq.decode(pt) catch |err| {
+            scoped_log.debug("failed to decode TALKREQ from node={s} addr={any}: {}", .{
+                &shortNodeId(&from),
+                from_addr,
+                err,
+            });
+            return;
+        };
+        self.noteReceivedMessage(pt);
+        const protocol_name = self.alloc.dupe(u8, talk_req.protocol) catch return;
+        const request = self.alloc.dupe(u8, talk_req.request) catch {
+            self.alloc.free(protocol_name);
+            return;
+        };
+
+        self.markNodeSeenAndPingEvictionCandidate(from, from_addr, socket);
+        scoped_log.debug("received TALKREQ req_id={x} from node={s} addr={any} protocol={s} request_len={d}", .{
+            talk_req.req_id.slice(),
+            &shortNodeId(&from),
+            from_addr,
+            talk_req.protocol,
+            talk_req.request.len,
+        });
+        self.event_queue.push(self.alloc, .{
+            .talkreq = .{
+                .peer_id = from,
+                .peer_addr = from_addr,
+                .req_id = talk_req.req_id,
+                .protocol = protocol_name,
+                .request = request,
+            },
+        }) catch {
+            self.alloc.free(protocol_name);
+            self.alloc.free(request);
+        };
+    }
+
+    fn handleTalkResp(
+        self: *Protocol,
+        pt: []const u8,
+        from: NodeId,
+        from_addr: Address,
+        socket: *const net.Socket,
+    ) void {
+        const talk_resp = messages.TalkResp.decode(pt) catch |err| {
+            scoped_log.debug("failed to decode TALKRESP from node={s} addr={any}: {}", .{
+                &shortNodeId(&from),
+                from_addr,
+                err,
+            });
+            return;
+        };
+        self.noteReceivedMessage(pt);
+        const endpoint = Endpoint{ .node_id = from, .addr = from_addr };
+        var request = self.requests.finishActiveExpectingKind(endpoint, talk_resp.req_id, .talkreq) orelse {
+            scoped_log.debug("received TALKRESP with no matching TALKREQ request req_id={x} from node={s} addr={any}", .{
+                talk_resp.req_id.slice(),
+                &shortNodeId(&from),
+                from_addr,
+            });
+            return;
+        };
+        defer request.deinit(self.alloc);
+
+        const response = self.alloc.dupe(u8, talk_resp.response) catch return;
+
+        self.markNodeSeenAndPingEvictionCandidate(from, from_addr, socket);
+        scoped_log.debug("received TALKRESP req_id={x} from node={s} addr={any} response_len={d}", .{
+            talk_resp.req_id.slice(),
+            &shortNodeId(&from),
+            from_addr,
+            talk_resp.response.len,
+        });
+        self.event_queue.push(self.alloc, .{
+            .talkresp = .{
+                .peer_id = from,
+                .peer_addr = from_addr,
+                .req_id = talk_resp.req_id,
+                .response = response,
+            },
+        }) catch self.alloc.free(response);
+        self.sendNextQueuedRequest(&from, from_addr, socket);
+    }
+
+    pub fn addNode(self: *Protocol, node_id: NodeId, pubkey: ?*const [33]u8, addr: Address, enr: ?[]const u8) void {
+        if (enr) |enr_bytes| {
+            if (self.entryFromEnr(enr_bytes, .disconnected, addr)) |decoded_entry| {
+                var entry = decoded_entry;
+                if (!std.mem.eql(u8, &entry.node_id, &node_id)) {
+                    scoped_log.debug("ignoring addNode ENR/node-id mismatch expected={s} got={s} addr={any}", .{
+                        &shortNodeId(&node_id),
+                        &shortNodeId(&entry.node_id),
+                        addr,
+                    });
+                    return;
+                }
+                if (pubkey) |pk| {
+                    if (!std.mem.eql(u8, &entry.pubkey, pk)) {
+                        scoped_log.debug("ignoring addNode ENR/pubkey mismatch node={s} addr={any}", .{
+                            &shortNodeId(&node_id),
+                            addr,
+                        });
+                        return;
+                    }
+                }
+                // addNode is a local trust decision (for example, a configured
+                // bootnode), unlike ENRs learned from an untrusted NODES reply.
+                // Promote an equal/newer record already learned for this node;
+                // the normal ENR insertion path intentionally ignores stale or
+                // equal sequences and would otherwise lose the trust decision.
+                if (self.routing_table.getEntryWithPending(&node_id)) |existing| {
+                    if (existing.enr_seq >= entry.enr_seq) {
+                        var trusted = existing.*;
+                        trusted.locally_trusted = true;
+                        trusted.relay_eligible = true;
+                        _ = self.routing_table.insertDetailed(trusted);
+                        return;
+                    }
+                }
+                entry.locally_trusted = true;
+                entry.relay_eligible = true;
+                _ = self.insertEnrEntry(entry);
+                return;
+            }
+            scoped_log.debug("addNode ENR was unusable; falling back to contact node={s} addr={any}", .{
+                &shortNodeId(&node_id),
+                addr,
+            });
+        }
+        self.contacts.remember(node_id, pubkey, addr);
+    }
+};
+
+fn markFindNodeDistance(seen: *[257]bool, distance: u16) bool {
+    if (distance > 256 or seen[distance]) return false;
+    seen[distance] = true;
+    return true;
+}
+
+// =========== Tests ===========
+
+test "maximum NODES response fits the accepted chunk bound" {
+    const required = try std.math.divCeil(usize, MAX_NODES_RESPONSE, MAX_NODES_ENRS_PER_PACKET);
+    try std.testing.expect(required <= MAX_NODES_RESPONSE_CHUNKS);
+}
+
+test "FINDNODE distance deduplication accepts each valid distance once" {
+    var seen = [_]bool{false} ** 257;
+    try std.testing.expect(markFindNodeDistance(&seen, 0));
+    try std.testing.expect(!markFindNodeDistance(&seen, 0));
+    try std.testing.expect(markFindNodeDistance(&seen, 256));
+    try std.testing.expect(!markFindNodeDistance(&seen, 256));
+    try std.testing.expect(!markFindNodeDistance(&seen, 257));
+}
+
+test "discv5 protocol: basic init" {
+    const alloc = std.testing.allocator;
+    const io = std.Options.debug_io;
+    const hex = @import("hex");
+
+    const sk = hex.hexToBytesComptime(32, "eef77acb6c6a6eebc5b363a475ac583ec7eccdb42b6481424c60f59aa326547f");
+    const key_pair = try secp.keyPairFromSecret(&sk);
+    const pk = secp.compressedPubkey(&key_pair);
+    const node_id = @import("enr.zig").nodeIdFromCompressedPubkey(&pk);
+
+    var proto = try Protocol.init(io, alloc, .{
+        .local_key_pair = key_pair,
+        .local_node_id = node_id,
+    });
+    defer proto.deinit();
+
+    try std.testing.expectEqual(@as(usize, 0), proto.routing_table.nodeCount());
+
+    var node_id2: NodeId = [_]u8{0xbb} ** 32;
+    node_id2[31] = 0x01;
+    proto.addNode(node_id2, null, .{ .ip4 = .{ .bytes = .{ 192, 168, 1, 1 }, .port = 30303 } }, null);
+    try std.testing.expectEqual(@as(usize, 0), proto.routing_table.nodeCount());
+}
+
+test "discv5 protocol: session cache capacity is bounded" {
+    const alloc = std.testing.allocator;
+    const io = std.Options.debug_io;
+    const hex = @import("hex");
+
+    const secret_key = hex.hexToBytesComptime(32, "eef77acb6c6a6eebc5b363a475ac583ec7eccdb42b6481424c60f59aa326547f");
+    const key_pair = try secp.keyPairFromSecret(&secret_key);
+    const pubkey = secp.compressedPubkey(&key_pair);
+    const node_id = enr_mod.nodeIdFromCompressedPubkey(&pubkey);
+
+    const default_config = Config{ .local_key_pair = key_pair, .local_node_id = node_id };
+    try std.testing.expectEqual(MAX_SESSIONS, default_config.session_cache_capacity);
+
+    try std.testing.expectError(error.InvalidSessionCacheCapacity, Protocol.init(io, alloc, .{
+        .local_key_pair = key_pair,
+        .local_node_id = node_id,
+        .session_cache_capacity = 0,
+    }));
+    try std.testing.expectError(error.InvalidSessionCacheCapacity, Protocol.init(io, alloc, .{
+        .local_key_pair = key_pair,
+        .local_node_id = node_id,
+        .session_cache_capacity = MAX_SESSIONS + 1,
+    }));
+}
+
+test "discv5 protocol metrics classify sent and received message counters" {
+    const alloc = std.testing.allocator;
+    const io = std.Options.debug_io;
+
+    const sk = [_]u8{0x01} ** 32;
+    const key_pair = try secp.keyPairFromSecret(&sk);
+    const pk = secp.compressedPubkey(&key_pair);
+    const node_id = enr_mod.nodeIdFromCompressedPubkey(&pk);
+
+    var proto = try Protocol.init(io, alloc, .{
+        .local_key_pair = key_pair,
+        .local_node_id = node_id,
+    });
+    defer proto.deinit();
+
+    proto.noteSentMessage(&[_]u8{ messages.MSG_PING, 0x00 });
+    proto.noteSentMessage(&[_]u8{ messages.MSG_TALKRESP, 0x00 });
+
+    var socket = try bindDatagramSocket(io, .{ .ip4 = .{ .bytes = .{ 127, 0, 0, 1 }, .port = 0 } });
+    defer socket.close(io);
+    try proto.dispatchMessage(&[_]u8{messages.MSG_PING}, node_id, socket.address, &socket);
+    try proto.dispatchMessage(&[_]u8{0xff}, node_id, socket.address, &socket);
+
+    const valid_ping = messages.Ping{
+        .req_id = try messages.ReqId.fromSlice(&[_]u8{0x01}),
+        .enr_seq = 1,
+    };
+    const valid_ping_bytes = try valid_ping.encode(alloc);
+    defer alloc.free(valid_ping_bytes);
+    try proto.dispatchMessage(valid_ping_bytes, node_id, socket.address, &socket);
+
+    const snapshot = proto.metricsSnapshot();
+    try std.testing.expectEqual(@as(u64, 1), snapshot.sent_message_count[metrics_mod.MessageType.ping.index()]);
+    try std.testing.expectEqual(@as(u64, 1), snapshot.sent_message_count[metrics_mod.MessageType.talkresp.index()]);
+    try std.testing.expectEqual(@as(u64, 1), snapshot.rcvd_message_count[metrics_mod.MessageType.ping.index()]);
+    try std.testing.expectEqual(@as(u64, 0), snapshot.rcvd_message_count[metrics_mod.MessageType.talkreq.index()]);
+}
+
+test "discv5 protocol: WHOAREYOU handshake round-trip" {
+    // Simulate: node A sends request -> node B responds WHOAREYOU -> node A
+    //           builds handshake -> node B receives and establishes session.
+    const alloc = std.testing.allocator;
+    const io = std.Options.debug_io;
+    const hex = @import("hex");
+
+    // Node A keys
+    const sk_a = hex.hexToBytesComptime(32, "eef77acb6c6a6eebc5b363a475ac583ec7eccdb42b6481424c60f59aa326547f");
+    const key_pair_a = try secp.keyPairFromSecret(&sk_a);
+    const pk_a = secp.compressedPubkey(&key_pair_a);
+    const node_id_a = enr_mod.nodeIdFromCompressedPubkey(&pk_a);
+
+    // Node B keys
+    const sk_b = hex.hexToBytesComptime(32, "66fb62bfbd66b9177a138c1e5cddbe4f7c30c343e94e68df8769459cb14571f7");
+    const key_pair_b = try secp.keyPairFromSecret(&sk_b);
+    const pk_b = secp.compressedPubkey(&key_pair_b);
+    const node_id_b = enr_mod.nodeIdFromCompressedPubkey(&pk_b);
+
+    var socket_a = try bindDatagramSocket(io, .{ .ip4 = .{ .bytes = .{ 127, 0, 0, 1 }, .port = 0 } });
+    defer socket_a.close(io);
+    var socket_b = try bindDatagramSocket(io, .{ .ip4 = .{ .bytes = .{ 127, 0, 0, 1 }, .port = 0 } });
+    defer socket_b.close(io);
+
+    const addr_a = socket_a.address;
+    const addr_b = socket_b.address;
+
+    // Set up node A's protocol
+    var proto_a = try Protocol.init(io, alloc, .{
+        .local_key_pair = key_pair_a,
+        .local_node_id = node_id_a,
+    });
+    defer proto_a.deinit();
+
+    // Set up node B's protocol
+    var proto_b = try Protocol.init(io, alloc, .{
+        .local_key_pair = key_pair_b,
+        .local_node_id = node_id_b,
+    });
+    defer proto_b.deinit();
+    // Pre-register node A's static pubkey so B can verify A's id-nonce signature.
+    proto_b.addNode(node_id_a, &pk_a, addr_a, null);
+
+    // Step 1: Node A sends a PING to node B (no session exists).
+    const ping = messages.Ping{
+        .req_id = try messages.ReqId.fromSlice(&[_]u8{ 0x00, 0x00, 0x00, 0x01 }),
+        .enr_seq = 1,
+    };
+    const ping_bytes = try ping.encode(alloc);
+    defer alloc.free(ping_bytes);
+
+    try proto_a.sendRequest(&node_id_b, &pk_b, addr_b, ping.req_id, .ping, &.{}, ping_bytes, &socket_a);
+
+    // Verify node A sent one packet and stored a pending request.
+    try std.testing.expectEqual(@as(usize, 1), proto_a.requests.pendingCount());
+
+    // Step 2: Node B receives the packet. Since no session exists, it responds
+    // with WHOAREYOU.
+    var recv_buf_b: [MAX_PACKET_SIZE]u8 = undefined;
+    const inbound_a = try socket_b.receiveTimeout(io, &recv_buf_b, .{
+        .duration = .{
+            .raw = Io.Duration.fromMilliseconds(250),
+            .clock = .awake,
+        },
+    });
+    try proto_b.handlePacket(inbound_a.data, inbound_a.from, &socket_b);
+
+    // Node B should now have an active challenge separate from established sessions.
+    try std.testing.expect(proto_b.getChallengeCopy(&node_id_a, addr_a) != null);
+    try std.testing.expect(proto_b.getSessionCopy(&node_id_a, addr_a) == null);
+
+    // A second unauthenticated MESSAGE from the same claimed endpoint must not
+    // replace the live challenge and invalidate the legitimate handshake.
+    const original_challenge = proto_b.getChallengeCopy(&node_id_a, addr_a).?;
+    var duplicate_probe_buf: [MAX_PACKET_SIZE]u8 = undefined;
+    const duplicate_probe = try proto_a.encodeProbePacketInto(&duplicate_probe_buf, &node_id_b, ping_bytes);
+    try socket_a.send(io, &addr_b, duplicate_probe.pkt);
+    const duplicate_inbound = try socket_b.receiveTimeout(io, &recv_buf_b, .{
+        .duration = .{ .raw = Io.Duration.fromMilliseconds(250), .clock = .awake },
+    });
+    try proto_b.handlePacket(duplicate_inbound.data, duplicate_inbound.from, &socket_b);
+    const retained_challenge = proto_b.getChallengeCopy(&node_id_a, addr_a).?;
+    try std.testing.expectEqualSlices(u8, &original_challenge.challenge_data, &retained_challenge.challenge_data);
+
+    // Step 3: Node A receives the WHOAREYOU and responds with a handshake.
+    var recv_buf_a: [MAX_PACKET_SIZE]u8 = undefined;
+    const inbound_b = try socket_a.receiveTimeout(io, &recv_buf_a, .{
+        .duration = .{
+            .raw = Io.Duration.fromMilliseconds(250),
+            .clock = .awake,
+        },
+    });
+    try proto_a.handlePacket(inbound_b.data, inbound_b.from, &socket_a);
+
+    // Node A keeps provisional keys on the active request only; the session
+    // cache remains established-only until B proves it accepted the handshake.
+    try std.testing.expect(proto_a.getSessionCopy(&node_id_b, addr_b) == null);
+
+    // The pending request should be consumed.
+    try std.testing.expectEqual(@as(usize, 0), proto_a.requests.pendingCount());
+
+    const queued_req_id = try proto_a.sendPing(
+        &node_id_b,
+        &pk_b,
+        addr_b,
+        1,
+        &socket_a,
+    );
+    try std.testing.expect(queued_req_id.len > 0);
+
+    // Step 4: Node B receives the handshake.
+    const handshake = try socket_b.receiveTimeout(io, &recv_buf_b, .{
+        .duration = .{
+            .raw = Io.Duration.fromMilliseconds(250),
+            .clock = .awake,
+        },
+    });
+    try proto_b.handlePacket(handshake.data, handshake.from, &socket_b);
+
+    // Node B should now have an established session.
+    try std.testing.expect(proto_b.getSessionCopy(&node_id_a, addr_a) != null);
+
+    // Step 5: Node A receives B's post-handshake PONG.
+    const pong_packet = try socket_a.receiveTimeout(io, &recv_buf_a, .{
+        .duration = .{
+            .raw = Io.Duration.fromMilliseconds(250),
+            .clock = .awake,
+        },
+    });
+    try proto_a.handlePacket(pong_packet.data, pong_packet.from, &socket_a);
+
+    try std.testing.expect(proto_a.getSessionCopy(&node_id_b, addr_b) != null);
+
+    // Drain the request that was queued behind the initial handshake.
+    const queued_ping = try socket_b.receiveTimeout(io, &recv_buf_b, .{
+        .duration = .{ .raw = Io.Duration.fromMilliseconds(250), .clock = .awake },
+    });
+    try proto_b.handlePacket(queued_ping.data, queued_ping.from, &socket_b);
+    const queued_pong = try socket_a.receiveTimeout(io, &recv_buf_a, .{
+        .duration = .{ .raw = Io.Duration.fromMilliseconds(250), .clock = .awake },
+    });
+    try proto_a.handlePacket(queued_pong.data, queued_pong.from, &socket_a);
+    try std.testing.expect(proto_a.requests.getActivePtr(.{ .node_id = node_id_b, .addr = addr_b }, queued_req_id) == null);
+
+    // If B forgets the established session, A's next authenticated request is
+    // challenged and must rekey instead of remaining stuck on stale keys.
+    try std.testing.expect(proto_b.session_store.removeSession(.{ .node_id = node_id_a, .addr = addr_a }));
+    const rekey_req_id = try proto_a.sendPing(&node_id_b, &pk_b, addr_b, 1, &socket_a);
+
+    const stale_message = try socket_b.receiveTimeout(io, &recv_buf_b, .{
+        .duration = .{ .raw = Io.Duration.fromMilliseconds(250), .clock = .awake },
+    });
+    try proto_b.handlePacket(stale_message.data, stale_message.from, &socket_b);
+
+    const rekey_challenge = try socket_a.receiveTimeout(io, &recv_buf_a, .{
+        .duration = .{ .raw = Io.Duration.fromMilliseconds(250), .clock = .awake },
+    });
+    try proto_a.handlePacket(rekey_challenge.data, rekey_challenge.from, &socket_a);
+
+    const rekey_handshake = try socket_b.receiveTimeout(io, &recv_buf_b, .{
+        .duration = .{ .raw = Io.Duration.fromMilliseconds(250), .clock = .awake },
+    });
+    try proto_b.handlePacket(rekey_handshake.data, rekey_handshake.from, &socket_b);
+    try std.testing.expect(proto_b.getChallengeCopy(&node_id_a, addr_a) == null);
+    try std.testing.expect(proto_b.getSessionCopy(&node_id_a, addr_a) != null);
+    try std.testing.expectEqual(@as(u64, 3), proto_b.metricsSnapshot().sent_message_count[metrics_mod.MessageType.pong.index()]);
+
+    const rekey_pong = try socket_a.receiveTimeout(io, &recv_buf_a, .{
+        .duration = .{ .raw = Io.Duration.fromMilliseconds(250), .clock = .awake },
+    });
+    try proto_a.handlePacket(rekey_pong.data, rekey_pong.from, &socket_a);
+
+    try std.testing.expect(proto_a.getSessionCopy(&node_id_b, addr_b) != null);
+    try std.testing.expect(proto_b.getSessionCopy(&node_id_a, addr_a) != null);
+    try std.testing.expect(proto_a.requests.getActivePtr(.{ .node_id = node_id_b, .addr = addr_b }, rekey_req_id) == null);
+}
+
+test "discv5 protocol: FINDNODE only relays trusted or liveness-verified ENRs" {
+    const alloc = std.testing.allocator;
+    const io = std.Options.debug_io;
+    const hex = @import("hex");
+
+    const sk_a = hex.hexToBytesComptime(32, "eef77acb6c6a6eebc5b363a475ac583ec7eccdb42b6481424c60f59aa326547f");
+    const key_pair_a = try secp.keyPairFromSecret(&sk_a);
+    const pk_a = secp.compressedPubkey(&key_pair_a);
+    const node_id_a = enr_mod.nodeIdFromCompressedPubkey(&pk_a);
+
+    const sk_b = hex.hexToBytesComptime(32, "66fb62bfbd66b9177a138c1e5cddbe4f7c30c343e94e68df8769459cb14571f7");
+    const key_pair_b = try secp.keyPairFromSecret(&sk_b);
+    const pk_b = secp.compressedPubkey(&key_pair_b);
+    const node_id_b = enr_mod.nodeIdFromCompressedPubkey(&pk_b);
+
+    const sk_c = hex.hexToBytesComptime(32, "7e8107fe766b7f1821c3a7fbc56d18f734f0ebf898f0b85f82412b6d1fa7f4d3");
+    const key_pair_c = try secp.keyPairFromSecret(&sk_c);
+    const pk_c = secp.compressedPubkey(&key_pair_c);
+    const node_id_c = enr_mod.nodeIdFromCompressedPubkey(&pk_c);
+
+    var socket_a = try bindDatagramSocket(io, .{ .ip4 = .{ .bytes = .{ 127, 0, 0, 1 }, .port = 0 } });
+    defer socket_a.close(io);
+    var socket_b = try bindDatagramSocket(io, .{ .ip4 = .{ .bytes = .{ 127, 0, 0, 1 }, .port = 0 } });
+    defer socket_b.close(io);
+
+    const addr_a = socket_a.address;
+    const addr_b = socket_b.address;
+    const addr_c = Address{ .ip4 = .{ .bytes = .{ 127, 0, 0, 1 }, .port = 30305 } };
+
+    var a_builder = enr_mod.Builder.init(alloc, key_pair_a, 1);
+    a_builder.ip = switch (addr_a) {
+        .ip4 => |ip4| ip4.bytes,
+        .ip6 => unreachable,
+    };
+    a_builder.udp = addr_a.getPort();
+    const a_enr = try a_builder.encode();
+    defer alloc.free(a_enr);
+
+    var b_builder = enr_mod.Builder.init(alloc, key_pair_b, 1);
+    b_builder.ip = switch (addr_b) {
+        .ip4 => |ip4| ip4.bytes,
+        .ip6 => unreachable,
+    };
+    b_builder.udp = addr_b.getPort();
+    const b_enr = try b_builder.encode();
+    defer alloc.free(b_enr);
+
+    var c_builder = enr_mod.Builder.init(alloc, key_pair_c, 1);
+    c_builder.ip = switch (addr_c) {
+        .ip4 => |ip4| ip4.bytes,
+        .ip6 => unreachable,
+    };
+    c_builder.udp = addr_c.getPort();
+    const c_enr = try c_builder.encode();
+    defer alloc.free(c_enr);
+
+    var proto_a = try Protocol.init(io, alloc, .{
+        .local_key_pair = key_pair_a,
+        .local_node_id = node_id_a,
+        .local_enr = a_enr,
+        .local_enr_seq = 1,
+    });
+    defer proto_a.deinit();
+
+    var proto_b = try Protocol.init(io, alloc, .{
+        .local_key_pair = key_pair_b,
+        .local_node_id = node_id_b,
+        .local_enr = b_enr,
+        .local_enr_seq = 1,
+    });
+    defer proto_b.deinit();
+
+    proto_a.addNode(node_id_b, &pk_b, addr_b, b_enr);
+    proto_b.addNode(node_id_a, &pk_a, addr_a, a_enr);
+    // Model an ENR learned from an untrusted NODES response. Locally configured
+    // entries use addNode and are eligible for relay immediately.
+    proto_b.rememberEnr(c_enr);
+    try std.testing.expect(proto_a.routing_table.getEntry(&node_id_b).?.relay_eligible);
+    try std.testing.expect(!proto_b.routing_table.getEntry(&node_id_c).?.relay_eligible);
+
+    const c_distance = kbucket.logDistance(&node_id_b, &node_id_c) orelse return error.NoDistance;
+    const distances = [_]u16{ 0, @as(u16, c_distance) + 1 };
+    _ = try proto_a.sendFindNode(&node_id_b, &pk_b, addr_b, &distances, &socket_a);
+
+    var recv_buf_a: [MAX_PACKET_SIZE]u8 = undefined;
+    var recv_buf_b: [MAX_PACKET_SIZE]u8 = undefined;
+
+    const inbound_a = try socket_b.receiveTimeout(io, &recv_buf_b, .{
+        .duration = .{
+            .raw = Io.Duration.fromMilliseconds(250),
+            .clock = .awake,
+        },
+    });
+    try proto_b.handlePacket(inbound_a.data, inbound_a.from, &socket_b);
+
+    const inbound_b = try socket_a.receiveTimeout(io, &recv_buf_a, .{
+        .duration = .{
+            .raw = Io.Duration.fromMilliseconds(250),
+            .clock = .awake,
+        },
+    });
+    try proto_a.handlePacket(inbound_b.data, inbound_b.from, &socket_a);
+
+    const handshake = try socket_b.receiveTimeout(io, &recv_buf_b, .{
+        .duration = .{
+            .raw = Io.Duration.fromMilliseconds(250),
+            .clock = .awake,
+        },
+    });
+    try proto_b.handlePacket(handshake.data, handshake.from, &socket_b);
+
+    const nodes_packet = try socket_a.receiveTimeout(io, &recv_buf_a, .{
+        .duration = .{
+            .raw = Io.Duration.fromMilliseconds(250),
+            .clock = .awake,
+        },
+    });
+    try proto_a.handlePacket(nodes_packet.data, nodes_packet.from, &socket_a);
+
+    try std.testing.expectEqual(@as(usize, 0), proto_a.requests.activeCount());
+
+    var event = proto_a.popEvent() orelse return error.MissingNodesEvent;
+    defer event.deinit(alloc);
+    try std.testing.expect(event == .nodes);
+    try std.testing.expectEqual(node_id_b, event.nodes.peer_id);
+    try std.testing.expectEqual(@as(usize, 1), event.nodes.enrs.len);
+
+    var saw_b = false;
+    var saw_c = false;
+    for (event.nodes.enrs) |raw_enr| {
+        const parsed = try enr_mod.decode(raw_enr);
+        const node_id = parsed.nodeId() orelse continue;
+        if (std.mem.eql(u8, &node_id, &node_id_b)) saw_b = true;
+        if (std.mem.eql(u8, &node_id, &node_id_c)) saw_c = true;
+    }
+    try std.testing.expect(saw_b);
+    try std.testing.expect(!saw_c);
+
+    const mismatched_c_addr = Address{ .ip4 = .{ .bytes = .{ 127, 0, 0, 1 }, .port = 30306 } };
+    _ = proto_b.markNodeSeen(node_id_c, mismatched_c_addr, .connected);
+    try std.testing.expect(!proto_b.routing_table.getEntry(&node_id_c).?.relay_eligible);
+
+    _ = proto_b.markNodeSeen(node_id_c, addr_c, .connected);
+    try std.testing.expect(proto_b.routing_table.getEntry(&node_id_c).?.relay_eligible);
+    var learned_c = proto_b.routing_table.getEntry(&node_id_c).?.*;
+    learned_c.relay_eligible = false;
+    learned_c.locally_trusted = false;
+    try std.testing.expect(proto_b.routing_table.insert(learned_c));
+
+    // A later local trust decision must promote an already learned equal-sequence
+    // ENR instead of being discarded by the normal stale-ENR check.
+    proto_b.addNode(node_id_c, &pk_c, addr_c, c_enr);
+    try std.testing.expect(proto_b.routing_table.getEntry(&node_id_c).?.relay_eligible);
+
+    _ = try proto_a.sendFindNode(&node_id_b, &pk_b, addr_b, &distances, &socket_a);
+
+    const verified_request = try socket_b.receiveTimeout(io, &recv_buf_b, .{
+        .duration = .{
+            .raw = Io.Duration.fromMilliseconds(250),
+            .clock = .awake,
+        },
+    });
+    try proto_b.handlePacket(verified_request.data, verified_request.from, &socket_b);
+
+    const verified_response = try socket_a.receiveTimeout(io, &recv_buf_a, .{
+        .duration = .{
+            .raw = Io.Duration.fromMilliseconds(250),
+            .clock = .awake,
+        },
+    });
+    try proto_a.handlePacket(verified_response.data, verified_response.from, &socket_a);
+
+    var verified_event = proto_a.popEvent() orelse return error.MissingNodesEvent;
+    defer verified_event.deinit(alloc);
+    try std.testing.expect(verified_event == .nodes);
+    try std.testing.expectEqual(@as(usize, 2), verified_event.nodes.enrs.len);
+
+    saw_c = false;
+    for (verified_event.nodes.enrs) |raw_enr| {
+        const parsed = try enr_mod.decode(raw_enr);
+        const node_id = parsed.nodeId() orelse continue;
+        if (std.mem.eql(u8, &node_id, &node_id_c)) saw_c = true;
+    }
+    try std.testing.expect(saw_c);
+}
+
+test "discv5 protocol: TALKREQ/TALKRESP round-trip produces events" {
+    const alloc = std.testing.allocator;
+    const io = std.Options.debug_io;
+    const hex = @import("hex");
+
+    const sk_a = hex.hexToBytesComptime(32, "eef77acb6c6a6eebc5b363a475ac583ec7eccdb42b6481424c60f59aa326547f");
+    const key_pair_a = try secp.keyPairFromSecret(&sk_a);
+    const pk_a = secp.compressedPubkey(&key_pair_a);
+    const node_id_a = enr_mod.nodeIdFromCompressedPubkey(&pk_a);
+
+    const sk_b = hex.hexToBytesComptime(32, "66fb62bfbd66b9177a138c1e5cddbe4f7c30c343e94e68df8769459cb14571f7");
+    const key_pair_b = try secp.keyPairFromSecret(&sk_b);
+    const pk_b = secp.compressedPubkey(&key_pair_b);
+    const node_id_b = enr_mod.nodeIdFromCompressedPubkey(&pk_b);
+
+    var socket_a = try bindDatagramSocket(io, .{ .ip4 = .{ .bytes = .{ 127, 0, 0, 1 }, .port = 0 } });
+    defer socket_a.close(io);
+    var socket_b = try bindDatagramSocket(io, .{ .ip4 = .{ .bytes = .{ 127, 0, 0, 1 }, .port = 0 } });
+    defer socket_b.close(io);
+
+    const addr_a = socket_a.address;
+    const addr_b = socket_b.address;
+
+    var proto_a = try Protocol.init(io, alloc, .{
+        .local_key_pair = key_pair_a,
+        .local_node_id = node_id_a,
+    });
+    defer proto_a.deinit();
+
+    var proto_b = try Protocol.init(io, alloc, .{
+        .local_key_pair = key_pair_b,
+        .local_node_id = node_id_b,
+    });
+    defer proto_b.deinit();
+
+    proto_a.addNode(node_id_b, &pk_b, addr_b, null);
+    proto_b.addNode(node_id_a, &pk_a, addr_a, null);
+
+    const req_id = try proto_a.sendTalkRequest(
+        &node_id_b,
+        &pk_b,
+        addr_b,
+        "/eth2/test",
+        "ping",
+        &socket_a,
+    );
+
+    var recv_buf_a: [MAX_PACKET_SIZE]u8 = undefined;
+    var recv_buf_b: [MAX_PACKET_SIZE]u8 = undefined;
+
+    const inbound_a = try socket_b.receiveTimeout(io, &recv_buf_b, .{
+        .duration = .{
+            .raw = Io.Duration.fromMilliseconds(250),
+            .clock = .awake,
+        },
+    });
+    try proto_b.handlePacket(inbound_a.data, inbound_a.from, &socket_b);
+
+    const inbound_b = try socket_a.receiveTimeout(io, &recv_buf_a, .{
+        .duration = .{
+            .raw = Io.Duration.fromMilliseconds(250),
+            .clock = .awake,
+        },
+    });
+    try proto_a.handlePacket(inbound_b.data, inbound_b.from, &socket_a);
+
+    const handshake = try socket_b.receiveTimeout(io, &recv_buf_b, .{
+        .duration = .{
+            .raw = Io.Duration.fromMilliseconds(250),
+            .clock = .awake,
+        },
+    });
+    try proto_b.handlePacket(handshake.data, handshake.from, &socket_b);
+
+    var request_event = proto_b.popEvent() orelse return error.MissingTalkReqEvent;
+    defer request_event.deinit(alloc);
+    try std.testing.expect(request_event == .talkreq);
+    try std.testing.expectEqual(node_id_a, request_event.talkreq.peer_id);
+    try std.testing.expectEqualSlices(u8, req_id.slice(), request_event.talkreq.req_id.slice());
+    try std.testing.expectEqualStrings("/eth2/test", request_event.talkreq.protocol);
+    try std.testing.expectEqualStrings("ping", request_event.talkreq.request);
+
+    try proto_b.sendTalkResponse(
+        request_event.talkreq.peer_id,
+        request_event.talkreq.peer_addr,
+        request_event.talkreq.req_id,
+        "pong",
+        &socket_b,
+    );
+
+    const response_packet = try socket_a.receiveTimeout(io, &recv_buf_a, .{
+        .duration = .{
+            .raw = Io.Duration.fromMilliseconds(250),
+            .clock = .awake,
+        },
+    });
+    try proto_a.handlePacket(response_packet.data, response_packet.from, &socket_a);
+
+    var response_event = proto_a.popEvent() orelse return error.MissingTalkRespEvent;
+    defer response_event.deinit(alloc);
+    try std.testing.expect(response_event == .talkresp);
+    try std.testing.expectEqual(node_id_b, response_event.talkresp.peer_id);
+    try std.testing.expectEqualSlices(u8, req_id.slice(), response_event.talkresp.req_id.slice());
+    try std.testing.expectEqualStrings("pong", response_event.talkresp.response);
+}
+
+test "discv5 protocol: request timeout prunes active and pending state" {
+    const alloc = std.testing.allocator;
+    const io = std.Options.debug_io;
+    const hex = @import("hex");
+
+    const sk_a = hex.hexToBytesComptime(32, "eef77acb6c6a6eebc5b363a475ac583ec7eccdb42b6481424c60f59aa326547f");
+    const key_pair_a = try secp.keyPairFromSecret(&sk_a);
+    const pk_a = secp.compressedPubkey(&key_pair_a);
+    const node_id_a = enr_mod.nodeIdFromCompressedPubkey(&pk_a);
+
+    const sk_b = hex.hexToBytesComptime(32, "66fb62bfbd66b9177a138c1e5cddbe4f7c30c343e94e68df8769459cb14571f7");
+    const key_pair_b = try secp.keyPairFromSecret(&sk_b);
+    const pk_b = secp.compressedPubkey(&key_pair_b);
+    const node_id_b = enr_mod.nodeIdFromCompressedPubkey(&pk_b);
+
+    var socket_a = try bindDatagramSocket(io, .{ .ip4 = .{ .bytes = .{ 127, 0, 0, 1 }, .port = 0 } });
+    defer socket_a.close(io);
+
+    var proto_a = try Protocol.init(io, alloc, .{
+        .local_key_pair = key_pair_a,
+        .local_node_id = node_id_a,
+        .request_timeout_ms = 1,
+        .request_retries = 0,
+    });
+    defer proto_a.deinit();
+
+    const addr_b = Address{ .ip4 = .{ .bytes = .{ 127, 0, 0, 1 }, .port = 30303 } };
+    proto_a.addNode(node_id_b, &pk_b, addr_b, null);
+
+    const req_id = try proto_a.sendPing(&node_id_b, &pk_b, addr_b, 1, &socket_a);
+    try std.testing.expectEqual(@as(usize, 1), proto_a.requests.activeCount());
+    try std.testing.expectEqual(@as(usize, 1), proto_a.requests.pendingCount());
+
+    proto_a.requests.forceAllActiveStartedAtForTest(0);
+
+    proto_a.pruneExpiredState();
+
+    try std.testing.expectEqual(@as(usize, 0), proto_a.requests.activeCount());
+    try std.testing.expectEqual(@as(usize, 0), proto_a.requests.pendingCount());
+
+    var event = proto_a.popEvent() orelse return error.MissingTimeoutEvent;
+    defer event.deinit(alloc);
+    try std.testing.expect(event == .request_timeout);
+    try std.testing.expectEqual(node_id_b, event.request_timeout.peer_id);
+    try std.testing.expectEqualSlices(u8, req_id.slice(), event.request_timeout.req_id.slice());
+    try std.testing.expectEqual(RequestKind.ping, event.request_timeout.kind);
+}
+
+test "discv5 protocol: WHOAREYOU requires matching pending nonce and address" {
+    const alloc = std.testing.allocator;
+    const io = std.Options.debug_io;
+    const hex = @import("hex");
+
+    const sk_a = hex.hexToBytesComptime(32, "eef77acb6c6a6eebc5b363a475ac583ec7eccdb42b6481424c60f59aa326547f");
+    const key_pair_a = try secp.keyPairFromSecret(&sk_a);
+    const pk_a = secp.compressedPubkey(&key_pair_a);
+    const node_id_a = enr_mod.nodeIdFromCompressedPubkey(&pk_a);
+
+    const sk_b = hex.hexToBytesComptime(32, "66fb62bfbd66b9177a138c1e5cddbe4f7c30c343e94e68df8769459cb14571f7");
+    const key_pair_b = try secp.keyPairFromSecret(&sk_b);
+    const pk_b = secp.compressedPubkey(&key_pair_b);
+    const node_id_b = enr_mod.nodeIdFromCompressedPubkey(&pk_b);
+
+    var socket_a = try bindDatagramSocket(io, .{ .ip4 = .{ .bytes = .{ 127, 0, 0, 1 }, .port = 0 } });
+    defer socket_a.close(io);
+    var socket_b = try bindDatagramSocket(io, .{ .ip4 = .{ .bytes = .{ 127, 0, 0, 1 }, .port = 0 } });
+    defer socket_b.close(io);
+
+    const addr_a = socket_a.address;
+    const addr_b = socket_b.address;
+
+    var proto_a = try Protocol.init(io, alloc, .{
+        .local_key_pair = key_pair_a,
+        .local_node_id = node_id_a,
+    });
+    defer proto_a.deinit();
+
+    var proto_b = try Protocol.init(io, alloc, .{
+        .local_key_pair = key_pair_b,
+        .local_node_id = node_id_b,
+    });
+    defer proto_b.deinit();
+    proto_b.addNode(node_id_a, &pk_a, addr_a, null);
+
+    const ping = messages.Ping{
+        .req_id = try messages.ReqId.fromSlice(&[_]u8{ 0x00, 0x00, 0x00, 0x01 }),
+        .enr_seq = 1,
+    };
+    const ping_bytes = try ping.encode(alloc);
+    defer alloc.free(ping_bytes);
+
+    try proto_a.sendRequest(&node_id_b, &pk_b, addr_b, ping.req_id, .ping, &.{}, ping_bytes, &socket_a);
+    try std.testing.expectEqual(@as(usize, 1), proto_a.requests.pendingCount());
+
+    // Simulate a stale pending nonce while keeping the destination address
+    // intact. Gold TS behavior rejects this rather than falling back to address.
+    try std.testing.expect(proto_a.requests.forceFirstProbeNonceForTest([_]u8{0xaa} ** 12));
+
+    var recv_buf_b: [MAX_PACKET_SIZE]u8 = undefined;
+    const inbound_a = try socket_b.receiveTimeout(io, &recv_buf_b, .{
+        .duration = .{
+            .raw = Io.Duration.fromMilliseconds(250),
+            .clock = .awake,
+        },
+    });
+    try proto_b.handlePacket(inbound_a.data, inbound_a.from, &socket_b);
+
+    var recv_buf_a: [MAX_PACKET_SIZE]u8 = undefined;
+    const inbound_b = try socket_a.receiveTimeout(io, &recv_buf_a, .{
+        .duration = .{
+            .raw = Io.Duration.fromMilliseconds(250),
+            .clock = .awake,
+        },
+    });
+    try proto_a.handlePacket(inbound_b.data, inbound_b.from, &socket_a);
+
+    try std.testing.expect(proto_a.getSessionCopy(&node_id_b, addr_b) == null);
+    try std.testing.expectEqual(@as(usize, 1), proto_a.requests.pendingCount());
+}
+
+test "discv5 protocol: unsolicited WHOAREYOU is ignored" {
+    const alloc = std.testing.allocator;
+    const io = std.Options.debug_io;
+    const hex = @import("hex");
+
+    const sk_a = hex.hexToBytesComptime(32, "eef77acb6c6a6eebc5b363a475ac583ec7eccdb42b6481424c60f59aa326547f");
+    const key_pair_a = try secp.keyPairFromSecret(&sk_a);
+    const pk_a = secp.compressedPubkey(&key_pair_a);
+    const node_id_a = enr_mod.nodeIdFromCompressedPubkey(&pk_a);
+
+    var socket_a = try bindDatagramSocket(io, .{ .ip4 = .{ .bytes = .{ 127, 0, 0, 1 }, .port = 0 } });
+    defer socket_a.close(io);
+    var socket_b = try bindDatagramSocket(io, .{ .ip4 = .{ .bytes = .{ 127, 0, 0, 1 }, .port = 0 } });
+    defer socket_b.close(io);
+
+    const addr_a = socket_a.address;
+
+    var proto_a = try Protocol.init(io, alloc, .{
+        .local_key_pair = key_pair_a,
+        .local_node_id = node_id_a,
+    });
+    defer proto_a.deinit();
+
+    var request_nonce: [12]u8 = [_]u8{0x42} ** 12;
+    var id_nonce: [16]u8 = [_]u8{0x24} ** 16;
+    var masking_iv: [16]u8 = [_]u8{0x11} ** 16;
+
+    var whoareyou_buf: [packet.WHOAREYOU_CHALLENGE_DATA_SIZE]u8 = undefined;
+    const whoareyou = try packet.encodeWhoareyouPacketInto(&whoareyou_buf, .{
+        .masking_iv = &masking_iv,
+        .recipient_node_id = &node_id_a,
+        .request_nonce = &request_nonce,
+        .id_nonce = &id_nonce,
+        .enr_seq = 0,
+    }, null);
+
+    try socket_b.send(io, &addr_a, whoareyou);
+
+    var recv_buf_a: [MAX_PACKET_SIZE]u8 = undefined;
+    const inbound = try socket_a.receiveTimeout(io, &recv_buf_a, .{
+        .duration = .{
+            .raw = Io.Duration.fromMilliseconds(250),
+            .clock = .awake,
+        },
+    });
+    try proto_a.handlePacket(inbound.data, inbound.from, &socket_a);
+
+    try std.testing.expectEqual(@as(usize, 0), proto_a.requests.pendingCount());
+    try std.testing.expectEqual(@as(usize, 0), proto_a.requests.activeCount());
+    try std.testing.expectEqual(@as(usize, 0), proto_a.activeSessionCount());
+    try std.testing.expect(proto_a.popEvent() == null);
+
+    var recv_buf_b: [MAX_PACKET_SIZE]u8 = undefined;
+    try std.testing.expectError(error.Timeout, socket_b.receiveTimeout(io, &recv_buf_b, .{
+        .duration = .{
+            .raw = Io.Duration.fromMilliseconds(50),
+            .clock = .awake,
+        },
+    }));
+}
+
+test "discv5 protocol: WHOAREYOU rate limiter is bounded" {
+    const alloc = std.testing.allocator;
+    const io = std.Options.debug_io;
+
+    const sk = [_]u8{0x01} ** 32;
+    const key_pair = try secp.keyPairFromSecret(&sk);
+    const pk = secp.compressedPubkey(&key_pair);
+    const node_id = enr_mod.nodeIdFromCompressedPubkey(&pk);
+
+    var proto = try Protocol.init(io, alloc, .{
+        .local_key_pair = key_pair,
+        .local_node_id = node_id,
+        .whoareyou_rate_capacity = 2,
+    });
+    defer proto.deinit();
+
+    const addr_a = Address{ .ip4 = .{ .bytes = .{ 127, 0, 0, 1 }, .port = 30303 } };
+    const addr_b = Address{ .ip4 = .{ .bytes = .{ 127, 0, 0, 2 }, .port = 30303 } };
+    const addr_c = Address{ .ip4 = .{ .bytes = .{ 127, 0, 0, 3 }, .port = 30303 } };
+
+    var i: u32 = 0;
+    while (i < MAX_WHOAREYOU_PER_SEC) : (i += 1) {
+        try std.testing.expect(proto.allowWhoareyou(addr_a));
+    }
+    try std.testing.expect(!proto.allowWhoareyou(addr_a));
+
+    try std.testing.expect(proto.allowWhoareyou(addr_b));
+    try std.testing.expect(proto.allowWhoareyou(addr_c));
+    try std.testing.expectEqual(@as(usize, 2), proto.session_store.whoareyou_rate.count());
+}
+
+test "discv5 protocol: handlePacket does not prune expired state" {
+    const alloc = std.testing.allocator;
+    const io = std.Options.debug_io;
+    const hex = @import("hex");
+
+    const sk = hex.hexToBytesComptime(32, "eef77acb6c6a6eebc5b363a475ac583ec7eccdb42b6481424c60f59aa326547f");
+    const key_pair = try secp.keyPairFromSecret(&sk);
+    const pk = secp.compressedPubkey(&key_pair);
+    const node_id = enr_mod.nodeIdFromCompressedPubkey(&pk);
+
+    var proto = try Protocol.init(io, alloc, .{
+        .local_key_pair = key_pair,
+        .local_node_id = node_id,
+    });
+    defer proto.deinit();
+
+    var socket = try bindDatagramSocket(io, .{ .ip4 = .{ .bytes = .{ 127, 0, 0, 1 }, .port = 0 } });
+    defer socket.close(io);
+
+    const peer_id = [_]u8{0x55} ** 32;
+    const req_id = try messages.ReqId.fromSlice(&[_]u8{ 0x01, 0x02, 0x03, 0x04 });
+    try proto.requests.putActiveAwaitingResponse(
+        Endpoint{ .node_id = peer_id, .addr = socket.address },
+        req_id,
+        .ping,
+        &.{},
+        &socket,
+        &[_]u8{0x99},
+        0,
+        null,
+    );
+
+    var raw = [_]u8{0x00};
+    try proto.handlePacket(&raw, socket.address, &socket);
+
+    try std.testing.expectEqual(@as(usize, 1), proto.requests.activeCount());
+    try std.testing.expectEqual(@as(usize, 0), proto.event_queue.pending());
+}
+
+test "discv5 protocol: request retries delay timeout event" {
+    const alloc = std.testing.allocator;
+    const io = std.Options.debug_io;
+    const hex = @import("hex");
+
+    const sk = hex.hexToBytesComptime(32, "eef77acb6c6a6eebc5b363a475ac583ec7eccdb42b6481424c60f59aa326547f");
+    const key_pair = try secp.keyPairFromSecret(&sk);
+    const pk = secp.compressedPubkey(&key_pair);
+    const node_id = enr_mod.nodeIdFromCompressedPubkey(&pk);
+
+    var proto = try Protocol.init(io, alloc, .{
+        .local_key_pair = key_pair,
+        .local_node_id = node_id,
+        .request_timeout_ms = 1,
+        .request_retries = 1,
+    });
+    defer proto.deinit();
+
+    const peer_id = [_]u8{0x33} ** 32;
+    const req_id = try messages.ReqId.fromSlice(&[_]u8{ 0x0a, 0x0b, 0x0c, 0x0d });
+    var socket = try bindDatagramSocket(io, .{ .ip4 = .{ .bytes = .{ 127, 0, 0, 1 }, .port = 0 } });
+    defer socket.close(io);
+    const endpoint = Endpoint{ .node_id = peer_id, .addr = socket.address };
+    try proto.requests.putActiveAwaitingResponse(
+        endpoint,
+        req_id,
+        .ping,
+        &.{},
+        &socket,
+        &[_]u8{0x99},
+        0,
+        null,
+    );
+
+    proto.pruneExpiredRequests(std.time.ns_per_ms);
+    try std.testing.expectEqual(@as(usize, 1), proto.requests.activeCount());
+    try std.testing.expect(proto.popEvent() == null);
+    const retried = proto.requests.getActivePtr(endpoint, req_id) orelse return error.MissingRetriedRequest;
+    try std.testing.expectEqual(@as(u32, 1), retried.attempts);
+
+    proto.pruneExpiredRequests(2 * std.time.ns_per_ms);
+    try std.testing.expectEqual(@as(usize, 0), proto.requests.activeCount());
+    var event = proto.popEvent() orelse return error.MissingTimeoutEvent;
+    defer event.deinit(alloc);
+    try std.testing.expect(event == .request_timeout);
+    try std.testing.expectEqual(RequestKind.ping, event.request_timeout.kind);
+    try std.testing.expectEqualSlices(u8, req_id.slice(), event.request_timeout.req_id.slice());
+}
+
+test "discv5 protocol: active timeout advances queued request as new probe" {
+    const alloc = std.testing.allocator;
+    const io = std.Options.debug_io;
+    const hex = @import("hex");
+
+    const sk = hex.hexToBytesComptime(32, "eef77acb6c6a6eebc5b363a475ac583ec7eccdb42b6481424c60f59aa326547f");
+    const key_pair = try secp.keyPairFromSecret(&sk);
+    const pk = secp.compressedPubkey(&key_pair);
+    const node_id = enr_mod.nodeIdFromCompressedPubkey(&pk);
+
+    var proto = try Protocol.init(io, alloc, .{
+        .local_key_pair = key_pair,
+        .local_node_id = node_id,
+        .request_timeout_ms = 1,
+        .request_retries = 0,
+    });
+    defer proto.deinit();
+
+    var socket = try bindDatagramSocket(io, .{ .ip4 = .{ .bytes = .{ 127, 0, 0, 1 }, .port = 0 } });
+    defer socket.close(io);
+
+    const peer_id = [_]u8{0x45} ** 32;
+    const peer_pk = [_]u8{0x02} ++ [_]u8{0x45} ** 32;
+    const endpoint = Endpoint{ .node_id = peer_id, .addr = .{ .ip4 = .{ .bytes = .{ 127, 0, 0, 1 }, .port = 30303 } } };
+    const active_req_id = try messages.ReqId.fromSlice(&[_]u8{0x01});
+    const queued_req_id = try messages.ReqId.fromSlice(&[_]u8{0x02});
+    const plaintext = [_]u8{ messages.MSG_PING, 0x01, 0x02 };
+
+    try proto.requests.putActiveProbe(
+        endpoint,
+        active_req_id,
+        .ping,
+        &.{},
+        &socket,
+        &[_]u8{0x99},
+        0,
+        [_]u8{0xbb} ** packet.NONCE_SIZE,
+        &peer_pk,
+        &plaintext,
+    );
+    try proto.requests.queueRequest(endpoint, &peer_pk, queued_req_id, .ping, &.{}, &plaintext, 0);
+
+    proto.pruneExpiredRequests(std.time.ns_per_ms);
+
+    try std.testing.expectEqual(@as(usize, 1), proto.requests.activeCount());
+    try std.testing.expectEqual(@as(usize, 1), proto.requests.pendingCount());
+    var event = proto.popEvent() orelse return error.MissingTimeoutEvent;
+    defer event.deinit(alloc);
+    try std.testing.expect(event == .request_timeout);
+    try std.testing.expectEqualSlices(u8, active_req_id.slice(), event.request_timeout.req_id.slice());
+}
+
+test "discv5 protocol: explicit queued request drop emits timeout events" {
+    const alloc = std.testing.allocator;
+    const io = std.Options.debug_io;
+    const hex = @import("hex");
+
+    const sk = hex.hexToBytesComptime(32, "eef77acb6c6a6eebc5b363a475ac583ec7eccdb42b6481424c60f59aa326547f");
+    const key_pair = try secp.keyPairFromSecret(&sk);
+    const pk = secp.compressedPubkey(&key_pair);
+    const node_id = enr_mod.nodeIdFromCompressedPubkey(&pk);
+
+    var proto = try Protocol.init(io, alloc, .{
+        .local_key_pair = key_pair,
+        .local_node_id = node_id,
+        .request_timeout_ms = 1,
+        .request_retries = 1,
+    });
+    defer proto.deinit();
+
+    const peer_id = [_]u8{0x44} ** 32;
+    const peer_pk = [_]u8{0x02} ++ [_]u8{0x44} ** 32;
+    const endpoint = Endpoint{ .node_id = peer_id, .addr = .{ .ip4 = .{ .bytes = .{ 127, 0, 0, 1 }, .port = 30303 } } };
+    try proto.requests.queueRequest(
+        endpoint,
+        &peer_pk,
+        try messages.ReqId.fromSlice(&[_]u8{0x01}),
+        .ping,
+        &.{},
+        &[_]u8{ messages.MSG_PING, 0x01, 0x02, 0x03 },
+        0,
+    );
+
+    var expired: std.ArrayListUnmanaged(ExpiredRequest) = .empty;
+    defer expired.deinit(alloc);
+    try proto.requests.dropQueuedForEndpoint(endpoint, &expired);
+    for (expired.items) |request| proto.appendRequestTimeout(request);
+    try std.testing.expectEqual(@as(usize, 0), proto.requests.pendingCount());
+    var event = proto.popEvent() orelse return error.MissingTimeoutEvent;
+    defer event.deinit(alloc);
+    try std.testing.expect(event == .request_timeout);
+    try std.testing.expectEqual(RequestKind.ping, event.request_timeout.kind);
+}
+
+test "discv5 protocol: session cache expires by TTL and bounds by LRU capacity" {
+    const alloc = std.testing.allocator;
+    const io = std.Options.debug_io;
+    const hex = @import("hex");
+
+    const sk = hex.hexToBytesComptime(32, "eef77acb6c6a6eebc5b363a475ac583ec7eccdb42b6481424c60f59aa326547f");
+    const key_pair = try secp.keyPairFromSecret(&sk);
+    const pk = secp.compressedPubkey(&key_pair);
+    const local_id = enr_mod.nodeIdFromCompressedPubkey(&pk);
+
+    var ttl_proto = try Protocol.init(io, alloc, .{
+        .local_key_pair = key_pair,
+        .local_node_id = local_id,
+        .session_timeout_ms = 1,
+        .session_cache_capacity = 4,
+    });
+    defer ttl_proto.deinit();
+
+    const ttl_peer = [_]u8{0x11} ** 32;
+    const ttl_addr = Address{ .ip4 = .{ .bytes = .{ 127, 0, 0, 1 }, .port = 30303 } };
+    ttl_proto.putSession(&ttl_peer, ttl_addr, .{
+        .node_id = ttl_peer,
+        .initiator_key = [_]u8{0x01} ** 16,
+        .recipient_key = [_]u8{0x02} ** 16,
+        .seen_nonces = SeenNonces.init(),
+    });
+    try std.testing.expect(ttl_proto.getSessionCopy(&ttl_peer, ttl_addr) != null);
+    try std.Io.sleep(io, std.Io.Duration.fromMilliseconds(1100), .awake);
+    try std.testing.expect(ttl_proto.getSessionCopy(&ttl_peer, ttl_addr) == null);
+
+    var lru_proto = try Protocol.init(io, alloc, .{
+        .local_key_pair = key_pair,
+        .local_node_id = local_id,
+        .session_cache_capacity = 2,
+    });
+    defer lru_proto.deinit();
+
+    inline for (0..3) |i| {
+        var peer = [_]u8{@as(u8, @intCast(0x20 + i))} ** 32;
+        const peer_addr = Address{ .ip4 = .{
+            .bytes = .{ 127, 0, 0, 1 },
+            .port = @as(u16, @intCast(30310 + i)),
+        } };
+        lru_proto.putSession(&peer, peer_addr, .{
+            .node_id = peer,
+            .initiator_key = [_]u8{@as(u8, @intCast(i + 1))} ** 16,
+            .recipient_key = [_]u8{@as(u8, @intCast(i + 11))} ** 16,
+            .seen_nonces = SeenNonces.init(),
+        });
+    }
+    try std.testing.expect(lru_proto.activeSessionCount() <= 2);
+}
+
+test "discv5 protocol: endpoint caches use semantic address identity" {
+    const alloc = std.testing.allocator;
+    const io = std.Options.debug_io;
+    const hex = @import("hex");
+
+    const sk = hex.hexToBytesComptime(32, "eef77acb6c6a6eebc5b363a475ac583ec7eccdb42b6481424c60f59aa326547f");
+    const key_pair = try secp.keyPairFromSecret(&sk);
+    const pk = secp.compressedPubkey(&key_pair);
+    const local_id = enr_mod.nodeIdFromCompressedPubkey(&pk);
+
+    var proto = try Protocol.init(io, alloc, .{
+        .local_key_pair = key_pair,
+        .local_node_id = local_id,
+    });
+    defer proto.deinit();
+
+    const peer = [_]u8{0x55} ** 32;
+    const addr_a = Address{ .ip6 = .{
+        .bytes = [_]u8{0xaa} ** 16,
+        .port = 30303,
+        .flow = 1,
+    } };
+    const addr_b = Address{ .ip6 = .{
+        .bytes = [_]u8{0xaa} ** 16,
+        .port = 30303,
+        .flow = 2,
+    } };
+
+    proto.putSession(&peer, addr_a, .{
+        .node_id = peer,
+        .initiator_key = [_]u8{0x01} ** 16,
+        .recipient_key = [_]u8{0x02} ** 16,
+        .seen_nonces = SeenNonces.init(),
+    });
+    try std.testing.expect(proto.getSessionCopy(&peer, addr_b) != null);
+
+    proto.putChallenge(&peer, addr_a, .{
+        .challenge_data = [_]u8{0x03} ** CHALLENGE_DATA_SIZE,
+    });
+    try std.testing.expect(proto.getChallengeCopy(&peer, addr_b) != null);
+}
+
+test "discv5 protocol: WHOAREYOU challenge state is separate from established session cache" {
+    const alloc = std.testing.allocator;
+    const io = std.Options.debug_io;
+    const hex = @import("hex");
+
+    const sk = hex.hexToBytesComptime(32, "eef77acb6c6a6eebc5b363a475ac583ec7eccdb42b6481424c60f59aa326547f");
+    const key_pair = try secp.keyPairFromSecret(&sk);
+    const pk = secp.compressedPubkey(&key_pair);
+    const local_id = enr_mod.nodeIdFromCompressedPubkey(&pk);
+
+    var proto = try Protocol.init(io, alloc, .{
+        .local_key_pair = key_pair,
+        .local_node_id = local_id,
+    });
+    defer proto.deinit();
+
+    var socket = try bindDatagramSocket(io, .{ .ip4 = .{ .bytes = .{ 127, 0, 0, 1 }, .port = 0 } });
+    defer socket.close(io);
+
+    const peer = [_]u8{0x66} ** 32;
+    const nonce = [_]u8{0x77} ** 12;
+    try proto.sendWhoareyou(peer, &nonce, socket.address, &socket);
+
+    try std.testing.expect(proto.getSessionCopy(&peer, socket.address) == null);
+    const challenge = proto.getChallengeCopy(&peer, socket.address) orelse return error.MissingChallenge;
+    try std.testing.expect(!std.mem.allEqual(u8, &challenge.challenge_data, 0));
+}

--- a/src/discv5/protocol/contact_book.zig
+++ b/src/discv5/protocol/contact_book.zig
@@ -1,0 +1,77 @@
+//! Fallback directory of peers we have identity + address for, but whose ENR is
+//! not verified enough for the routing table. It is consulted when resolving a
+//! peer's static pubkey/address for handshakes and request sending; an entry is
+//! dropped once the peer earns a routing-table slot.
+
+const std = @import("std");
+const scoped_log = std.log.scoped(.discv5_protocol);
+const Allocator = std.mem.Allocator;
+
+const enr_mod = @import("../enr.zig");
+const protocol_state = @import("state.zig");
+
+const Io = std.Io;
+const Address = Io.net.IpAddress;
+const NodeId = enr_mod.NodeId;
+const Contact = protocol_state.Contact;
+
+pub const ContactBook = struct {
+    contacts: std.AutoHashMap(NodeId, Contact),
+    local_node_id: NodeId,
+    max_contacts: usize,
+
+    pub fn init(alloc: Allocator, local_node_id: NodeId, max_contacts: usize) ContactBook {
+        return .{
+            .contacts = std.AutoHashMap(NodeId, Contact).init(alloc),
+            .local_node_id = local_node_id,
+            .max_contacts = max_contacts,
+        };
+    }
+
+    pub fn deinit(self: *ContactBook) void {
+        self.contacts.deinit();
+    }
+
+    pub fn get(self: *const ContactBook, node_id: NodeId) ?Contact {
+        return self.contacts.get(node_id);
+    }
+
+    /// Record a peer's static key + address. No-ops for our own node id or when
+    /// no pubkey is supplied; a full table silently drops the entry.
+    pub fn remember(self: *ContactBook, node_id: NodeId, pubkey: ?*const [33]u8, addr: Address) void {
+        if (std.mem.eql(u8, &node_id, &self.local_node_id)) return;
+        const pk = pubkey orelse return;
+        if (!self.contacts.contains(node_id) and self.contacts.count() >= self.max_contacts) return;
+        self.contacts.put(node_id, .{ .pubkey = pk.*, .addr = addr }) catch return;
+        const short = std.fmt.bytesToHex(node_id[0..4].*, .lower);
+        scoped_log.debug("remembered contact node={s} addr={any}", .{ &short, addr });
+    }
+
+    /// Drop a contact, e.g. once it has earned a routing-table entry.
+    pub fn forget(self: *ContactBook, node_id: NodeId) void {
+        _ = self.contacts.remove(node_id);
+    }
+};
+
+test "contact book bounds distinct peers while allowing updates" {
+    const alloc = std.testing.allocator;
+    const local = [_]u8{0} ** 32;
+    var book = ContactBook.init(alloc, local, 2);
+    defer book.deinit();
+
+    const pubkey = [_]u8{2} ** 33;
+    const first = [_]u8{1} ** 32;
+    const second = [_]u8{2} ** 32;
+    const overflow = [_]u8{3} ** 32;
+    const addr_a = Address{ .ip4 = .{ .bytes = .{ 127, 0, 0, 1 }, .port = 9000 } };
+    const addr_b = Address{ .ip4 = .{ .bytes = .{ 127, 0, 0, 1 }, .port = 9001 } };
+
+    book.remember(first, &pubkey, addr_a);
+    book.remember(second, &pubkey, addr_a);
+    book.remember(overflow, &pubkey, addr_a);
+    try std.testing.expectEqual(@as(usize, 2), book.contacts.count());
+    try std.testing.expect(book.get(overflow) == null);
+
+    book.remember(first, &pubkey, addr_b);
+    try std.testing.expect(book.get(first).?.addr.eql(&addr_b));
+}

--- a/src/discv5/protocol/events.zig
+++ b/src/discv5/protocol/events.zig
@@ -1,0 +1,77 @@
+const std = @import("std");
+const Allocator = std.mem.Allocator;
+const Io = std.Io;
+const Address = Io.net.IpAddress;
+
+const messages = @import("message.zig");
+const request_tracker = @import("request_tracker.zig");
+const NodeId = @import("../enr.zig").NodeId;
+
+pub const PongEvent = struct {
+    peer_id: NodeId,
+    peer_addr: Address,
+    req_id: messages.ReqId,
+    enr_seq: u64,
+    recipient_ip: messages.Pong.RecipientIp,
+    recipient_port: u16,
+};
+
+pub const NodesEvent = struct {
+    peer_id: NodeId,
+    peer_addr: Address,
+    req_id: messages.ReqId,
+    enrs: [][]u8,
+
+    pub fn deinit(self: *NodesEvent, alloc: Allocator) void {
+        for (self.enrs) |enr| alloc.free(enr);
+        alloc.free(self.enrs);
+    }
+};
+
+pub const TalkReqEvent = struct {
+    peer_id: NodeId,
+    peer_addr: Address,
+    req_id: messages.ReqId,
+    protocol: []u8,
+    request: []u8,
+
+    pub fn deinit(self: *TalkReqEvent, alloc: Allocator) void {
+        alloc.free(self.protocol);
+        alloc.free(self.request);
+    }
+};
+
+pub const TalkRespEvent = struct {
+    peer_id: NodeId,
+    peer_addr: Address,
+    req_id: messages.ReqId,
+    response: []u8,
+
+    pub fn deinit(self: *TalkRespEvent, alloc: Allocator) void {
+        alloc.free(self.response);
+    }
+};
+
+pub const RequestTimeoutEvent = struct {
+    peer_id: NodeId,
+    req_id: messages.ReqId,
+    kind: request_tracker.RequestKind,
+};
+
+pub const Event = union(enum) {
+    pong: PongEvent,
+    nodes: NodesEvent,
+    talkreq: TalkReqEvent,
+    talkresp: TalkRespEvent,
+    request_timeout: RequestTimeoutEvent,
+
+    pub fn deinit(self: *Event, alloc: Allocator) void {
+        switch (self.*) {
+            .pong => {},
+            .nodes => |*nodes| nodes.deinit(alloc),
+            .talkreq => |*talkreq| talkreq.deinit(alloc),
+            .talkresp => |*talkresp| talkresp.deinit(alloc),
+            .request_timeout => {},
+        }
+    }
+};

--- a/src/discv5/protocol/handshake.zig
+++ b/src/discv5/protocol/handshake.zig
@@ -1,0 +1,183 @@
+//! Pure wire-format and validation helpers for the discv5 handshake.
+//!
+//! These functions are stateless: they take explicit inputs and return values
+//! or errors, with no reference to the protocol instance. That keeps the
+//! `handleWhoareyou`/`handleHandshake` handlers as thin orchestration and makes
+//! the fiddly byte-layout and ENR-validation logic unit-testable on its own.
+
+const std = @import("std");
+const enr_mod = @import("../enr.zig");
+
+const Io = std.Io;
+const Address = Io.net.IpAddress;
+const NodeId = enr_mod.NodeId;
+
+/// id-signature size in handshake authdata (fixed for identity scheme "v4").
+pub const sig_size: u8 = 64;
+/// Ephemeral compressed-pubkey size in handshake authdata.
+pub const eph_key_size: u8 = 33;
+/// authdata-head = src-id (32) || sig-size (1) || eph-key-size (1).
+const authdata_head_size: usize = 34;
+
+pub const Error = error{
+    ShortAuthdata,
+    TruncatedAuthdata,
+    BadAuthdataSizes,
+    InvalidEnr,
+    EnrMissingPubkey,
+    EnrNodeIdMismatch,
+    EnrEndpointMismatch,
+    BufferTooSmall,
+};
+
+/// Parsed view over a received HANDSHAKE packet's authdata. `id_sig` and
+/// `eph_pubkey` borrow from the caller's `authdata` buffer.
+pub const Authdata = struct {
+    src_id: NodeId,
+    id_sig: *const [sig_size]u8,
+    eph_pubkey: *const [eph_key_size]u8,
+    maybe_enr: ?[]const u8,
+};
+
+/// Validate the authdata structure and slice out its fields:
+///   authdata = src-id (32) || sig-size (1) || eph-key-size (1)
+///              || id-signature (64) || eph-pubkey (33) || [record]
+pub fn parseAuthdata(authdata: []const u8) Error!Authdata {
+    if (authdata.len < authdata_head_size) return Error.ShortAuthdata;
+
+    const declared_sig = authdata[32];
+    const declared_eph = authdata[33];
+    if (authdata.len < authdata_head_size + @as(usize, declared_sig) + @as(usize, declared_eph))
+        return Error.TruncatedAuthdata;
+    if (declared_sig != sig_size or declared_eph != eph_key_size) return Error.BadAuthdataSizes;
+
+    const sig_end = authdata_head_size + @as(usize, sig_size);
+    const eph_end = sig_end + @as(usize, eph_key_size);
+    return .{
+        .src_id = authdata[0..32].*,
+        .id_sig = authdata[authdata_head_size..][0..sig_size],
+        .eph_pubkey = authdata[sig_end..][0..eph_key_size],
+        .maybe_enr = if (authdata.len > eph_end) authdata[eph_end..] else null,
+    };
+}
+
+/// Assemble HANDSHAKE authdata into `out`, returning the populated prefix.
+/// `enr_bytes` may be empty to omit the optional record.
+pub fn buildAuthdata(
+    out: []u8,
+    local_node_id: NodeId,
+    id_sig: *const [sig_size]u8,
+    eph_pubkey: *const [eph_key_size]u8,
+    enr_bytes: []const u8,
+) Error![]u8 {
+    const sig_end = authdata_head_size + @as(usize, sig_size);
+    const eph_end = sig_end + @as(usize, eph_key_size);
+    const total = eph_end + enr_bytes.len;
+    if (total > out.len) return Error.BufferTooSmall;
+
+    out[0..32].* = local_node_id;
+    out[32] = sig_size;
+    out[33] = eph_key_size;
+    @memcpy(out[authdata_head_size..sig_end], id_sig);
+    @memcpy(out[sig_end..eph_end], eph_pubkey);
+    if (enr_bytes.len > 0) @memcpy(out[eph_end..total], enr_bytes);
+    return out[0..total];
+}
+
+/// Decode `enr_bytes`, confirm it carries a secp256k1 pubkey whose derived
+/// node-id equals `src_id`, and return that compressed pubkey.
+pub fn pubkeyFromEnr(enr_bytes: []const u8, src_id: NodeId) Error![eph_key_size]u8 {
+    const parsed = enr_mod.decode(enr_bytes) catch return Error.InvalidEnr;
+    const pk = parsed.pubkey orelse return Error.EnrMissingPubkey;
+    if (!std.mem.eql(u8, &enr_mod.nodeIdFromCompressedPubkey(&pk), &src_id))
+        return Error.EnrNodeIdMismatch;
+    return pk;
+}
+
+/// Decode `enr_bytes` and confirm its advertised endpoint matches `observed`,
+/// unless `allow_unverified` is set (an ENR with no endpoint always passes).
+pub fn verifyEnrEndpoint(enr_bytes: []const u8, src_id: NodeId, observed: Address, allow_unverified: bool) Error!void {
+    const parsed = enr_mod.decode(enr_bytes) catch return Error.InvalidEnr;
+    if (!endpointMatches(&parsed, &src_id, observed) and !allow_unverified)
+        return Error.EnrEndpointMismatch;
+}
+
+/// True when `parsed`'s node-id equals `expected_node_id` and either it
+/// advertises no endpoint or an advertised endpoint matches `observed_addr`.
+fn endpointMatches(parsed: *const enr_mod.Enr, expected_node_id: *const NodeId, observed_addr: Address) bool {
+    const node_id = parsed.nodeId() orelse return false;
+    if (!std.mem.eql(u8, &node_id, expected_node_id)) return false;
+
+    var has_endpoint = false;
+    if (parsed.ip) |ip| {
+        if (parsed.udp) |port| {
+            has_endpoint = true;
+            switch (observed_addr) {
+                .ip4 => |ip4| {
+                    if (std.mem.eql(u8, &ip, &ip4.bytes) and port == ip4.port) return true;
+                },
+                .ip6 => {},
+            }
+        }
+    }
+    if (parsed.ip6) |ip6| {
+        if (parsed.udp6) |port| {
+            has_endpoint = true;
+            switch (observed_addr) {
+                .ip4 => {},
+                .ip6 => |addr_ip6| {
+                    if (std.mem.eql(u8, &ip6, &addr_ip6.bytes) and port == addr_ip6.port) return true;
+                },
+            }
+        }
+    }
+
+    return !has_endpoint;
+}
+
+test "parseAuthdata round-trips a built authdata header" {
+    const node_id = [_]u8{0xAB} ** 32;
+    var sig = [_]u8{0} ** sig_size;
+    sig[0] = 0x11;
+    var eph = [_]u8{0} ** eph_key_size;
+    eph[0] = 0x22;
+
+    var buf: [256]u8 = undefined;
+    const built = try buildAuthdata(&buf, node_id, &sig, &eph, &[_]u8{});
+    const parsed = try parseAuthdata(built);
+
+    try std.testing.expectEqualSlices(u8, &node_id, &parsed.src_id);
+    try std.testing.expectEqualSlices(u8, &sig, parsed.id_sig);
+    try std.testing.expectEqualSlices(u8, &eph, parsed.eph_pubkey);
+    try std.testing.expect(parsed.maybe_enr == null);
+}
+
+test "parseAuthdata carries the optional trailing ENR" {
+    const node_id = [_]u8{0x01} ** 32;
+    const sig = [_]u8{0} ** sig_size;
+    const eph = [_]u8{0} ** eph_key_size;
+    const enr = [_]u8{ 0xDE, 0xAD, 0xBE, 0xEF };
+
+    var buf: [256]u8 = undefined;
+    const built = try buildAuthdata(&buf, node_id, &sig, &eph, &enr);
+    const parsed = try parseAuthdata(built);
+    try std.testing.expectEqualSlices(u8, &enr, parsed.maybe_enr.?);
+}
+
+test "parseAuthdata rejects short and truncated authdata" {
+    try std.testing.expectError(Error.ShortAuthdata, parseAuthdata(&[_]u8{ 0x00, 0x01 }));
+
+    var head = [_]u8{0} ** authdata_head_size;
+    head[32] = sig_size;
+    head[33] = eph_key_size;
+    try std.testing.expectError(Error.TruncatedAuthdata, parseAuthdata(&head));
+}
+
+test "parseAuthdata rejects non-v4 sizes" {
+    // Long enough to pass the truncation check (which runs first) so the
+    // wrong-sizes check is what trips.
+    var buf = [_]u8{0} ** (authdata_head_size + 65 + eph_key_size);
+    buf[32] = 65; // wrong sig size
+    buf[33] = eph_key_size;
+    try std.testing.expectError(Error.BadAuthdataSizes, parseAuthdata(&buf));
+}

--- a/src/discv5/protocol/message.zig
+++ b/src/discv5/protocol/message.zig
@@ -1,0 +1,748 @@
+//! Discovery v5 message types
+
+const std = @import("std");
+const Allocator = std.mem.Allocator;
+const rlp = @import("../rlp.zig");
+
+pub const MSG_PING: u8 = 0x01;
+pub const MSG_PONG: u8 = 0x02;
+pub const MSG_FINDNODE: u8 = 0x03;
+pub const MSG_NODES: u8 = 0x04;
+pub const MSG_TALKREQ: u8 = 0x05;
+pub const MSG_TALKRESP: u8 = 0x06;
+
+pub const MAX_ENCODED_SIZE: usize = 1280;
+
+pub const Error = error{
+    InvalidMessage,
+    OutOfMemory,
+    InvalidEncoding,
+    UnexpectedType,
+    Overflow,
+    BufferTooSmall,
+};
+
+// Message payloads are fixed-shape RLP lists. Reject both trailing outer RLP
+// bytes and extra fields inside the list so malformed packets have one clear
+// interpretation.
+fn readMessageList(data: []const u8, expected_type: u8) Error!rlp.Reader {
+    if (data.len < 1 or data[0] != expected_type) return Error.InvalidMessage;
+
+    var r = rlp.Reader.init(data[1..]);
+    const list = r.readList() catch return Error.InvalidEncoding;
+    if (!r.atEnd()) return Error.InvalidEncoding;
+    return list;
+}
+
+fn expectEnd(r: *const rlp.Reader) Error!void {
+    if (!r.atEnd()) return Error.InvalidEncoding;
+}
+
+/// Discv5 request IDs are RLP byte arrays of length 0..8, and responses must
+/// echo the exact byte sequence from the request. Keep the length alongside the
+/// fixed backing storage so values like `01`, `01 00`, and `01 00 00 00` stay
+/// distinct without allocating. The unused tail is zeroed so `ReqId` can be
+/// used directly as a value key in hash maps.
+pub const ReqId = struct {
+    bytes: [8]u8,
+    len: u8,
+
+    pub fn fromSlice(s: []const u8) Error!ReqId {
+        if (s.len > 8) return Error.InvalidMessage;
+        var id = ReqId{ .bytes = [_]u8{0} ** 8, .len = @intCast(s.len) };
+        @memcpy(id.bytes[0..s.len], s);
+        return id;
+    }
+
+    pub fn slice(self: *const ReqId) []const u8 {
+        return self.bytes[0..self.len];
+    }
+};
+
+pub const Ping = struct {
+    req_id: ReqId,
+    enr_seq: u64,
+
+    pub fn encode(self: *const Ping, alloc: Allocator) ![]u8 {
+        var buf: [MAX_ENCODED_SIZE]u8 = undefined;
+        const encoded = try self.encodeInto(&buf);
+        return try alloc.dupe(u8, encoded);
+    }
+
+    pub fn encodeInto(self: *const Ping, out: []u8) Error![]u8 {
+        if (out.len == 0) return Error.BufferTooSmall;
+        var w = rlp.Writer.initBuffer(out[1..]);
+        const list_start = try w.beginListBounded();
+        try w.writeBytesBounded(self.req_id.slice());
+        try w.writeUint64Bounded(self.enr_seq);
+        try w.finishList(list_start);
+        const rlp_bytes = w.bytes();
+        out[0] = MSG_PING;
+        return out[0 .. 1 + rlp_bytes.len];
+    }
+
+    pub fn decode(data: []const u8) Error!Ping {
+        var list = try readMessageList(data, MSG_PING);
+        const req_id_bytes = list.readBytes() catch return Error.InvalidEncoding;
+        const req_id = try ReqId.fromSlice(req_id_bytes);
+        const enr_seq = list.readUint64() catch return Error.InvalidEncoding;
+        try expectEnd(&list);
+        return Ping{ .req_id = req_id, .enr_seq = enr_seq };
+    }
+};
+
+pub const Pong = struct {
+    pub const RecipientIp = union(enum) {
+        ip4: [4]u8,
+        ip6: [16]u8,
+    };
+
+    req_id: ReqId,
+    enr_seq: u64,
+    recipient_ip: RecipientIp,
+    recipient_port: u16,
+
+    pub fn encode(self: *const Pong, alloc: Allocator) ![]u8 {
+        var buf: [MAX_ENCODED_SIZE]u8 = undefined;
+        const encoded = try self.encodeInto(&buf);
+        return try alloc.dupe(u8, encoded);
+    }
+
+    pub fn encodeInto(self: *const Pong, out: []u8) Error![]u8 {
+        if (out.len == 0) return Error.BufferTooSmall;
+        var w = rlp.Writer.initBuffer(out[1..]);
+        const list_start = try w.beginListBounded();
+        try w.writeBytesBounded(self.req_id.slice());
+        try w.writeUint64Bounded(self.enr_seq);
+        switch (self.recipient_ip) {
+            .ip4 => |ip| try w.writeBytesBounded(&ip),
+            .ip6 => |ip| try w.writeBytesBounded(&ip),
+        }
+        try w.writeUint64Bounded(self.recipient_port);
+        try w.finishList(list_start);
+        const rlp_bytes = w.bytes();
+        out[0] = MSG_PONG;
+        return out[0 .. 1 + rlp_bytes.len];
+    }
+
+    pub fn decode(data: []const u8) Error!Pong {
+        var list = try readMessageList(data, MSG_PONG);
+        const req_id_bytes = list.readBytes() catch return Error.InvalidEncoding;
+        const req_id = try ReqId.fromSlice(req_id_bytes);
+        const enr_seq = list.readUint64() catch return Error.InvalidEncoding;
+        const ip_bytes = list.readBytes() catch return Error.InvalidEncoding;
+        const port_value = list.readUint64() catch return Error.InvalidEncoding;
+        if (port_value > std.math.maxInt(u16)) return Error.InvalidMessage;
+        const port: u16 = @intCast(port_value);
+        try expectEnd(&list);
+        return Pong{
+            .req_id = req_id,
+            .enr_seq = enr_seq,
+            .recipient_ip = switch (ip_bytes.len) {
+                4 => .{ .ip4 = ip_bytes[0..4].* },
+                16 => .{ .ip6 = ip_bytes[0..16].* },
+                else => return Error.InvalidMessage,
+            },
+            .recipient_port = port,
+        };
+    }
+};
+
+pub const FindNode = struct {
+    req_id: ReqId,
+    distances: []const u16,
+
+    pub fn encode(self: *const FindNode, alloc: Allocator) ![]u8 {
+        var buf: [MAX_ENCODED_SIZE]u8 = undefined;
+        const encoded = try self.encodeInto(&buf);
+        return try alloc.dupe(u8, encoded);
+    }
+
+    pub fn encodeInto(self: *const FindNode, out: []u8) Error![]u8 {
+        if (out.len == 0) return Error.BufferTooSmall;
+        var w = rlp.Writer.initBuffer(out[1..]);
+        const list_start = try w.beginListBounded();
+        try w.writeBytesBounded(self.req_id.slice());
+        const dist_start = try w.beginListBounded();
+        for (self.distances) |d| {
+            try w.writeUint64Bounded(d);
+        }
+        try w.finishList(dist_start);
+        try w.finishList(list_start);
+        const rlp_bytes = w.bytes();
+        out[0] = MSG_FINDNODE;
+        return out[0 .. 1 + rlp_bytes.len];
+    }
+
+    pub fn decode(alloc: Allocator, data: []const u8) Error!struct { msg: FindNode, distances: []u16 } {
+        var stack_distances: [127]u16 = undefined;
+        const msg = try decodeInto(data, &stack_distances);
+        const dist_slice = try alloc.dupe(u16, msg.distances);
+        return .{
+            .msg = FindNode{ .req_id = msg.req_id, .distances = dist_slice },
+            .distances = dist_slice,
+        };
+    }
+
+    pub fn decodeInto(data: []const u8, distances_out: []u16) Error!FindNode {
+        var list = try readMessageList(data, MSG_FINDNODE);
+        const req_id_bytes = list.readBytes() catch return Error.InvalidEncoding;
+        const req_id = try ReqId.fromSlice(req_id_bytes);
+
+        var dist_list = list.readList() catch return Error.InvalidEncoding;
+        var distances_len: usize = 0;
+        while (!dist_list.atEnd()) {
+            const d = dist_list.readUint64() catch return Error.InvalidEncoding;
+            if (d > 256) return Error.InvalidMessage;
+            if (distances_len >= distances_out.len) return Error.BufferTooSmall;
+            distances_out[distances_len] = @intCast(d);
+            distances_len += 1;
+        }
+        try expectEnd(&list);
+        return FindNode{ .req_id = req_id, .distances = distances_out[0..distances_len] };
+    }
+};
+
+pub const Nodes = struct {
+    req_id: ReqId,
+    total: u64,
+    enrs: []const []const u8,
+
+    pub fn encode(self: *const Nodes, alloc: Allocator) ![]u8 {
+        var buf: [MAX_ENCODED_SIZE]u8 = undefined;
+        const encoded = try self.encodeInto(&buf);
+        return try alloc.dupe(u8, encoded);
+    }
+
+    pub fn encodeInto(self: *const Nodes, out: []u8) Error![]u8 {
+        if (out.len == 0) return Error.BufferTooSmall;
+        var w = rlp.Writer.initBuffer(out[1..]);
+        const list_start = try w.beginListBounded();
+        try w.writeBytesBounded(self.req_id.slice());
+        try w.writeUint64Bounded(self.total);
+        const enr_start = try w.beginListBounded();
+        for (self.enrs) |enr| {
+            try w.writeRawItemBounded(enr);
+        }
+        try w.finishList(enr_start);
+        try w.finishList(list_start);
+        const rlp_bytes = w.bytes();
+        out[0] = MSG_NODES;
+        return out[0 .. 1 + rlp_bytes.len];
+    }
+
+    pub fn decode(alloc: Allocator, data: []const u8) Error!struct { msg: Nodes, enrs: [][]u8 } {
+        var stack_enrs: [16][]const u8 = undefined;
+        const msg = try decodeInto(data, &stack_enrs);
+        var enrs: std.ArrayListUnmanaged([]u8) = .empty;
+        errdefer {
+            for (enrs.items) |enr| alloc.free(enr);
+            enrs.deinit(alloc);
+        }
+        for (msg.enrs) |enr| {
+            try enrs.append(alloc, try alloc.dupe(u8, enr));
+        }
+        const owned = try enrs.toOwnedSlice(alloc);
+        return .{
+            .msg = .{ .req_id = msg.req_id, .total = msg.total, .enrs = owned },
+            .enrs = owned,
+        };
+    }
+
+    pub fn decodeInto(data: []const u8, enrs_out: [][]const u8) Error!Nodes {
+        var list = try readMessageList(data, MSG_NODES);
+        const req_id_bytes = list.readBytes() catch return Error.InvalidEncoding;
+        const req_id = try ReqId.fromSlice(req_id_bytes);
+        const total = list.readUint64() catch return Error.InvalidEncoding;
+
+        var enr_list = list.readList() catch return Error.InvalidEncoding;
+        var enrs_len: usize = 0;
+        while (!enr_list.atEnd()) {
+            const enr_bytes = enr_list.readRawItem() catch return Error.InvalidEncoding;
+            if (enrs_len >= enrs_out.len) return Error.BufferTooSmall;
+            enrs_out[enrs_len] = enr_bytes;
+            enrs_len += 1;
+        }
+        try expectEnd(&list);
+        return Nodes{ .req_id = req_id, .total = total, .enrs = enrs_out[0..enrs_len] };
+    }
+};
+
+pub const TalkReq = struct {
+    req_id: ReqId,
+    protocol: []const u8,
+    request: []const u8,
+
+    pub fn encode(self: *const TalkReq, alloc: Allocator) ![]u8 {
+        var buf: [MAX_ENCODED_SIZE]u8 = undefined;
+        const encoded = try self.encodeInto(&buf);
+        return try alloc.dupe(u8, encoded);
+    }
+
+    pub fn encodeInto(self: *const TalkReq, out: []u8) Error![]u8 {
+        if (out.len == 0) return Error.BufferTooSmall;
+        var w = rlp.Writer.initBuffer(out[1..]);
+        const list_start = try w.beginListBounded();
+        try w.writeBytesBounded(self.req_id.slice());
+        try w.writeBytesBounded(self.protocol);
+        try w.writeBytesBounded(self.request);
+        try w.finishList(list_start);
+        const rlp_bytes = w.bytes();
+        out[0] = MSG_TALKREQ;
+        return out[0 .. 1 + rlp_bytes.len];
+    }
+
+    pub fn decode(data: []const u8) Error!TalkReq {
+        var list = try readMessageList(data, MSG_TALKREQ);
+        const req_id_bytes = list.readBytes() catch return Error.InvalidEncoding;
+        const req_id = try ReqId.fromSlice(req_id_bytes);
+        const protocol = list.readBytes() catch return Error.InvalidEncoding;
+        const request = list.readBytes() catch return Error.InvalidEncoding;
+        try expectEnd(&list);
+        return TalkReq{ .req_id = req_id, .protocol = protocol, .request = request };
+    }
+};
+
+pub const TalkResp = struct {
+    req_id: ReqId,
+    response: []const u8,
+
+    pub fn encode(self: *const TalkResp, alloc: Allocator) ![]u8 {
+        var buf: [MAX_ENCODED_SIZE]u8 = undefined;
+        const encoded = try self.encodeInto(&buf);
+        return try alloc.dupe(u8, encoded);
+    }
+
+    pub fn encodeInto(self: *const TalkResp, out: []u8) Error![]u8 {
+        if (out.len == 0) return Error.BufferTooSmall;
+        var w = rlp.Writer.initBuffer(out[1..]);
+        const list_start = try w.beginListBounded();
+        try w.writeBytesBounded(self.req_id.slice());
+        try w.writeBytesBounded(self.response);
+        try w.finishList(list_start);
+        const rlp_bytes = w.bytes();
+        out[0] = MSG_TALKRESP;
+        return out[0 .. 1 + rlp_bytes.len];
+    }
+
+    pub fn decode(data: []const u8) Error!TalkResp {
+        var list = try readMessageList(data, MSG_TALKRESP);
+        const req_id_bytes = list.readBytes() catch return Error.InvalidEncoding;
+        const req_id = try ReqId.fromSlice(req_id_bytes);
+        const response = list.readBytes() catch return Error.InvalidEncoding;
+        try expectEnd(&list);
+        return TalkResp{ .req_id = req_id, .response = response };
+    }
+};
+
+// =========== Tests ===========
+
+fn appendTrailingByte(alloc: Allocator, encoded: []const u8) ![]u8 {
+    const with_trailing = try alloc.alloc(u8, encoded.len + 1);
+    @memcpy(with_trailing[0..encoded.len], encoded);
+    with_trailing[encoded.len] = 0x80;
+    return with_trailing;
+}
+
+fn appendExtraShortListField(alloc: Allocator, encoded: []const u8) ![]u8 {
+    try std.testing.expect(encoded.len >= 2);
+    try std.testing.expect(encoded[1] >= 0xc0 and encoded[1] < 0xf8);
+    try std.testing.expect(encoded[1] < 0xf7);
+
+    const with_extra = try alloc.alloc(u8, encoded.len + 1);
+    @memcpy(with_extra[0..encoded.len], encoded);
+    with_extra[1] += 1;
+    with_extra[encoded.len] = 0x80;
+    return with_extra;
+}
+
+test "discv5 messages: PING encode/decode" {
+    const alloc = std.testing.allocator;
+    const ping = Ping{
+        .req_id = try ReqId.fromSlice(&[_]u8{ 0x00, 0x00, 0x00, 0x01 }),
+        .enr_seq = 2,
+    };
+    const encoded = try ping.encode(alloc);
+    defer alloc.free(encoded);
+
+    const decoded = try Ping.decode(encoded);
+    try std.testing.expectEqual(@as(u64, 2), decoded.enr_seq);
+    try std.testing.expectEqualSlices(u8, ping.req_id.slice(), decoded.req_id.slice());
+}
+
+test "discv5 messages accept empty request IDs" {
+    const empty_req_id = try ReqId.fromSlice(&.{});
+    try std.testing.expectEqual(@as(u8, 0), empty_req_id.len);
+    try std.testing.expectEqual(@as(usize, 0), empty_req_id.slice().len);
+    try std.testing.expectError(Error.InvalidMessage, ReqId.fromSlice(&([_]u8{0} ** 9)));
+
+    var encoded_buf: [MAX_ENCODED_SIZE]u8 = undefined;
+
+    const ping = Ping{ .req_id = empty_req_id, .enr_seq = 1 };
+    const encoded_ping = try ping.encodeInto(&encoded_buf);
+    const decoded_ping = try Ping.decode(encoded_ping);
+    try std.testing.expectEqual(@as(usize, 0), decoded_ping.req_id.slice().len);
+
+    const pong = Pong{
+        .req_id = decoded_ping.req_id,
+        .enr_seq = 1,
+        .recipient_ip = .{ .ip4 = .{ 127, 0, 0, 1 } },
+        .recipient_port = 9000,
+    };
+    const encoded_pong = try pong.encodeInto(&encoded_buf);
+    const decoded_pong = try Pong.decode(encoded_pong);
+    try std.testing.expectEqual(@as(usize, 0), decoded_pong.req_id.slice().len);
+
+    const find_node = FindNode{ .req_id = empty_req_id, .distances = &.{1} };
+    const encoded_find_node = try find_node.encodeInto(&encoded_buf);
+    var distances_buf: [1]u16 = undefined;
+    const decoded_find_node = try FindNode.decodeInto(encoded_find_node, &distances_buf);
+    try std.testing.expectEqual(@as(usize, 0), decoded_find_node.req_id.slice().len);
+
+    const nodes = Nodes{ .req_id = empty_req_id, .total = 1, .enrs = &.{} };
+    const encoded_nodes = try nodes.encodeInto(&encoded_buf);
+    var enrs_buf: [1][]const u8 = undefined;
+    const decoded_nodes = try Nodes.decodeInto(encoded_nodes, &enrs_buf);
+    try std.testing.expectEqual(@as(usize, 0), decoded_nodes.req_id.slice().len);
+
+    const talk_req = TalkReq{ .req_id = empty_req_id, .protocol = "test", .request = "request" };
+    const encoded_talk_req = try talk_req.encodeInto(&encoded_buf);
+    const decoded_talk_req = try TalkReq.decode(encoded_talk_req);
+    try std.testing.expectEqual(@as(usize, 0), decoded_talk_req.req_id.slice().len);
+
+    const talk_resp = TalkResp{ .req_id = empty_req_id, .response = "response" };
+    const encoded_talk_resp = try talk_resp.encodeInto(&encoded_buf);
+    const decoded_talk_resp = try TalkResp.decode(encoded_talk_resp);
+    try std.testing.expectEqual(@as(usize, 0), decoded_talk_resp.req_id.slice().len);
+}
+
+test "discv5 messages reject trailing bytes after outer RLP" {
+    const alloc = std.testing.allocator;
+
+    {
+        const msg = Ping{
+            .req_id = try ReqId.fromSlice(&[_]u8{0x01}),
+            .enr_seq = 2,
+        };
+        const encoded = try msg.encode(alloc);
+        defer alloc.free(encoded);
+        const with_trailing = try appendTrailingByte(alloc, encoded);
+        defer alloc.free(with_trailing);
+        try std.testing.expectError(Error.InvalidEncoding, Ping.decode(with_trailing));
+    }
+
+    {
+        const msg = Pong{
+            .req_id = try ReqId.fromSlice(&[_]u8{0x01}),
+            .enr_seq = 2,
+            .recipient_ip = .{ .ip4 = [4]u8{ 127, 0, 0, 1 } },
+            .recipient_port = 9000,
+        };
+        const encoded = try msg.encode(alloc);
+        defer alloc.free(encoded);
+        const with_trailing = try appendTrailingByte(alloc, encoded);
+        defer alloc.free(with_trailing);
+        try std.testing.expectError(Error.InvalidEncoding, Pong.decode(with_trailing));
+    }
+
+    {
+        const distances = [_]u16{ 256, 255 };
+        const msg = FindNode{
+            .req_id = try ReqId.fromSlice(&[_]u8{0x01}),
+            .distances = &distances,
+        };
+        const encoded = try msg.encode(alloc);
+        defer alloc.free(encoded);
+        const with_trailing = try appendTrailingByte(alloc, encoded);
+        defer alloc.free(with_trailing);
+        var distances_out: [2]u16 = undefined;
+        try std.testing.expectError(Error.InvalidEncoding, FindNode.decodeInto(with_trailing, &distances_out));
+    }
+
+    {
+        var enr_buf: [16]u8 = undefined;
+        var w = rlp.Writer.initBuffer(&enr_buf);
+        try w.writeBytesBounded("enr");
+        const enr = w.bytes();
+        const msg = Nodes{
+            .req_id = try ReqId.fromSlice(&[_]u8{0x01}),
+            .total = 1,
+            .enrs = &.{enr},
+        };
+        const encoded = try msg.encode(alloc);
+        defer alloc.free(encoded);
+        const with_trailing = try appendTrailingByte(alloc, encoded);
+        defer alloc.free(with_trailing);
+        var enrs_out: [1][]const u8 = undefined;
+        try std.testing.expectError(Error.InvalidEncoding, Nodes.decodeInto(with_trailing, &enrs_out));
+    }
+
+    {
+        const msg = TalkReq{
+            .req_id = try ReqId.fromSlice(&[_]u8{0x01}),
+            .protocol = "eth",
+            .request = "hello",
+        };
+        const encoded = try msg.encode(alloc);
+        defer alloc.free(encoded);
+        const with_trailing = try appendTrailingByte(alloc, encoded);
+        defer alloc.free(with_trailing);
+        try std.testing.expectError(Error.InvalidEncoding, TalkReq.decode(with_trailing));
+    }
+
+    {
+        const msg = TalkResp{
+            .req_id = try ReqId.fromSlice(&[_]u8{0x01}),
+            .response = "hello",
+        };
+        const encoded = try msg.encode(alloc);
+        defer alloc.free(encoded);
+        const with_trailing = try appendTrailingByte(alloc, encoded);
+        defer alloc.free(with_trailing);
+        try std.testing.expectError(Error.InvalidEncoding, TalkResp.decode(with_trailing));
+    }
+}
+
+test "discv5 messages reject extra fields inside message list" {
+    const alloc = std.testing.allocator;
+
+    {
+        const msg = Ping{
+            .req_id = try ReqId.fromSlice(&[_]u8{0x01}),
+            .enr_seq = 2,
+        };
+        const encoded = try msg.encode(alloc);
+        defer alloc.free(encoded);
+        const with_extra = try appendExtraShortListField(alloc, encoded);
+        defer alloc.free(with_extra);
+        try std.testing.expectError(Error.InvalidEncoding, Ping.decode(with_extra));
+    }
+
+    {
+        const msg = Pong{
+            .req_id = try ReqId.fromSlice(&[_]u8{0x01}),
+            .enr_seq = 2,
+            .recipient_ip = .{ .ip4 = [4]u8{ 127, 0, 0, 1 } },
+            .recipient_port = 9000,
+        };
+        const encoded = try msg.encode(alloc);
+        defer alloc.free(encoded);
+        const with_extra = try appendExtraShortListField(alloc, encoded);
+        defer alloc.free(with_extra);
+        try std.testing.expectError(Error.InvalidEncoding, Pong.decode(with_extra));
+    }
+
+    {
+        const distances = [_]u16{ 256, 255 };
+        const msg = FindNode{
+            .req_id = try ReqId.fromSlice(&[_]u8{0x01}),
+            .distances = &distances,
+        };
+        const encoded = try msg.encode(alloc);
+        defer alloc.free(encoded);
+        const with_extra = try appendExtraShortListField(alloc, encoded);
+        defer alloc.free(with_extra);
+        var distances_out: [2]u16 = undefined;
+        try std.testing.expectError(Error.InvalidEncoding, FindNode.decodeInto(with_extra, &distances_out));
+    }
+
+    {
+        var enr_buf: [16]u8 = undefined;
+        var w = rlp.Writer.initBuffer(&enr_buf);
+        try w.writeBytesBounded("enr");
+        const enr = w.bytes();
+        const msg = Nodes{
+            .req_id = try ReqId.fromSlice(&[_]u8{0x01}),
+            .total = 1,
+            .enrs = &.{enr},
+        };
+        const encoded = try msg.encode(alloc);
+        defer alloc.free(encoded);
+        const with_extra = try appendExtraShortListField(alloc, encoded);
+        defer alloc.free(with_extra);
+        var enrs_out: [1][]const u8 = undefined;
+        try std.testing.expectError(Error.InvalidEncoding, Nodes.decodeInto(with_extra, &enrs_out));
+    }
+
+    {
+        const msg = TalkReq{
+            .req_id = try ReqId.fromSlice(&[_]u8{0x01}),
+            .protocol = "eth",
+            .request = "hello",
+        };
+        const encoded = try msg.encode(alloc);
+        defer alloc.free(encoded);
+        const with_extra = try appendExtraShortListField(alloc, encoded);
+        defer alloc.free(with_extra);
+        try std.testing.expectError(Error.InvalidEncoding, TalkReq.decode(with_extra));
+    }
+
+    {
+        const msg = TalkResp{
+            .req_id = try ReqId.fromSlice(&[_]u8{0x01}),
+            .response = "hello",
+        };
+        const encoded = try msg.encode(alloc);
+        defer alloc.free(encoded);
+        const with_extra = try appendExtraShortListField(alloc, encoded);
+        defer alloc.free(with_extra);
+        try std.testing.expectError(Error.InvalidEncoding, TalkResp.decode(with_extra));
+    }
+}
+
+test "discv5 messages: PONG encode/decode" {
+    const alloc = std.testing.allocator;
+    const pong = Pong{
+        .req_id = try ReqId.fromSlice(&[_]u8{ 0x00, 0x00, 0x00, 0x01 }),
+        .enr_seq = 1,
+        .recipient_ip = .{ .ip4 = [4]u8{ 127, 0, 0, 1 } },
+        .recipient_port = 9000,
+    };
+    const encoded = try pong.encode(alloc);
+    defer alloc.free(encoded);
+
+    const decoded = try Pong.decode(encoded);
+    try std.testing.expectEqual(@as(u64, 1), decoded.enr_seq);
+    try std.testing.expectEqual(@as(u16, 9000), decoded.recipient_port);
+    try std.testing.expectEqualDeep(pong.recipient_ip, decoded.recipient_ip);
+}
+
+test "discv5 messages: PONG encode/decode IPv6" {
+    const alloc = std.testing.allocator;
+    const pong = Pong{
+        .req_id = try ReqId.fromSlice(&[_]u8{ 0x00, 0x00, 0x00, 0x02 }),
+        .enr_seq = 2,
+        .recipient_ip = .{ .ip6 = [16]u8{ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1 } },
+        .recipient_port = 9001,
+    };
+    const encoded = try pong.encode(alloc);
+    defer alloc.free(encoded);
+
+    const decoded = try Pong.decode(encoded);
+    try std.testing.expectEqual(@as(u64, 2), decoded.enr_seq);
+    try std.testing.expectEqual(@as(u16, 9001), decoded.recipient_port);
+    try std.testing.expectEqualDeep(pong.recipient_ip, decoded.recipient_ip);
+}
+
+test "discv5 messages: PONG rejects a non-canonical port integer" {
+    const encoded = [_]u8{
+        MSG_PONG,
+        0xca,
+        0x01,
+        0x80,
+        0x84,
+        127,
+        0,
+        0,
+        1,
+        0x82,
+        0,
+        1,
+    };
+    try std.testing.expectError(Error.InvalidEncoding, Pong.decode(&encoded));
+}
+
+test "discv5 messages: FINDNODE encode/decode" {
+    const alloc = std.testing.allocator;
+    const distances = [_]u16{ 256, 255, 254 };
+    const msg = FindNode{
+        .req_id = try ReqId.fromSlice(&[_]u8{0x01}),
+        .distances = &distances,
+    };
+    const encoded = try msg.encode(alloc);
+    defer alloc.free(encoded);
+
+    const result = try FindNode.decode(alloc, encoded);
+    defer alloc.free(result.distances);
+    try std.testing.expectEqual(@as(usize, 3), result.distances.len);
+    try std.testing.expectEqual(@as(u16, 256), result.distances[0]);
+}
+
+test "discv5 messages: TALKREQ encode/decode" {
+    const alloc = std.testing.allocator;
+    const req = TalkReq{
+        .req_id = try ReqId.fromSlice(&[_]u8{0x01}),
+        .protocol = "eth",
+        .request = "hello",
+    };
+    const encoded = try req.encode(alloc);
+    defer alloc.free(encoded);
+
+    const decoded = try TalkReq.decode(encoded);
+    try std.testing.expectEqualSlices(u8, "eth", decoded.protocol);
+    try std.testing.expectEqualSlices(u8, "hello", decoded.request);
+}
+
+test "discv5 messages: NODES encode/decode" {
+    const alloc = std.testing.allocator;
+    const req_id = try ReqId.fromSlice("id");
+    var enr_a_buf: [32]u8 = undefined;
+    var w_a = rlp.Writer.initBuffer(&enr_a_buf);
+    try w_a.writeBytesBounded("enr-a");
+    const enr_a = try alloc.dupe(u8, w_a.bytes());
+    defer alloc.free(enr_a);
+
+    var enr_b_buf: [32]u8 = undefined;
+    var w_b = rlp.Writer.initBuffer(&enr_b_buf);
+    const list_start = try w_b.beginListBounded();
+    try w_b.writeBytesBounded("enr-b");
+    try w_b.finishList(list_start);
+    const enr_b = try alloc.dupe(u8, w_b.bytes());
+    defer alloc.free(enr_b);
+    const msg = Nodes{
+        .req_id = req_id,
+        .total = 2,
+        .enrs = &.{ enr_a, enr_b },
+    };
+
+    const encoded = try msg.encode(alloc);
+    defer alloc.free(encoded);
+
+    const decoded = try Nodes.decode(alloc, encoded);
+    defer {
+        for (decoded.enrs) |enr| alloc.free(enr);
+        alloc.free(decoded.enrs);
+    }
+
+    try std.testing.expectEqual(@as(u64, 2), decoded.msg.total);
+    try std.testing.expectEqual(@as(usize, 2), decoded.enrs.len);
+    try std.testing.expectEqualSlices(u8, enr_a, decoded.enrs[0]);
+    try std.testing.expectEqualSlices(u8, enr_b, decoded.enrs[1]);
+}
+
+test "discv5 messages: NODES decode returns encoded ENR bytes" {
+    const alloc = std.testing.allocator;
+    const enr_mod = @import("../enr.zig");
+    const hex_mod = @import("hex");
+    const secp = @import("../secp256k1.zig");
+
+    const secret_key = hex_mod.hexToBytesComptime(32, "b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291");
+    const key_pair = try secp.keyPairFromSecret(&secret_key);
+    var builder = enr_mod.Builder.init(alloc, key_pair, 1);
+    builder.ip = [4]u8{ 127, 0, 0, 1 };
+    builder.udp = 9000;
+    const enr_bytes = try builder.encode();
+    defer alloc.free(enr_bytes);
+
+    const req_id = try ReqId.fromSlice("id");
+    const msg = Nodes{
+        .req_id = req_id,
+        .total = 1,
+        .enrs = &.{enr_bytes},
+    };
+
+    const encoded = try msg.encode(alloc);
+    defer alloc.free(encoded);
+
+    const decoded = try Nodes.decode(alloc, encoded);
+    defer {
+        for (decoded.enrs) |enr| alloc.free(enr);
+        alloc.free(decoded.enrs);
+    }
+
+    try std.testing.expectEqual(@as(usize, 1), decoded.enrs.len);
+    try std.testing.expectEqualSlices(u8, enr_bytes, decoded.enrs[0]);
+
+    const parsed = try enr_mod.decode(decoded.enrs[0]);
+    try std.testing.expect(parsed.nodeId() != null);
+}

--- a/src/discv5/protocol/packet.zig
+++ b/src/discv5/protocol/packet.zig
@@ -1,0 +1,324 @@
+//! Discovery v5 packet encoding/decoding
+
+const std = @import("std");
+const Aes128 = std.crypto.core.aes.Aes128;
+const Aes128Gcm = std.crypto.aead.aes_gcm.Aes128Gcm;
+
+pub const MASKING_IV_SIZE = 16;
+pub const MAX_PACKET_SIZE: usize = 1280;
+pub const STATIC_HEADER_SIZE = 6 + 2 + 1 + 12 + 2; // = 23
+pub const PROTOCOL_ID = "discv5";
+pub const VERSION: u16 = 0x0001;
+
+pub const FLAG_MESSAGE: u8 = 0;
+pub const FLAG_WHOAREYOU: u8 = 1;
+pub const FLAG_HANDSHAKE: u8 = 2;
+
+pub const NONCE_SIZE = 12;
+pub const NODE_ID_SIZE = 32;
+pub const GCM_TAG_SIZE = 16;
+pub const ID_NONCE_SIZE = 16;
+pub const WHOAREYOU_AUTHDATA_SIZE = ID_NONCE_SIZE + 8;
+pub const WHOAREYOU_CHALLENGE_DATA_SIZE = MASKING_IV_SIZE + STATIC_HEADER_SIZE + WHOAREYOU_AUTHDATA_SIZE;
+
+pub const Error = error{
+    InvalidPacket,
+    InvalidProtocolId,
+    UnsupportedVersion,
+    DecryptionFailed,
+    BufferTooSmall,
+    InvalidFlag,
+    OutOfMemory,
+};
+
+pub const StaticHeader = struct {
+    protocol_id: [6]u8,
+    version: u16,
+    flag: u8,
+    nonce: [12]u8,
+    authdata_size: u16,
+};
+
+/// Views into a decoded discv5 packet.
+///
+/// `decode` mutates the caller-owned packet buffer in place: bytes
+/// `MASKING_IV_SIZE..MASKING_IV_SIZE + header_raw.len` are changed from the
+/// masked wire header into the plaintext `static_header || authdata` header.
+/// The message ciphertext bytes are not modified.
+///
+/// All slices in this struct borrow from that caller-owned packet buffer, so a
+/// `ParsedPacket` must not outlive the `raw` buffer passed to `decode`.
+pub const ParsedPacket = struct {
+    masking_iv: [16]u8,
+    /// Plaintext `static_header || authdata`, used as AES-GCM associated data.
+    header_raw: []const u8,
+    static_header: StaticHeader,
+    /// Plaintext authdata slice inside `header_raw`.
+    authdata_raw: []const u8,
+    /// Encrypted message payload slice inside the original packet buffer.
+    message_ciphertext: []const u8,
+};
+
+pub const MessagePacketKind = enum {
+    ordinary,
+    handshake,
+
+    fn flag(self: MessagePacketKind) u8 {
+        return switch (self) {
+            .ordinary => FLAG_MESSAGE,
+            .handshake => FLAG_HANDSHAKE,
+        };
+    }
+};
+
+pub const MessagePacketArgs = struct {
+    kind: MessagePacketKind,
+    masking_iv: *const [MASKING_IV_SIZE]u8,
+    recipient_node_id: *const [NODE_ID_SIZE]u8,
+    nonce: *const [NONCE_SIZE]u8,
+    authdata: []const u8,
+    write_key: *const [16]u8,
+    plaintext: []const u8,
+};
+
+pub const WhoareyouPacketArgs = struct {
+    masking_iv: *const [MASKING_IV_SIZE]u8,
+    recipient_node_id: *const [NODE_ID_SIZE]u8,
+    request_nonce: *const [NONCE_SIZE]u8,
+    id_nonce: *const [ID_NONCE_SIZE]u8,
+    enr_seq: u64,
+};
+
+/// AES-128-CTR encrypt/decrypt in place
+pub fn aesCtr(key: *const [16]u8, iv: *const [16]u8, data: []u8) void {
+    const aes = Aes128.initEnc(key.*);
+    var counter = iv.*;
+    var i: usize = 0;
+    while (i < data.len) {
+        var keystream: [16]u8 = undefined;
+        aes.encrypt(&keystream, &counter);
+        // Increment counter (big-endian)
+        var j: usize = 15;
+        while (true) {
+            counter[j] +%= 1;
+            if (counter[j] != 0) break;
+            if (j == 0) break;
+            j -= 1;
+        }
+        const chunk = @min(16, data.len - i);
+        for (0..chunk) |k| {
+            data[i + k] ^= keystream[k];
+        }
+        i += chunk;
+    }
+}
+
+/// Decode a raw UDP packet in place.
+///
+/// The caller must pass a mutable packet buffer. On success, the header bytes in
+/// `raw` are unmasked in place and the returned `ParsedPacket` borrows slices
+/// from `raw`. The message ciphertext is left untouched. On failure before the
+/// final in-place unmasking step, `raw` is left unchanged.
+pub fn decode(raw: []u8, dest_node_id: *const [32]u8) Error!ParsedPacket {
+    if (raw.len < MASKING_IV_SIZE + STATIC_HEADER_SIZE) return Error.InvalidPacket;
+
+    const masking_iv = raw[0..16].*;
+    const masking_key = dest_node_id[0..16];
+
+    if (raw.len < 39) return Error.InvalidPacket;
+
+    // Probe a stack copy of the static header first so `raw` remains unchanged
+    // until we know the full authdata length and can validate packet bounds.
+    const masked_static = raw[16 .. 16 + STATIC_HEADER_SIZE];
+    var static_buf: [STATIC_HEADER_SIZE]u8 = undefined;
+    @memcpy(&static_buf, masked_static);
+    aesCtr(masking_key[0..16], &masking_iv, &static_buf);
+
+    if (!std.mem.eql(u8, static_buf[0..6], PROTOCOL_ID)) {
+        return Error.InvalidProtocolId;
+    }
+
+    const version = std.mem.readInt(u16, static_buf[6..8], .big);
+    if (version != VERSION) return Error.UnsupportedVersion;
+
+    const flag = static_buf[8];
+    const nonce = static_buf[9..21].*;
+    const authdata_size = std.mem.readInt(u16, static_buf[21..23], .big);
+
+    if (raw.len < 16 + STATIC_HEADER_SIZE + authdata_size) return Error.InvalidPacket;
+
+    const header_total = STATIC_HEADER_SIZE + authdata_size;
+    const header_raw = raw[16 .. 16 + header_total];
+    // Unmask static_header || authdata in place with the CTR stream starting at
+    // byte zero. This preserves the exact plaintext header used as GCM AD.
+    aesCtr(masking_key[0..16], &masking_iv, header_raw);
+
+    const static_header = StaticHeader{
+        .protocol_id = header_raw[0..6].*,
+        .version = std.mem.readInt(u16, header_raw[6..8], .big),
+        .flag = flag,
+        .nonce = nonce,
+        .authdata_size = authdata_size,
+    };
+
+    const authdata_raw = header_raw[STATIC_HEADER_SIZE..header_total];
+    const message_ciphertext = raw[16 + header_total ..];
+
+    return ParsedPacket{
+        .masking_iv = masking_iv,
+        .header_raw = header_raw,
+        .static_header = static_header,
+        .authdata_raw = authdata_raw,
+        .message_ciphertext = message_ciphertext,
+    };
+}
+
+/// Decrypt a message packet using AES-128-GCM
+/// Decrypt a message packet into caller-owned memory.
+///
+/// `out` must hold the plaintext (`ciphertext.len - GCM_TAG_SIZE`), and
+/// `ad_buf` must hold `masking_iv || header_raw`.
+pub fn decryptMessageInto(
+    out: []u8,
+    ad_buf: []u8,
+    read_key: *const [16]u8,
+    nonce: *const [12]u8,
+    ciphertext: []const u8,
+    masking_iv: *const [16]u8,
+    header_raw: []const u8,
+) Error![]u8 {
+    if (ciphertext.len < GCM_TAG_SIZE) return Error.DecryptionFailed;
+
+    const ct = ciphertext[0 .. ciphertext.len - GCM_TAG_SIZE];
+    if (ct.len > out.len) return Error.BufferTooSmall;
+    const ad_len = MASKING_IV_SIZE + header_raw.len;
+    if (ad_len > ad_buf.len) return Error.BufferTooSmall;
+
+    var tag: [GCM_TAG_SIZE]u8 = undefined;
+    @memcpy(&tag, ciphertext[ciphertext.len - GCM_TAG_SIZE ..]);
+
+    const ad = ad_buf[0..ad_len];
+    @memcpy(ad[0..MASKING_IV_SIZE], masking_iv);
+    @memcpy(ad[MASKING_IV_SIZE..], header_raw);
+
+    const pt = out[0..ct.len];
+    Aes128Gcm.decrypt(pt, ct, tag, ad, nonce.*, read_key.*) catch {
+        return Error.DecryptionFailed;
+    };
+
+    return pt;
+}
+
+/// Encode an ordinary or handshake message packet.
+///
+/// The header is written in plaintext first so it can serve as AES-GCM
+/// associated data together with the masking IV. It is masked in place only
+/// after the ciphertext and tag have been produced.
+/// Encode an ordinary or handshake message packet into caller-owned memory.
+pub fn encodeMessagePacketInto(out: []u8, args: MessagePacketArgs) Error![]u8 {
+    const header_total = try headerSize(args.authdata);
+    const message_offset = MASKING_IV_SIZE + header_total;
+    const tag_offset = message_offset + args.plaintext.len;
+    const total = tag_offset + GCM_TAG_SIZE;
+    if (total > out.len) return Error.BufferTooSmall;
+
+    const encoded = out[0..total];
+    @memcpy(encoded[0..MASKING_IV_SIZE], args.masking_iv);
+    const header = encoded[MASKING_IV_SIZE..][0..header_total];
+    try writeHeader(header, args.kind.flag(), args.nonce, args.authdata);
+
+    const ad = encoded[0..message_offset];
+    const ciphertext = encoded[message_offset..tag_offset];
+    var tag: [GCM_TAG_SIZE]u8 = undefined;
+    Aes128Gcm.encrypt(ciphertext, &tag, args.plaintext, ad, args.nonce.*, args.write_key.*);
+    @memcpy(encoded[tag_offset..], &tag);
+
+    aesCtr(args.recipient_node_id[0..MASKING_IV_SIZE], args.masking_iv, header);
+    return encoded;
+}
+
+/// Encode a WHOAREYOU challenge packet.
+///
+/// If `challenge_data_out` is provided, it receives
+/// `masking_iv || plaintext_static_header || plaintext_authdata`, the exact
+/// challenge data used by the identity proof.
+/// Encode a WHOAREYOU challenge packet into caller-owned memory.
+pub fn encodeWhoareyouPacketInto(
+    out: []u8,
+    args: WhoareyouPacketArgs,
+    challenge_data_out: ?*[WHOAREYOU_CHALLENGE_DATA_SIZE]u8,
+) Error![]u8 {
+    if (out.len < WHOAREYOU_CHALLENGE_DATA_SIZE) return Error.BufferTooSmall;
+
+    var authdata: [WHOAREYOU_AUTHDATA_SIZE]u8 = undefined;
+    @memcpy(authdata[0..ID_NONCE_SIZE], args.id_nonce);
+    std.mem.writeInt(u64, authdata[ID_NONCE_SIZE..WHOAREYOU_AUTHDATA_SIZE], args.enr_seq, .big);
+
+    const encoded = out[0..WHOAREYOU_CHALLENGE_DATA_SIZE];
+    @memcpy(encoded[0..MASKING_IV_SIZE], args.masking_iv);
+    const header = encoded[MASKING_IV_SIZE..];
+    try writeHeader(header, FLAG_WHOAREYOU, args.request_nonce, &authdata);
+
+    if (challenge_data_out) |challenge_out| {
+        challenge_out.* = encoded[0..WHOAREYOU_CHALLENGE_DATA_SIZE].*;
+    }
+
+    aesCtr(args.recipient_node_id[0..MASKING_IV_SIZE], args.masking_iv, header);
+    return encoded;
+}
+
+fn headerSize(authdata: []const u8) Error!usize {
+    if (authdata.len > std.math.maxInt(u16)) return Error.InvalidPacket;
+    return STATIC_HEADER_SIZE + authdata.len;
+}
+
+fn writeHeader(
+    header: []u8,
+    flag: u8,
+    nonce: *const [NONCE_SIZE]u8,
+    authdata: []const u8,
+) Error!void {
+    const total = try headerSize(authdata);
+    if (header.len < total) return Error.BufferTooSmall;
+    const out = header[0..total];
+
+    const authdata_size: u16 = @intCast(authdata.len);
+    @memcpy(out[0..6], PROTOCOL_ID);
+    std.mem.writeInt(u16, out[6..8], VERSION, .big);
+    out[8] = flag;
+    @memcpy(out[9..21], nonce);
+    std.mem.writeInt(u16, out[21..23], authdata_size, .big);
+    @memcpy(out[STATIC_HEADER_SIZE..], authdata);
+}
+
+test "discv5 packet: AES-CTR masking round-trip" {
+    var data = [_]u8{ 0x01, 0x02, 0x03, 0x04, 0x05 };
+    const key = [_]u8{0xaa} ** 16;
+    const iv = [_]u8{0xbb} ** 16;
+    aesCtr(&key, &iv, &data);
+    aesCtr(&key, &iv, &data);
+    try std.testing.expectEqualSlices(u8, &[_]u8{ 0x01, 0x02, 0x03, 0x04, 0x05 }, &data);
+}
+
+test "discv5 packet: AES-GCM encrypt/decrypt" {
+    const hex = @import("hex");
+
+    const key = hex.hexToBytesComptime(16, "9f2d77db7004bf8a1a85107ac686990b");
+    const nonce = hex.hexToBytesComptime(12, "27b5af763c446acd2749fe8e");
+    const pt = hex.hexToBytesComptime(4, "01c20101");
+    const ad = hex.hexToBytesComptime(32, "93a7400fa0d6a694ebc24d5cf570f65d04215b6ac00757875e3f3a5f42107903");
+    const expected_ct = hex.hexToBytesComptime(20, "a5d12a2d94b8ccb3ba55558229867dc13bfa3648");
+
+    var ct: [4]u8 = undefined;
+    var tag: [16]u8 = undefined;
+    Aes128Gcm.encrypt(&ct, &tag, &pt, &ad, nonce, key);
+    var actual: [20]u8 = undefined;
+    @memcpy(actual[0..4], &ct);
+    @memcpy(actual[4..], &tag);
+
+    try std.testing.expectEqualSlices(u8, &expected_ct, &actual);
+
+    var pt2: [4]u8 = undefined;
+    try Aes128Gcm.decrypt(&pt2, &ct, tag, &ad, nonce, key);
+    try std.testing.expectEqualSlices(u8, &pt, &pt2);
+}

--- a/src/discv5/protocol/request_tracker.zig
+++ b/src/discv5/protocol/request_tracker.zig
@@ -1,0 +1,1162 @@
+//! Request lifecycle state for discv5 protocol traffic.
+//!
+//! Active requests are in-flight packets retained for retry and response
+//! matching. WHOAREYOU probes are indexed separately by `(source address,
+//! request nonce)` because WHOAREYOU packets are unauthenticated and do not
+//! carry the remote node id. Requests not yet sent are durable request intents
+//! held in bounded FIFO queues per peer endpoint.
+
+const std = @import("std");
+const Allocator = std.mem.Allocator;
+const Io = std.Io;
+const net = Io.net;
+const Address = net.IpAddress;
+
+const messages = @import("message.zig");
+const NodeId = @import("../enr.zig").NodeId;
+const packet = @import("packet.zig");
+const state = @import("state.zig");
+
+pub const Error = error{
+    BufferTooSmall,
+    TooManyActiveRequests,
+    TooManyQueuedRequests,
+    TooManyQueuedRequestsForEndpoint,
+    MissingActiveRequest,
+    InvalidChallenge,
+    EndpointEstablishing,
+} || Allocator.Error;
+
+pub const Limits = struct {
+    max_active_requests: usize = 1024,
+    max_queued_requests: usize = 1024,
+    max_queued_requests_per_endpoint: usize = 16,
+};
+
+pub const PacketBytes = struct {
+    bytes: [packet.MAX_PACKET_SIZE]u8 = undefined,
+    len: u16 = 0,
+
+    pub fn init(data: []const u8) error{BufferTooSmall}!PacketBytes {
+        var out = PacketBytes{};
+        try out.set(data);
+        return out;
+    }
+
+    pub fn set(self: *PacketBytes, data: []const u8) error{BufferTooSmall}!void {
+        if (data.len > self.bytes.len) return error.BufferTooSmall;
+        @memcpy(self.bytes[0..data.len], data);
+        self.len = @intCast(data.len);
+    }
+
+    pub fn slice(self: *const PacketBytes) []const u8 {
+        return self.bytes[0..self.len];
+    }
+};
+
+pub const RequestKind = enum {
+    ping,
+    findnode,
+    talkreq,
+};
+
+pub const Endpoint = struct {
+    node_id: NodeId,
+    addr: Address,
+};
+
+pub const RequestKey = struct {
+    endpoint: Endpoint,
+    req_id: messages.ReqId,
+
+    pub fn from(endpoint: Endpoint, req_id: messages.ReqId) RequestKey {
+        return .{ .endpoint = endpoint, .req_id = req_id };
+    }
+};
+
+pub const EndpointContext = struct {
+    pub fn hash(_: EndpointContext, endpoint: Endpoint) u64 {
+        var hasher = std.hash.Wyhash.init(0);
+        hasher.update(endpoint.node_id[0..]);
+        hashAddressPort(&hasher, endpoint.addr);
+        return hasher.final();
+    }
+
+    pub fn eql(_: EndpointContext, a: Endpoint, b: Endpoint) bool {
+        return std.mem.eql(u8, &a.node_id, &b.node_id) and Address.eql(&a.addr, &b.addr);
+    }
+};
+
+const RequestKeyContext = struct {
+    pub fn hash(_: RequestKeyContext, key: RequestKey) u64 {
+        var hasher = std.hash.Wyhash.init(0);
+        hasher.update(key.endpoint.node_id[0..]);
+        hashAddressPort(&hasher, key.endpoint.addr);
+        hasher.update(key.req_id.slice());
+        std.hash.autoHash(&hasher, key.req_id.len);
+        return hasher.final();
+    }
+
+    pub fn eql(_: RequestKeyContext, a: RequestKey, b: RequestKey) bool {
+        return EndpointContext.eql(.{}, a.endpoint, b.endpoint) and
+            a.req_id.len == b.req_id.len and
+            std.mem.eql(u8, a.req_id.slice(), b.req_id.slice());
+    }
+};
+
+fn hashAddressPort(hasher: *std.hash.Wyhash, addr: Address) void {
+    switch (addr) {
+        .ip4 => |ip4| {
+            hasher.update(&[_]u8{4});
+            hasher.update(ip4.bytes[0..]);
+            std.hash.autoHash(hasher, ip4.port);
+        },
+        .ip6 => |ip6| {
+            hasher.update(&[_]u8{6});
+            hasher.update(ip6.bytes[0..]);
+            std.hash.autoHash(hasher, ip6.port);
+        },
+    }
+}
+
+const AddressPortKey = struct {
+    family: Address.Family,
+    bytes: [16]u8,
+    port: u16,
+
+    fn fromAddress(addr: Address) AddressPortKey {
+        return switch (addr) {
+            .ip4 => |ip4| blk: {
+                var bytes = [_]u8{0} ** 16;
+                @memcpy(bytes[0..4], &ip4.bytes);
+                break :blk .{ .family = .ip4, .bytes = bytes, .port = ip4.port };
+            },
+            .ip6 => |ip6| .{ .family = .ip6, .bytes = ip6.bytes, .port = ip6.port },
+        };
+    }
+};
+
+const ChallengeKey = struct {
+    addr: AddressPortKey,
+    nonce: [packet.NONCE_SIZE]u8,
+
+    fn from(nonce: *const [packet.NONCE_SIZE]u8, addr: Address) ChallengeKey {
+        return .{ .addr = AddressPortKey.fromAddress(addr), .nonce = nonce.* };
+    }
+};
+
+pub const ActiveFindNodeRequest = struct {
+    enrs: std.ArrayListUnmanaged([]u8) = .empty,
+    total_responses: ?u64 = null,
+    responses_received: u64 = 0,
+    requested_distances: [127]u16 = undefined,
+    requested_distances_len: usize = 0,
+
+    pub fn deinit(self: *ActiveFindNodeRequest, alloc: Allocator) void {
+        for (self.enrs.items) |enr| alloc.free(enr);
+        self.enrs.deinit(alloc);
+    }
+};
+
+pub const ActiveRequestKind = union(enum) {
+    ping: void,
+    findnode: ActiveFindNodeRequest,
+    talkreq: void,
+
+    pub fn deinit(self: *ActiveRequestKind, alloc: Allocator) void {
+        switch (self.*) {
+            .ping => {},
+            .findnode => |*findnode| findnode.deinit(alloc),
+            .talkreq => {},
+        }
+    }
+};
+
+pub const ProbeState = struct {
+    nonce: [packet.NONCE_SIZE]u8,
+    dest_pubkey: [33]u8,
+    plaintext: PacketBytes,
+};
+
+pub const ResponseState = struct {
+    pending_session: ?state.PendingSessionKeys = null,
+    challenge_probe: ?ProbeState = null,
+};
+
+pub const ActiveRequestPhase = union(enum) {
+    awaiting_whoareyou: ProbeState,
+    awaiting_response: ResponseState,
+};
+
+pub const ActiveRequest = struct {
+    endpoint: Endpoint,
+    started_at_ns: i64,
+    attempts: u32 = 0,
+    socket: *const net.Socket,
+    retry_packet: PacketBytes,
+    phase: ActiveRequestPhase,
+    kind: ActiveRequestKind,
+
+    pub fn deinit(self: *ActiveRequest, alloc: Allocator) void {
+        self.kind.deinit(alloc);
+    }
+
+    pub fn requestKind(self: *const ActiveRequest) RequestKind {
+        return switch (self.kind) {
+            .ping => .ping,
+            .findnode => .findnode,
+            .talkreq => .talkreq,
+        };
+    }
+};
+
+pub const RequestIntent = struct {
+    queued_at_ns: i64,
+    endpoint: Endpoint,
+    dest_pubkey: [33]u8,
+    req_id: messages.ReqId,
+    request_kind: RequestKind,
+    requested_distances: [127]u16 = undefined,
+    requested_distances_len: usize = 0,
+    plaintext: PacketBytes,
+
+    pub fn init(
+        endpoint: Endpoint,
+        dest_pubkey: *const [33]u8,
+        req_id: messages.ReqId,
+        request_kind: RequestKind,
+        distance_values: []const u16,
+        plaintext: []const u8,
+        queued_at_ns: i64,
+    ) Error!RequestIntent {
+        return .{
+            .queued_at_ns = queued_at_ns,
+            .endpoint = endpoint,
+            .dest_pubkey = dest_pubkey.*,
+            .req_id = req_id,
+            .request_kind = request_kind,
+            .requested_distances = pendingDistances(distance_values),
+            .requested_distances_len = @min(distance_values.len, 127),
+            .plaintext = try PacketBytes.init(plaintext),
+        };
+    }
+
+    pub fn distances(self: *const RequestIntent) []const u16 {
+        return self.requested_distances[0..self.requested_distances_len];
+    }
+
+    pub fn plaintextSlice(self: *const RequestIntent) []const u8 {
+        return self.plaintext.slice();
+    }
+};
+
+const RequestQueue = struct {
+    items: std.ArrayListUnmanaged(RequestIntent) = .empty,
+    head: usize = 0,
+
+    fn deinit(self: *RequestQueue, alloc: Allocator) void {
+        self.items.deinit(alloc);
+    }
+
+    fn len(self: *const RequestQueue) usize {
+        return self.items.items.len - self.head;
+    }
+
+    fn isEmpty(self: *const RequestQueue) bool {
+        return self.len() == 0;
+    }
+
+    fn liveItems(self: *const RequestQueue) []const RequestIntent {
+        return self.items.items[self.head..];
+    }
+
+    fn append(self: *RequestQueue, alloc: Allocator, intent: RequestIntent) Allocator.Error!void {
+        self.compactIfSparse();
+        try self.items.append(alloc, intent);
+    }
+
+    fn prepend(self: *RequestQueue, alloc: Allocator, intent: RequestIntent) Allocator.Error!void {
+        if (self.head > 0) {
+            self.head -= 1;
+            self.items.items[self.head] = intent;
+            return;
+        }
+        try self.items.insert(alloc, 0, intent);
+    }
+
+    fn popFront(self: *RequestQueue) RequestIntent {
+        std.debug.assert(!self.isEmpty());
+        const intent = self.items.items[self.head];
+        self.head += 1;
+        self.compactIfSparse();
+        return intent;
+    }
+
+    fn orderedRemoveLiveIndex(self: *RequestQueue, index: usize) RequestIntent {
+        std.debug.assert(index < self.len());
+        const intent = self.items.orderedRemove(self.head + index);
+        self.compactIfSparse();
+        return intent;
+    }
+
+    fn clear(self: *RequestQueue) void {
+        self.items.clearRetainingCapacity();
+        self.head = 0;
+    }
+
+    fn compactIfSparse(self: *RequestQueue) void {
+        if (self.head == 0) return;
+        const live_len = self.len();
+        if (live_len == 0) {
+            self.clear();
+            return;
+        }
+        if (self.head < live_len) return;
+        std.mem.copyForwards(RequestIntent, self.items.items[0..live_len], self.items.items[self.head..]);
+        self.items.shrinkRetainingCapacity(live_len);
+        self.head = 0;
+    }
+};
+
+const PendingRequests = struct {
+    // Per-endpoint pending state includes both requests that have not been sent
+    // yet and, at most, one active request that is establishing a session. The
+    // active request lives in `active`; this key only blocks the endpoint queue
+    // until the WHOAREYOU/handshake exchange resolves.
+    establishing: ?RequestKey = null,
+    queue: RequestQueue = .{},
+
+    fn deinit(self: *PendingRequests, alloc: Allocator) void {
+        self.queue.deinit(alloc);
+    }
+
+    fn isEmpty(self: *const PendingRequests) bool {
+        return self.establishing == null and self.queue.isEmpty();
+    }
+};
+
+pub const ProbeView = struct {
+    key: RequestKey,
+    endpoint: Endpoint,
+    req_id: messages.ReqId,
+    request_kind: RequestKind,
+    dest_pubkey: *const [33]u8,
+    plaintext: []const u8,
+};
+
+pub const ExpiredRequest = struct {
+    endpoint: Endpoint,
+    req_id: messages.ReqId,
+    kind: RequestKind,
+    socket: ?*const net.Socket = null,
+};
+
+const ActiveRequestMap = std.HashMap(RequestKey, ActiveRequest, RequestKeyContext, std.hash_map.default_max_load_percentage);
+const PendingRequestsMap = std.HashMap(Endpoint, PendingRequests, EndpointContext, std.hash_map.default_max_load_percentage);
+
+pub const RequestTracker = struct {
+    alloc: Allocator,
+    limits: Limits,
+    active: ActiveRequestMap,
+    challenge_index: std.AutoHashMap(ChallengeKey, RequestKey),
+    queued: PendingRequestsMap,
+    queued_total: usize = 0,
+
+    pub fn init(alloc: Allocator, limits: Limits) RequestTracker {
+        return .{
+            .alloc = alloc,
+            .limits = limits,
+            .active = ActiveRequestMap.init(alloc),
+            .challenge_index = std.AutoHashMap(ChallengeKey, RequestKey).init(alloc),
+            .queued = PendingRequestsMap.init(alloc),
+        };
+    }
+
+    pub fn deinit(self: *RequestTracker) void {
+        var active_it = self.active.iterator();
+        while (active_it.next()) |entry| entry.value_ptr.deinit(self.alloc);
+        self.active.deinit();
+        self.challenge_index.deinit();
+        var queued_it = self.queued.iterator();
+        while (queued_it.next()) |entry| entry.value_ptr.deinit(self.alloc);
+        self.queued.deinit();
+    }
+
+    pub fn activeCount(self: *const RequestTracker) usize {
+        return self.active.count();
+    }
+
+    pub fn pendingCount(self: *const RequestTracker) usize {
+        return self.challenge_index.count() + self.queued_total;
+    }
+
+    pub fn hasActiveFindNodeRequest(self: *const RequestTracker, peer_id: *const NodeId) bool {
+        var it = self.active.iterator();
+        while (it.next()) |entry| {
+            if (!std.mem.eql(u8, &entry.value_ptr.endpoint.node_id, peer_id)) continue;
+            if (entry.value_ptr.kind == .findnode) return true;
+        }
+        return false;
+    }
+
+    pub fn shouldQueueForEndpoint(self: *const RequestTracker, endpoint: Endpoint) bool {
+        const endpoint_key = endpoint;
+        const pending = self.queued.get(endpoint_key) orelse return false;
+        return pending.establishing != null or !pending.queue.isEmpty();
+    }
+
+    pub fn pendingSessionKeysForEndpoint(self: *const RequestTracker, endpoint: Endpoint) ?state.PendingSessionKeys {
+        const endpoint_key = endpoint;
+        const pending = self.queued.get(endpoint_key) orelse return null;
+        const key = pending.establishing orelse return null;
+        const active = self.active.get(key) orelse return null;
+        return switch (active.phase) {
+            .awaiting_whoareyou => null,
+            .awaiting_response => |response| response.pending_session,
+        };
+    }
+
+    pub fn putActiveAwaitingResponse(
+        self: *RequestTracker,
+        endpoint: Endpoint,
+        req_id: messages.ReqId,
+        request_kind: RequestKind,
+        distances: []const u16,
+        socket: *const net.Socket,
+        packet_bytes: []const u8,
+        started_at_ns: i64,
+        pending_session: ?state.PendingSessionKeys,
+    ) Error!void {
+        const key = RequestKey.from(endpoint, req_id);
+        // Reserve a queued slot for the establishing marker before mutating.
+        if (pending_session != null and !self.queued.contains(endpoint)) {
+            try self.queued.ensureUnusedCapacity(1);
+        }
+
+        try self.putActive(key, endpoint, request_kind, distances, socket, packet_bytes, started_at_ns, .{
+            .awaiting_response = .{ .pending_session = pending_session },
+        });
+
+        if (pending_session != null) {
+            self.indexEstablishingAssumeCapacity(endpoint, key);
+        }
+    }
+
+    /// Track an authenticated request so a matching WHOAREYOU can recover when
+    /// the remote endpoint has forgotten the established session.
+    pub fn putActiveAwaitingResponseWithChallenge(
+        self: *RequestTracker,
+        endpoint: Endpoint,
+        req_id: messages.ReqId,
+        request_kind: RequestKind,
+        distances: []const u16,
+        socket: *const net.Socket,
+        packet_bytes: []const u8,
+        started_at_ns: i64,
+        nonce: [packet.NONCE_SIZE]u8,
+        dest_pubkey: *const [33]u8,
+        plaintext: []const u8,
+    ) Error!void {
+        const key = RequestKey.from(endpoint, req_id);
+        try self.challenge_index.ensureUnusedCapacity(1);
+        const plaintext_copy = try PacketBytes.init(plaintext);
+        try self.putActive(key, endpoint, request_kind, distances, socket, packet_bytes, started_at_ns, .{
+            .awaiting_response = .{
+                .challenge_probe = .{
+                    .nonce = nonce,
+                    .dest_pubkey = dest_pubkey.*,
+                    .plaintext = plaintext_copy,
+                },
+            },
+        });
+        self.challenge_index.putAssumeCapacityNoClobber(ChallengeKey.from(&nonce, endpoint.addr), key);
+    }
+
+    pub fn putActiveProbe(
+        self: *RequestTracker,
+        endpoint: Endpoint,
+        req_id: messages.ReqId,
+        request_kind: RequestKind,
+        distances: []const u16,
+        socket: *const net.Socket,
+        packet_bytes: []const u8,
+        started_at_ns: i64,
+        nonce: [packet.NONCE_SIZE]u8,
+        dest_pubkey: *const [33]u8,
+        plaintext: []const u8,
+    ) Error!void {
+        const key = RequestKey.from(endpoint, req_id);
+        // At most one in-flight handshake (establishing request) per endpoint.
+        if (self.queued.get(endpoint)) |pending| {
+            if (pending.establishing != null) return error.TooManyActiveRequests;
+        } else {
+            try self.queued.ensureUnusedCapacity(1);
+        }
+        try self.challenge_index.ensureUnusedCapacity(1);
+        const plaintext_copy = try PacketBytes.init(plaintext);
+
+        try self.putActive(key, endpoint, request_kind, distances, socket, packet_bytes, started_at_ns, .{
+            .awaiting_whoareyou = .{
+                .nonce = nonce,
+                .dest_pubkey = dest_pubkey.*,
+                .plaintext = plaintext_copy,
+            },
+        });
+
+        self.challenge_index.putAssumeCapacityNoClobber(ChallengeKey.from(&nonce, endpoint.addr), key);
+        self.indexEstablishingAssumeCapacity(endpoint, key);
+    }
+
+    /// Insert an active request for `key`, replacing any existing entry and
+    /// reserving the active-table slot. Phase-specific reservations (queued
+    /// establishing marker, challenge index) and post-insert indexing are the
+    /// caller's responsibility. Everything fallible here runs before the table
+    /// is mutated, so a failure leaves the tracker unchanged.
+    fn putActive(
+        self: *RequestTracker,
+        key: RequestKey,
+        endpoint: Endpoint,
+        request_kind: RequestKind,
+        distances: []const u16,
+        socket: *const net.Socket,
+        packet_bytes: []const u8,
+        started_at_ns: i64,
+        phase: ActiveRequestPhase,
+    ) Error!void {
+        if (!self.active.contains(key)) try self.ensureActiveInsertCapacity();
+        const retry_packet = try PacketBytes.init(packet_bytes);
+
+        self.removeActiveByKey(key);
+        self.active.putAssumeCapacityNoClobber(key, .{
+            .endpoint = endpoint,
+            .started_at_ns = started_at_ns,
+            .attempts = 0,
+            .socket = socket,
+            .retry_packet = retry_packet,
+            .phase = phase,
+            .kind = activeKindFromRequestKind(request_kind, distances),
+        });
+    }
+
+    pub fn cancelActive(self: *RequestTracker, endpoint: Endpoint, req_id: messages.ReqId) void {
+        self.removeActiveByKey(RequestKey.from(endpoint, req_id));
+    }
+
+    pub fn queueRequest(
+        self: *RequestTracker,
+        endpoint: Endpoint,
+        dest_pubkey: *const [33]u8,
+        req_id: messages.ReqId,
+        request_kind: RequestKind,
+        distances: []const u16,
+        plaintext: []const u8,
+        queued_at_ns: i64,
+    ) Error!void {
+        if (self.queued_total >= self.limits.max_queued_requests) return error.TooManyQueuedRequests;
+        const intent = try RequestIntent.init(endpoint, dest_pubkey, req_id, request_kind, distances, plaintext, queued_at_ns);
+        const endpoint_key = endpoint;
+        const gop = try self.queued.getOrPut(endpoint_key);
+        if (!gop.found_existing) gop.value_ptr.* = .{};
+        errdefer if (!gop.found_existing and gop.value_ptr.isEmpty()) {
+            gop.value_ptr.deinit(self.alloc);
+            _ = self.queued.remove(endpoint_key);
+        };
+        if (gop.value_ptr.queue.len() >= self.limits.max_queued_requests_per_endpoint) {
+            return error.TooManyQueuedRequestsForEndpoint;
+        }
+        try gop.value_ptr.queue.append(self.alloc, intent);
+        self.queued_total += 1;
+    }
+
+    pub fn probeForChallenge(
+        self: *RequestTracker,
+        nonce: *const [packet.NONCE_SIZE]u8,
+        from: Address,
+    ) ?ProbeView {
+        const challenge_key = ChallengeKey.from(nonce, from);
+        const key = self.challenge_index.get(challenge_key) orelse return null;
+        const active = self.active.getPtr(key) orelse return null;
+        if (!Address.eql(&active.endpoint.addr, &from)) return null;
+        return switch (active.phase) {
+            .awaiting_response => |*response| blk: {
+                const probe = if (response.challenge_probe) |*value| value else break :blk null;
+                if (!std.mem.eql(u8, &probe.nonce, nonce)) break :blk null;
+                break :blk .{
+                    .key = key,
+                    .endpoint = active.endpoint,
+                    .req_id = key.req_id,
+                    .request_kind = active.requestKind(),
+                    .dest_pubkey = &probe.dest_pubkey,
+                    .plaintext = probe.plaintext.slice(),
+                };
+            },
+            .awaiting_whoareyou => |*probe| blk: {
+                if (!std.mem.eql(u8, &probe.nonce, nonce)) break :blk null;
+                break :blk .{
+                    .key = key,
+                    .endpoint = active.endpoint,
+                    .req_id = key.req_id,
+                    .request_kind = active.requestKind(),
+                    .dest_pubkey = &probe.dest_pubkey,
+                    .plaintext = probe.plaintext.slice(),
+                };
+            },
+        };
+    }
+
+    pub fn acceptChallenge(
+        self: *RequestTracker,
+        key: RequestKey,
+        nonce: *const [packet.NONCE_SIZE]u8,
+        from: Address,
+        packet_bytes: []const u8,
+        pending_session: state.PendingSessionKeys,
+        now_ns: i64,
+    ) Error!void {
+        const challenge_key = ChallengeKey.from(nonce, from);
+        const indexed_key = self.challenge_index.get(challenge_key) orelse return error.InvalidChallenge;
+        if (!std.meta.eql(indexed_key, key)) return error.InvalidChallenge;
+
+        const active = self.active.getPtr(key) orelse return error.MissingActiveRequest;
+        if (!Address.eql(&active.endpoint.addr, &from)) return error.InvalidChallenge;
+        const probe = switch (active.phase) {
+            .awaiting_response => |response| response.challenge_probe orelse return error.InvalidChallenge,
+            .awaiting_whoareyou => |value| value,
+        };
+        if (!std.mem.eql(u8, &probe.nonce, nonce)) return error.InvalidChallenge;
+
+        // An established-session request does not already have an establishing
+        // queue marker; reserve it before mutating the active request.
+        if (self.queued.get(active.endpoint)) |pending| {
+            if (pending.establishing) |existing| {
+                if (!std.meta.eql(existing, key)) return error.EndpointEstablishing;
+            }
+        } else {
+            try self.queued.ensureUnusedCapacity(1);
+        }
+
+        const retry_packet = try PacketBytes.init(packet_bytes);
+        active.retry_packet = retry_packet;
+        active.started_at_ns = now_ns;
+        active.attempts = 0;
+        active.phase = .{ .awaiting_response = .{ .pending_session = pending_session } };
+        _ = self.challenge_index.remove(challenge_key);
+        self.indexEstablishingAssumeCapacity(active.endpoint, key);
+    }
+
+    pub fn getActivePtr(self: *RequestTracker, endpoint: Endpoint, req_id: messages.ReqId) ?*ActiveRequest {
+        return self.active.getPtr(RequestKey.from(endpoint, req_id));
+    }
+
+    pub fn finishActive(self: *RequestTracker, endpoint: Endpoint, req_id: messages.ReqId) ?ActiveRequest {
+        const key = RequestKey.from(endpoint, req_id);
+        const removed = self.active.fetchRemove(key) orelse return null;
+        var active = removed.value;
+        self.unindexActive(key, &active);
+        return active;
+    }
+
+    /// Remove and return the active request for (endpoint, req_id) only when it
+    /// exists and its kind matches `expected`; otherwise leave the tracker
+    /// unchanged and return null. Collapses the lookup + kind guard + removal that
+    /// single-response handlers (PONG, TALKRESP) would otherwise open-code.
+    pub fn finishActiveExpectingKind(
+        self: *RequestTracker,
+        endpoint: Endpoint,
+        req_id: messages.ReqId,
+        expected: std.meta.Tag(ActiveRequestKind),
+    ) ?ActiveRequest {
+        const key = RequestKey.from(endpoint, req_id);
+        const entry = self.active.getPtr(key) orelse return null;
+        if (std.meta.activeTag(entry.kind) != expected) return null;
+        var active = self.active.fetchRemove(key).?.value;
+        self.unindexActive(key, &active);
+        return active;
+    }
+
+    pub fn popNextQueued(self: *RequestTracker, endpoint: Endpoint) Error!?RequestIntent {
+        const endpoint_key = endpoint;
+        const pending = self.queued.getPtr(endpoint_key) orelse return null;
+        if (pending.establishing != null) return null;
+        if (pending.queue.isEmpty()) {
+            var removed = self.queued.fetchRemove(endpoint_key).?.value;
+            removed.deinit(self.alloc);
+            return null;
+        }
+
+        if (self.active.count() >= self.limits.max_active_requests) return error.TooManyActiveRequests;
+
+        const intent = pending.queue.popFront();
+        self.queued_total -= 1;
+        if (pending.isEmpty()) {
+            var removed = self.queued.fetchRemove(endpoint_key).?.value;
+            removed.deinit(self.alloc);
+        }
+        return intent;
+    }
+
+    pub fn pushFrontQueued(self: *RequestTracker, intent: RequestIntent) Error!void {
+        if (self.queued_total >= self.limits.max_queued_requests) return error.TooManyQueuedRequests;
+        const endpoint_key = intent.endpoint;
+        const gop = try self.queued.getOrPut(endpoint_key);
+        if (!gop.found_existing) gop.value_ptr.* = .{};
+        errdefer if (!gop.found_existing and gop.value_ptr.isEmpty()) {
+            gop.value_ptr.deinit(self.alloc);
+            _ = self.queued.remove(endpoint_key);
+        };
+        if (gop.value_ptr.queue.len() >= self.limits.max_queued_requests_per_endpoint) {
+            return error.TooManyQueuedRequestsForEndpoint;
+        }
+        try gop.value_ptr.queue.prepend(self.alloc, intent);
+        self.queued_total += 1;
+    }
+
+    pub fn pruneExpiredActive(
+        self: *RequestTracker,
+        io: Io,
+        now_ns: i64,
+        timeout_ms: u64,
+        retries: u32,
+        out: *std.ArrayListUnmanaged(ExpiredRequest),
+    ) Allocator.Error!void {
+        var expired: std.ArrayListUnmanaged(RequestKey) = .empty;
+        defer expired.deinit(self.alloc);
+
+        var it = self.active.iterator();
+        while (it.next()) |entry| {
+            if (!requestTimedOut(entry.value_ptr.started_at_ns, now_ns, timeout_ms)) continue;
+            if (entry.value_ptr.attempts < retries) {
+                const addr = entry.value_ptr.endpoint.addr;
+                entry.value_ptr.socket.send(io, &addr, entry.value_ptr.retry_packet.slice()) catch {
+                    try expired.append(self.alloc, entry.key_ptr.*);
+                    continue;
+                };
+                entry.value_ptr.attempts += 1;
+                entry.value_ptr.started_at_ns = now_ns;
+                continue;
+            }
+            try expired.append(self.alloc, entry.key_ptr.*);
+        }
+
+        try out.ensureUnusedCapacity(self.alloc, expired.items.len);
+        for (expired.items) |key| {
+            const removed = self.active.fetchRemove(key) orelse continue;
+            var active = removed.value;
+            self.unindexActive(key, &active);
+            out.appendAssumeCapacity(.{
+                .endpoint = active.endpoint,
+                .req_id = key.req_id,
+                .kind = active.requestKind(),
+                .socket = active.socket,
+            });
+            active.deinit(self.alloc);
+        }
+    }
+
+    pub fn pruneExpiredQueued(
+        self: *RequestTracker,
+        now_ns: i64,
+        timeout_ms: u64,
+        out: *std.ArrayListUnmanaged(ExpiredRequest),
+    ) Allocator.Error!void {
+        var expired_count: usize = 0;
+        var count_it = self.queued.iterator();
+        while (count_it.next()) |entry| {
+            for (entry.value_ptr.queue.liveItems()) |*intent| {
+                if (requestTimedOut(intent.queued_at_ns, now_ns, timeout_ms)) expired_count += 1;
+            }
+        }
+        try out.ensureUnusedCapacity(self.alloc, expired_count);
+
+        var empty_keys: std.ArrayListUnmanaged(Endpoint) = .empty;
+        defer empty_keys.deinit(self.alloc);
+        try empty_keys.ensureTotalCapacity(self.alloc, self.queued.count());
+
+        var it = self.queued.iterator();
+        while (it.next()) |entry| {
+            var i: usize = 0;
+            while (i < entry.value_ptr.queue.len()) {
+                if (!requestTimedOut(entry.value_ptr.queue.liveItems()[i].queued_at_ns, now_ns, timeout_ms)) {
+                    i += 1;
+                    continue;
+                }
+                const queued = entry.value_ptr.queue.orderedRemoveLiveIndex(i);
+                self.queued_total -= 1;
+                out.appendAssumeCapacity(.{
+                    .endpoint = queued.endpoint,
+                    .req_id = queued.req_id,
+                    .kind = queued.request_kind,
+                });
+            }
+            if (entry.value_ptr.isEmpty()) empty_keys.appendAssumeCapacity(entry.key_ptr.*);
+        }
+
+        for (empty_keys.items) |key| {
+            var removed = self.queued.fetchRemove(key).?.value;
+            removed.deinit(self.alloc);
+        }
+    }
+
+    pub fn dropQueuedForEndpoint(
+        self: *RequestTracker,
+        endpoint: Endpoint,
+        out: *std.ArrayListUnmanaged(ExpiredRequest),
+    ) Allocator.Error!void {
+        const endpoint_key = endpoint;
+        const pending = self.queued.getPtr(endpoint_key) orelse return;
+        const dropped_count = pending.queue.len();
+        try out.ensureUnusedCapacity(self.alloc, dropped_count);
+        for (pending.queue.liveItems()) |intent| {
+            out.appendAssumeCapacity(.{
+                .endpoint = intent.endpoint,
+                .req_id = intent.req_id,
+                .kind = intent.request_kind,
+            });
+        }
+        self.queued_total -= dropped_count;
+        pending.queue.clear();
+        if (pending.isEmpty()) {
+            var removed = self.queued.fetchRemove(endpoint_key).?.value;
+            removed.deinit(self.alloc);
+        }
+    }
+
+    pub fn forceAllActiveStartedAtForTest(self: *RequestTracker, started_at_ns: i64) void {
+        var it = self.active.iterator();
+        while (it.next()) |entry| entry.value_ptr.started_at_ns = started_at_ns;
+    }
+
+    pub fn forceAllQueuedAtForTest(self: *RequestTracker, queued_at_ns: i64) void {
+        var it = self.queued.iterator();
+        while (it.next()) |entry| {
+            for (entry.value_ptr.queue.items.items[entry.value_ptr.queue.head..]) |*queued| {
+                queued.queued_at_ns = queued_at_ns;
+            }
+        }
+    }
+
+    pub fn forceFirstProbeNonceForTest(self: *RequestTracker, nonce: [packet.NONCE_SIZE]u8) bool {
+        var it = self.active.iterator();
+        while (it.next()) |entry| {
+            switch (entry.value_ptr.phase) {
+                .awaiting_response => {},
+                .awaiting_whoareyou => |*probe| {
+                    probe.nonce = nonce;
+                    return true;
+                },
+            }
+        }
+        return false;
+    }
+
+    fn ensureActiveInsertCapacity(self: *RequestTracker) Error!void {
+        if (self.active.count() >= self.limits.max_active_requests) return error.TooManyActiveRequests;
+        try self.active.ensureUnusedCapacity(1);
+    }
+
+    fn indexEstablishingAssumeCapacity(self: *RequestTracker, endpoint_key: Endpoint, key: RequestKey) void {
+        const gop = self.queued.getOrPutAssumeCapacity(endpoint_key);
+        if (!gop.found_existing) gop.value_ptr.* = .{};
+        if (gop.value_ptr.establishing) |existing| {
+            std.debug.assert(std.meta.eql(existing, key));
+        }
+        gop.value_ptr.establishing = key;
+    }
+
+    fn removeActiveByKey(self: *RequestTracker, key: RequestKey) void {
+        const removed = self.active.fetchRemove(key) orelse return;
+        var active = removed.value;
+        self.unindexActive(key, &active);
+        active.deinit(self.alloc);
+    }
+
+    fn unindexActive(self: *RequestTracker, key: RequestKey, active: *const ActiveRequest) void {
+        switch (active.phase) {
+            .awaiting_response => |response| if (response.challenge_probe) |probe| {
+                _ = self.challenge_index.remove(ChallengeKey.from(&probe.nonce, active.endpoint.addr));
+            },
+            .awaiting_whoareyou => |probe| {
+                _ = self.challenge_index.remove(ChallengeKey.from(&probe.nonce, active.endpoint.addr));
+            },
+        }
+        const endpoint_key = active.endpoint;
+        if (self.queued.getPtr(endpoint_key)) |pending| {
+            if (pending.establishing) |existing| {
+                if (std.meta.eql(existing, key)) pending.establishing = null;
+            }
+            if (pending.isEmpty()) {
+                var removed = self.queued.fetchRemove(endpoint_key).?.value;
+                removed.deinit(self.alloc);
+            }
+        }
+    }
+};
+
+fn pendingDistances(distances: []const u16) [127]u16 {
+    var out: [127]u16 = undefined;
+    const len = @min(distances.len, out.len);
+    if (len > 0) @memcpy(out[0..len], distances[0..len]);
+    return out;
+}
+
+fn activeKindFromRequestKind(request_kind: RequestKind, distances: []const u16) ActiveRequestKind {
+    return switch (request_kind) {
+        .ping => .{ .ping = {} },
+        .talkreq => .{ .talkreq = {} },
+        .findnode => blk: {
+            var findnode = ActiveFindNodeRequest{};
+            const len = @min(distances.len, findnode.requested_distances.len);
+            if (len > 0) @memcpy(findnode.requested_distances[0..len], distances[0..len]);
+            findnode.requested_distances_len = len;
+            break :blk .{ .findnode = findnode };
+        },
+    };
+}
+
+fn requestTimedOut(started_at_ns: i64, now_ns: i64, timeout_ms: u64) bool {
+    const elapsed_ns: i128 = @as(i128, now_ns) - @as(i128, started_at_ns);
+    const timeout_ns: i128 = @as(i128, timeout_ms) * std.time.ns_per_ms;
+    return elapsed_ns >= timeout_ns;
+}
+
+test "request tracker enforces global and per-endpoint queue caps" {
+    const alloc = std.testing.allocator;
+    var tracker = RequestTracker.init(alloc, .{
+        .max_active_requests = 4,
+        .max_queued_requests = 2,
+        .max_queued_requests_per_endpoint = 1,
+    });
+    defer tracker.deinit();
+
+    const peer_a = [_]u8{0x11} ** 32;
+    const peer_b = [_]u8{0x22} ** 32;
+    const peer_c = [_]u8{0x33} ** 32;
+    const pubkey = [_]u8{0x02} ++ [_]u8{0x44} ** 32;
+    const req_id = try messages.ReqId.fromSlice(&[_]u8{0x01});
+    const plaintext = [_]u8{ messages.MSG_PING, 0x01 };
+
+    const endpoint_a = Endpoint{ .node_id = peer_a, .addr = .{ .ip4 = .{ .bytes = .{ 127, 0, 0, 1 }, .port = 30303 } } };
+    const endpoint_b = Endpoint{ .node_id = peer_b, .addr = .{ .ip4 = .{ .bytes = .{ 127, 0, 0, 1 }, .port = 30304 } } };
+    const endpoint_c = Endpoint{ .node_id = peer_c, .addr = .{ .ip4 = .{ .bytes = .{ 127, 0, 0, 1 }, .port = 30305 } } };
+
+    try tracker.queueRequest(endpoint_a, &pubkey, req_id, .ping, &.{}, &plaintext, 0);
+    try std.testing.expectError(
+        error.TooManyQueuedRequestsForEndpoint,
+        tracker.queueRequest(endpoint_a, &pubkey, req_id, .ping, &.{}, &plaintext, 0),
+    );
+
+    try tracker.queueRequest(endpoint_b, &pubkey, req_id, .ping, &.{}, &plaintext, 0);
+    try std.testing.expectError(
+        error.TooManyQueuedRequests,
+        tracker.queueRequest(endpoint_c, &pubkey, req_id, .ping, &.{}, &plaintext, 0),
+    );
+    try std.testing.expectEqual(@as(usize, 2), tracker.pendingCount());
+}
+
+test "endpoint stores node id and address directly" {
+    const node_id = [_]u8{0x11} ** 32;
+    const ip4 = Address{ .ip4 = .{ .bytes = .{ 127, 0, 0, 1 }, .port = 30303 } };
+    const endpoint = Endpoint{ .node_id = node_id, .addr = ip4 };
+
+    try std.testing.expectEqual(node_id, endpoint.node_id);
+    try std.testing.expect(Address.eql(&endpoint.addr, &ip4));
+}
+
+test "endpoint contexts use semantic address identity" {
+    const alloc = std.testing.allocator;
+    const node_id = [_]u8{0x11} ** 32;
+    const req_id = try messages.ReqId.fromSlice(&[_]u8{0x01});
+    const addr_a = Address{ .ip6 = .{
+        .bytes = [_]u8{0xaa} ** 16,
+        .port = 30303,
+        .flow = 1,
+    } };
+    const addr_b = Address{ .ip6 = .{
+        .bytes = [_]u8{0xaa} ** 16,
+        .port = 30303,
+        .flow = 2,
+    } };
+    const endpoint_a = Endpoint{ .node_id = node_id, .addr = addr_a };
+    const endpoint_b = Endpoint{ .node_id = node_id, .addr = addr_b };
+
+    var endpoints = std.HashMap(Endpoint, u8, EndpointContext, std.hash_map.default_max_load_percentage).init(alloc);
+    defer endpoints.deinit();
+    try endpoints.put(endpoint_a, 7);
+    try std.testing.expectEqual(@as(?u8, 7), endpoints.get(endpoint_b));
+
+    var requests = std.HashMap(RequestKey, u8, RequestKeyContext, std.hash_map.default_max_load_percentage).init(alloc);
+    defer requests.deinit();
+    try requests.put(RequestKey.from(endpoint_a, req_id), 9);
+    try std.testing.expectEqual(@as(?u8, 9), requests.get(RequestKey.from(endpoint_b, req_id)));
+}
+
+test "request keys support empty request IDs" {
+    const alloc = std.testing.allocator;
+    const endpoint = Endpoint{
+        .node_id = [_]u8{0x11} ** 32,
+        .addr = .{ .ip4 = .{ .bytes = .{ 127, 0, 0, 1 }, .port = 30303 } },
+    };
+    const empty_req_id = try messages.ReqId.fromSlice(&.{});
+    const nonempty_req_id = try messages.ReqId.fromSlice(&.{0x00});
+
+    var requests = std.HashMap(RequestKey, u8, RequestKeyContext, std.hash_map.default_max_load_percentage).init(alloc);
+    defer requests.deinit();
+    try requests.put(RequestKey.from(endpoint, empty_req_id), 7);
+
+    try std.testing.expectEqual(@as(?u8, 7), requests.get(RequestKey.from(endpoint, empty_req_id)));
+    try std.testing.expect(requests.get(RequestKey.from(endpoint, nonempty_req_id)) == null);
+}
+
+test "request tracker popped queued intents can be restored to the front" {
+    const alloc = std.testing.allocator;
+    var tracker = RequestTracker.init(alloc, .{
+        .max_active_requests = 4,
+        .max_queued_requests = 4,
+        .max_queued_requests_per_endpoint = 4,
+    });
+    defer tracker.deinit();
+
+    const peer = [_]u8{0x55} ** 32;
+    const pubkey = [_]u8{0x02} ++ [_]u8{0x66} ** 32;
+    const endpoint = Endpoint{ .node_id = peer, .addr = .{ .ip4 = .{ .bytes = .{ 127, 0, 0, 1 }, .port = 30303 } } };
+    const first_req_id = try messages.ReqId.fromSlice(&[_]u8{0x01});
+    const second_req_id = try messages.ReqId.fromSlice(&[_]u8{0x02});
+    const plaintext = [_]u8{ messages.MSG_PING, 0x01 };
+
+    try tracker.queueRequest(endpoint, &pubkey, first_req_id, .ping, &.{}, &plaintext, 0);
+    try tracker.queueRequest(endpoint, &pubkey, second_req_id, .ping, &.{}, &plaintext, 1);
+
+    const intent = (try tracker.popNextQueued(endpoint)) orelse return error.MissingQueuedRequest;
+    try std.testing.expectEqualSlices(u8, first_req_id.slice(), intent.req_id.slice());
+    try std.testing.expectEqual(@as(usize, 1), tracker.pendingCount());
+
+    try tracker.pushFrontQueued(intent);
+    try std.testing.expectEqual(@as(usize, 2), tracker.pendingCount());
+
+    const restored = (try tracker.popNextQueued(endpoint)) orelse return error.MissingQueuedRequest;
+    try std.testing.expectEqualSlices(u8, first_req_id.slice(), restored.req_id.slice());
+}
+
+test "authenticated request retains WHOAREYOU recovery metadata" {
+    const alloc = std.testing.allocator;
+    const io = std.Options.debug_io;
+    var tracker = RequestTracker.init(alloc, .{});
+    defer tracker.deinit();
+
+    var socket = try net.IpAddress.bind(&.{ .ip4 = .{ .bytes = .{ 127, 0, 0, 1 }, .port = 0 } }, io, .{ .mode = .dgram });
+    defer socket.close(io);
+
+    const endpoint = Endpoint{
+        .node_id = [_]u8{0x55} ** 32,
+        .addr = .{ .ip4 = .{ .bytes = .{ 127, 0, 0, 1 }, .port = 30303 } },
+    };
+    const req_id = try messages.ReqId.fromSlice(&[_]u8{0x01});
+    const nonce = [_]u8{0x22} ** packet.NONCE_SIZE;
+    const pubkey = [_]u8{0x02} ++ [_]u8{0x66} ** 32;
+    const plaintext = [_]u8{ messages.MSG_PING, 0x01 };
+
+    try tracker.putActiveAwaitingResponseWithChallenge(
+        endpoint,
+        req_id,
+        .ping,
+        &.{},
+        &socket,
+        &[_]u8{0x99},
+        0,
+        nonce,
+        &pubkey,
+        &plaintext,
+    );
+
+    const probe = tracker.probeForChallenge(&nonce, endpoint.addr) orelse return error.MissingActiveRequest;
+    try std.testing.expectEqualSlices(u8, &pubkey, probe.dest_pubkey);
+    try std.testing.expectEqualSlices(u8, &plaintext, probe.plaintext);
+}
+
+test "only one established-session request can re-establish an endpoint" {
+    const alloc = std.testing.allocator;
+    const io = std.Options.debug_io;
+    var tracker = RequestTracker.init(alloc, .{});
+    defer tracker.deinit();
+
+    var socket = try net.IpAddress.bind(&.{ .ip4 = .{ .bytes = .{ 127, 0, 0, 1 }, .port = 0 } }, io, .{ .mode = .dgram });
+    defer socket.close(io);
+
+    const endpoint = Endpoint{ .node_id = [_]u8{0x51} ** 32, .addr = socket.address };
+    const req_a = try messages.ReqId.fromSlice(&[_]u8{0xa1});
+    const req_b = try messages.ReqId.fromSlice(&[_]u8{0xb1});
+    const nonce_a = [_]u8{0x61} ** packet.NONCE_SIZE;
+    const nonce_b = [_]u8{0x62} ** packet.NONCE_SIZE;
+    const pubkey = [_]u8{0x63} ** 33;
+    const plaintext = [_]u8{ messages.MSG_PING, 0xc0 };
+    try tracker.putActiveAwaitingResponseWithChallenge(endpoint, req_a, .ping, &.{}, &socket, &[_]u8{0x71}, 1, nonce_a, &pubkey, &plaintext);
+    try tracker.putActiveAwaitingResponseWithChallenge(endpoint, req_b, .ping, &.{}, &socket, &[_]u8{0x72}, 1, nonce_b, &pubkey, &plaintext);
+
+    const keys = state.PendingSessionKeys{
+        .initiator_key = [_]u8{0x81} ** 16,
+        .recipient_key = [_]u8{0x82} ** 16,
+    };
+    try tracker.acceptChallenge(RequestKey.from(endpoint, req_a), &nonce_a, endpoint.addr, &[_]u8{0x91}, keys, 2);
+    try std.testing.expectError(error.EndpointEstablishing, tracker.acceptChallenge(RequestKey.from(endpoint, req_b), &nonce_b, endpoint.addr, &[_]u8{0x92}, keys, 2));
+}
+
+test "request tracker commits queued intents as authenticated sends or probes" {
+    const alloc = std.testing.allocator;
+    const io = std.Options.debug_io;
+
+    var tracker = RequestTracker.init(alloc, .{
+        .max_active_requests = 4,
+        .max_queued_requests = 4,
+        .max_queued_requests_per_endpoint = 2,
+    });
+    defer tracker.deinit();
+
+    var socket = try net.IpAddress.bind(&.{ .ip4 = .{ .bytes = .{ 127, 0, 0, 1 }, .port = 0 } }, io, .{
+        .mode = .dgram,
+    });
+    defer socket.close(io);
+
+    const peer = [_]u8{0x55} ** 32;
+    const pubkey = [_]u8{0x02} ++ [_]u8{0x66} ** 32;
+    const endpoint = Endpoint{ .node_id = peer, .addr = .{ .ip4 = .{ .bytes = .{ 127, 0, 0, 1 }, .port = 30303 } } };
+    const first_req_id = try messages.ReqId.fromSlice(&[_]u8{0x01});
+    const second_req_id = try messages.ReqId.fromSlice(&[_]u8{0x02});
+    const plaintext = [_]u8{ messages.MSG_PING, 0x01 };
+    const packet_bytes = try PacketBytes.init(&[_]u8{0x99});
+
+    try tracker.queueRequest(endpoint, &pubkey, first_req_id, .ping, &.{}, &plaintext, 0);
+    var intent = (try tracker.popNextQueued(endpoint)) orelse return error.MissingQueuedRequest;
+    try tracker.putActiveAwaitingResponse(
+        intent.endpoint,
+        intent.req_id,
+        intent.request_kind,
+        intent.distances(),
+        &socket,
+        packet_bytes.slice(),
+        10,
+        null,
+    );
+
+    try std.testing.expectEqual(@as(usize, 1), tracker.activeCount());
+    try std.testing.expectEqual(@as(usize, 0), tracker.pendingCount());
+
+    try tracker.queueRequest(endpoint, &pubkey, second_req_id, .ping, &.{}, &plaintext, 20);
+    intent = (try tracker.popNextQueued(endpoint)) orelse return error.MissingQueuedRequest;
+    try tracker.putActiveProbe(
+        intent.endpoint,
+        intent.req_id,
+        intent.request_kind,
+        intent.distances(),
+        &socket,
+        packet_bytes.slice(),
+        30,
+        [_]u8{0xaa} ** packet.NONCE_SIZE,
+        &intent.dest_pubkey,
+        intent.plaintextSlice(),
+    );
+
+    try std.testing.expectEqual(@as(usize, 2), tracker.activeCount());
+    try std.testing.expectEqual(@as(usize, 1), tracker.pendingCount());
+    try std.testing.expect(tracker.shouldQueueForEndpoint(endpoint));
+    try std.testing.expect(tracker.pendingSessionKeysForEndpoint(endpoint) == null);
+}

--- a/src/discv5/protocol/session.zig
+++ b/src/discv5/protocol/session.zig
@@ -1,0 +1,191 @@
+//! Session key derivation and management for discv5
+//!
+//! "v4" identity scheme:
+//! - ECDH: secp256k1 point multiplication
+//! - HKDF: SHA256-based key derivation per discv5 theory spec
+//! - AES-128-GCM: message encryption
+//! - ID-nonce signing: secp256k1 ECDSA
+
+const std = @import("std");
+const Sha256 = std.crypto.hash.sha2.Sha256;
+const HmacSha256 = std.crypto.auth.hmac.sha2.HmacSha256;
+const secp = @import("../secp256k1.zig");
+
+pub const SESSION_KEY_SIZE = 16;
+const max_challenge_data_len = 256;
+
+pub const DerivedKeys = struct {
+    initiator_key: [16]u8,
+    recipient_key: [16]u8,
+};
+
+/// ECDH: compute shared secret = compress(pubkey * keypair.secret)
+pub fn ecdh(pubkey: *const [33]u8, key_pair: *const secp.KeyPair) ![33]u8 {
+    return secp.ecdh(pubkey, key_pair);
+}
+
+/// HKDF-Extract: HMAC-SHA256(salt, ikm) → PRK
+fn hkdfExtract(salt: []const u8, ikm: []const u8) [32]u8 {
+    var prk: [32]u8 = undefined;
+    HmacSha256.create(&prk, ikm, salt);
+    return prk;
+}
+
+/// HKDF-Expand: expand PRK with info to get `length` bytes
+fn hkdfExpand(prk: *const [32]u8, info: []const u8, out: []u8) void {
+    var t: [32]u8 = undefined;
+    var prev: []const u8 = &[_]u8{};
+    var pos: usize = 0;
+    var counter: u8 = 1;
+
+    while (pos < out.len) {
+        var hmac = HmacSha256.init(prk);
+        hmac.update(prev);
+        hmac.update(info);
+        hmac.update(&[_]u8{counter});
+        hmac.final(&t);
+        prev = &t;
+
+        const chunk = @min(32, out.len - pos);
+        @memcpy(out[pos .. pos + chunk], t[0..chunk]);
+        pos += chunk;
+        counter += 1;
+    }
+}
+
+/// Derive session keys from discv5 handshake
+/// Per discv5 theory spec:
+///   secret = ecdh(dest-pubkey, ephemeral-key)
+///   kdf-info = "discovery v5 key agreement" || node-id-A || node-id-B
+///   prk = HKDF-Extract(salt=challenge-data, ikm=secret)
+///   key-data = HKDF-Expand(prk, kdf-info, 32)
+///   initiator-key = key-data[:16]
+///   recipient-key = key-data[16:]
+pub fn deriveKeys(
+    ephemeral_key_pair: *const secp.KeyPair,
+    dest_pubkey: *const [33]u8,
+    node_id_a: *const [32]u8,
+    node_id_b: *const [32]u8,
+    challenge_data: []const u8,
+) !DerivedKeys {
+    // 1. ECDH
+    const shared_secret = try ecdh(dest_pubkey, ephemeral_key_pair);
+
+    // 2. HKDF-Extract: salt=challenge-data, ikm=shared_secret
+    const prk = hkdfExtract(challenge_data, &shared_secret);
+
+    // 3. HKDF-Expand: info = "discovery v5 key agreement" || node-id-A || node-id-B
+    const prefix = "discovery v5 key agreement";
+    var kdf_info: [26 + 32 + 32]u8 = undefined;
+    @memcpy(kdf_info[0..26], prefix);
+    @memcpy(kdf_info[26..58], node_id_a);
+    @memcpy(kdf_info[58..90], node_id_b);
+
+    var key_data: [32]u8 = undefined;
+    hkdfExpand(&prk, &kdf_info, &key_data);
+
+    return DerivedKeys{
+        .initiator_key = key_data[0..16].*,
+        .recipient_key = key_data[16..32].*,
+    };
+}
+
+/// Compute the id-signature for a handshake
+/// Per discv5 theory spec:
+///   id-signature-text  = "discovery v5 identity proof"
+///   id-signature-input = id-signature-text || challenge-data || ephemeral-pubkey || node-id-B
+///   id-signature       = id_sign(sha256(id-signature-input))
+pub fn signIdNonce(
+    static_key_pair: *const secp.KeyPair,
+    challenge_data: []const u8,
+    eph_pubkey: *const [33]u8,
+    dest_node_id: *const [32]u8,
+) ![64]u8 {
+    const prefix = "discovery v5 identity proof";
+    if (challenge_data.len > max_challenge_data_len) return error.ChallengeTooLong;
+    var msg_buf: [27 + max_challenge_data_len + 33 + 32]u8 = undefined;
+    var msg_len: usize = 0;
+    @memcpy(msg_buf[msg_len .. msg_len + prefix.len], prefix);
+    msg_len += prefix.len;
+    @memcpy(msg_buf[msg_len .. msg_len + challenge_data.len], challenge_data);
+    msg_len += challenge_data.len;
+    @memcpy(msg_buf[msg_len .. msg_len + 33], eph_pubkey);
+    msg_len += 33;
+    @memcpy(msg_buf[msg_len .. msg_len + 32], dest_node_id);
+    msg_len += 32;
+
+    var hash: [32]u8 = undefined;
+    Sha256.hash(msg_buf[0..msg_len], &hash, .{});
+
+    return secp.sign(&hash, static_key_pair);
+}
+
+/// Verify an id-signature
+pub fn verifyIdSignature(
+    sig: *const [64]u8,
+    pubkey: *const [33]u8,
+    challenge_data: []const u8,
+    eph_pubkey: *const [33]u8,
+    local_node_id: *const [32]u8,
+) !void {
+    const prefix = "discovery v5 identity proof";
+    if (challenge_data.len > max_challenge_data_len) return error.ChallengeTooLong;
+    var msg_buf: [27 + max_challenge_data_len + 33 + 32]u8 = undefined;
+    var msg_len: usize = 0;
+    @memcpy(msg_buf[msg_len .. msg_len + prefix.len], prefix);
+    msg_len += prefix.len;
+    @memcpy(msg_buf[msg_len .. msg_len + challenge_data.len], challenge_data);
+    msg_len += challenge_data.len;
+    @memcpy(msg_buf[msg_len .. msg_len + 33], eph_pubkey);
+    msg_len += 33;
+    @memcpy(msg_buf[msg_len .. msg_len + 32], local_node_id);
+    msg_len += 32;
+
+    var hash: [32]u8 = undefined;
+    Sha256.hash(msg_buf[0..msg_len], &hash, .{});
+
+    try secp.verify(&hash, sig, pubkey);
+}
+
+// =========== Test vectors ===========
+
+test "discv5 ECDH test vector" {
+    const hex = @import("hex");
+    const public_key = hex.hexToBytesComptime(33, "039961e4c2356d61bedb83052c115d311acb3a96f5777296dcf297351130266231");
+    const secret_key = hex.hexToBytesComptime(32, "fb757dc581730490a1d7a00deea65e9b1936924caaea8f44d476014856b68736");
+    const key_pair = try secp.keyPairFromSecret(&secret_key);
+    const expected = hex.hexToBytesComptime(33, "033b11a2a1f214567e1537ce5e509ffd9b21373247f2a3ff6841f4976f53165e7e");
+
+    const shared = try ecdh(&public_key, &key_pair);
+    try std.testing.expectEqualSlices(u8, &expected, &shared);
+}
+
+test "discv5 key derivation test vector" {
+    const hex = @import("hex");
+    const eph_key = hex.hexToBytesComptime(32, "fb757dc581730490a1d7a00deea65e9b1936924caaea8f44d476014856b68736");
+    const eph_key_pair = try secp.keyPairFromSecret(&eph_key);
+    const dest_pubkey = hex.hexToBytesComptime(33, "0317931e6e0840220642f230037d285d122bc59063221ef3226b1f403ddc69ca91");
+    const node_id_a = hex.hexToBytesComptime(32, "aaaa8419e9f49d0083561b48287df592939a8d19947d8c0ef88f2a4856a69fbb");
+    const node_id_b = hex.hexToBytesComptime(32, "bbbb9d047f0488c0b5a93c1c3f2d8bafc7c8ff337024a55434a0d0555de64db9");
+    const challenge_data = hex.hexToBytesComptime(63, "000000000000000000000000000000006469736376350001010102030405060708090a0b0c00180102030405060708090a0b0c0d0e0f100000000000000000");
+
+    const expected_initiator = hex.hexToBytesComptime(16, "dccc82d81bd610f4f76d3ebe97a40571");
+    const expected_recipient = hex.hexToBytesComptime(16, "ac74bb8773749920b0d3a8881c173ec5");
+
+    const keys = try deriveKeys(&eph_key_pair, &dest_pubkey, &node_id_a, &node_id_b, &challenge_data);
+    try std.testing.expectEqualSlices(u8, &expected_initiator, &keys.initiator_key);
+    try std.testing.expectEqualSlices(u8, &expected_recipient, &keys.recipient_key);
+}
+
+test "discv5 id-nonce signing verifies generated signature" {
+    const hex = @import("hex");
+    const static_key_pair = secp.KeyPair.generate(std.Options.debug_io);
+    const static_pubkey = secp.compressedPubkey(&static_key_pair);
+    const challenge_data = hex.hexToBytesComptime(63, "000000000000000000000000000000006469736376350001010102030405060708090a0b0c00180102030405060708090a0b0c0d0e0f100000000000000000");
+    const eph_key_pair = secp.KeyPair.generate(std.Options.debug_io);
+    const eph_pubkey = secp.compressedPubkey(&eph_key_pair);
+    const node_id_b = [_]u8{0xbb} ** 32;
+
+    const sig = try signIdNonce(&static_key_pair, &challenge_data, &eph_pubkey, &node_id_b);
+    try verifyIdSignature(&sig, &static_pubkey, &challenge_data, &eph_pubkey, &node_id_b);
+}

--- a/src/discv5/protocol/session_store.zig
+++ b/src/discv5/protocol/session_store.zig
@@ -1,0 +1,118 @@
+//! Storage for the protocol's per-peer session state.
+//!
+//! Owns the three caches that back session establishment — established
+//! sessions, in-flight WHOAREYOU challenges, and the per-source WHOAREYOU rate
+//! limiter — and centralizes their TTL/eviction policy so the protocol handlers
+//! deal in endpoints and timestamps rather than cache mechanics.
+
+const std = @import("std");
+const scoped_log = std.log.scoped(.discv5_protocol);
+const Allocator = std.mem.Allocator;
+const Io = std.Io;
+const Address = Io.net.IpAddress;
+
+const lru = @import("../lru.zig");
+const request_tracker = @import("request_tracker.zig");
+const protocol_state = @import("state.zig");
+
+const Endpoint = request_tracker.Endpoint;
+const EndpointContext = request_tracker.EndpointContext;
+const SessionRecord = protocol_state.SessionRecord;
+const ActiveChallenge = protocol_state.ActiveChallenge;
+const AddressKey = protocol_state.AddressKey;
+const WhoareyouRateEntry = protocol_state.WhoareyouRateEntry;
+
+const SessionCache = lru.LruCacheWithContext(Endpoint, SessionRecord, EndpointContext);
+const ChallengeCache = lru.LruCacheWithContext(Endpoint, ActiveChallenge, EndpointContext);
+const WhoareyouRateCache = lru.LruCache(AddressKey, WhoareyouRateEntry);
+
+pub const Config = struct {
+    session_cache_capacity: u32,
+    session_timeout_ms: u64,
+    challenge_cache_capacity: usize,
+    challenge_timeout_ms: u64,
+    whoareyou_rate_capacity: usize,
+    whoareyou_rate_ttl_ms: u64,
+    max_whoareyou_per_sec: u32,
+};
+
+pub const SessionStore = struct {
+    sessions: SessionCache,
+    challenges: ChallengeCache,
+    whoareyou_rate: WhoareyouRateCache,
+    config: Config,
+
+    pub fn init(alloc: Allocator, config: Config) !SessionStore {
+        var sessions = try SessionCache.init(alloc, config.session_cache_capacity);
+        errdefer sessions.deinit(alloc);
+        var challenges = try ChallengeCache.init(alloc, config.challenge_cache_capacity);
+        errdefer challenges.deinit(alloc);
+        const whoareyou_rate = try WhoareyouRateCache.init(alloc, config.whoareyou_rate_capacity);
+        return .{
+            .sessions = sessions,
+            .challenges = challenges,
+            .whoareyou_rate = whoareyou_rate,
+            .config = config,
+        };
+    }
+
+    pub fn deinit(self: *SessionStore, alloc: Allocator) void {
+        self.sessions.deinit(alloc);
+        self.challenges.deinit(alloc);
+        self.whoareyou_rate.deinit(alloc);
+    }
+
+    pub fn getSession(self: *SessionStore, endpoint: Endpoint, now_ns: i64) ?SessionRecord {
+        return self.sessions.get(endpoint, now_ns);
+    }
+
+    pub fn putSession(self: *SessionStore, endpoint: Endpoint, session: SessionRecord, now_ns: i64) void {
+        self.sessions.put(endpoint, session, self.config.session_timeout_ms, now_ns);
+    }
+
+    pub fn removeSession(self: *SessionStore, endpoint: Endpoint) bool {
+        return self.sessions.remove(endpoint);
+    }
+
+    pub fn sessionCount(self: *SessionStore, now_ns: i64) usize {
+        self.sessions.pruneExpired(now_ns);
+        return self.sessions.count();
+    }
+
+    pub fn getChallenge(self: *SessionStore, endpoint: Endpoint, now_ns: i64) ?ActiveChallenge {
+        return self.challenges.get(endpoint, now_ns);
+    }
+
+    pub fn putChallenge(self: *SessionStore, endpoint: Endpoint, challenge: ActiveChallenge, now_ns: i64) void {
+        self.challenges.put(endpoint, challenge, self.config.challenge_timeout_ms, now_ns);
+    }
+
+    pub fn removeChallenge(self: *SessionStore, endpoint: Endpoint) bool {
+        return self.challenges.remove(endpoint);
+    }
+
+    /// Token-bucket gate for outbound WHOAREYOU responses, keyed by source
+    /// address. WHOAREYOU is sent before peer authentication and can be
+    /// triggered by spoofed source IPs, so the rate state is bounded by the
+    /// underlying TTL/LRU cache (CL-2020-08).
+    pub fn allowWhoareyou(self: *SessionStore, dest: Address, now_ns: i64) bool {
+        const key = AddressKey.fromAddress(dest);
+        var entry = self.whoareyou_rate.get(key, now_ns) orelse WhoareyouRateEntry{
+            .count = 0,
+            .window_start_ns = now_ns,
+        };
+
+        if (now_ns - entry.window_start_ns >= std.time.ns_per_s) {
+            entry = .{ .count = 1, .window_start_ns = now_ns };
+        } else {
+            if (entry.count >= self.config.max_whoareyou_per_sec) {
+                scoped_log.debug("WHOAREYOU rate limit hit for {any}", .{dest});
+                return false;
+            }
+            entry.count += 1;
+        }
+
+        self.whoareyou_rate.put(key, entry, self.config.whoareyou_rate_ttl_ms, now_ns);
+        return true;
+    }
+};

--- a/src/discv5/protocol/state.zig
+++ b/src/discv5/protocol/state.zig
@@ -1,0 +1,89 @@
+const std = @import("std");
+const Io = std.Io;
+const Address = Io.net.IpAddress;
+
+const enr_mod = @import("../enr.zig");
+const packet = @import("packet.zig");
+
+pub const NodeId = enr_mod.NodeId;
+pub const CHALLENGE_DATA_SIZE = packet.WHOAREYOU_CHALLENGE_DATA_SIZE;
+
+/// Bounded ring buffer of recently seen nonces per session.
+/// Provides replay protection without heap allocation (CL-2020-nonce).
+/// Capacity of 32 is sufficient for typical burst rates; older entries are
+/// evicted silently.
+pub const SEEN_NONCES_CAP: usize = 32;
+
+pub const SeenNonces = struct {
+    buf: [SEEN_NONCES_CAP][12]u8,
+    len: usize,
+    head: usize,
+
+    pub fn init() SeenNonces {
+        return .{ .buf = undefined, .len = 0, .head = 0 };
+    }
+
+    /// Returns true if nonce was already seen.
+    pub fn contains(self: *const SeenNonces, nonce: *const [12]u8) bool {
+        var i: usize = 0;
+        while (i < self.len) : (i += 1) {
+            const idx = (self.head + SEEN_NONCES_CAP - self.len + i) % SEEN_NONCES_CAP;
+            if (std.mem.eql(u8, &self.buf[idx], nonce)) return true;
+        }
+        return false;
+    }
+
+    /// Record a nonce. Evicts the oldest entry when the buffer is full.
+    pub fn insert(self: *SeenNonces, nonce: *const [12]u8) void {
+        self.buf[self.head] = nonce.*;
+        self.head = (self.head + 1) % SEEN_NONCES_CAP;
+        if (self.len < SEEN_NONCES_CAP) self.len += 1;
+    }
+};
+
+pub const PendingSessionKeys = struct {
+    initiator_key: [16]u8,
+    recipient_key: [16]u8,
+};
+
+pub const SessionRecord = struct {
+    node_id: NodeId,
+    initiator_key: [16]u8,
+    recipient_key: [16]u8,
+    /// New keys learned during rekey. Kept pending until a packet decrypts with them.
+    awaiting_initiator_key: ?[16]u8 = null,
+    awaiting_recipient_key: ?[16]u8 = null,
+    seen_nonces: SeenNonces,
+};
+
+pub const ActiveChallenge = struct {
+    challenge_data: [CHALLENGE_DATA_SIZE]u8,
+    remote_enr: ?[enr_mod.MAX_ENR_SIZE]u8 = null,
+    remote_enr_len: u16 = 0,
+};
+
+pub const AddressKey = struct {
+    family: Address.Family,
+    bytes: [16]u8,
+
+    pub fn fromAddress(addr: Address) AddressKey {
+        return switch (addr) {
+            .ip4 => |ip4| blk: {
+                var bytes = [_]u8{0} ** 16;
+                @memcpy(bytes[0..4], &ip4.bytes);
+                break :blk .{ .family = .ip4, .bytes = bytes };
+            },
+            .ip6 => |ip6| .{ .family = .ip6, .bytes = ip6.bytes },
+        };
+    }
+};
+
+pub const WhoareyouRateEntry = struct {
+    count: u32,
+    window_start_ns: i64,
+};
+
+pub const Contact = struct {
+    pubkey: [33]u8,
+    addr: Address,
+};

--- a/src/discv5/rate_limit.zig
+++ b/src/discv5/rate_limit.zig
@@ -1,0 +1,252 @@
+//! TS-compatible discv5 packet rate limiter.
+
+const std = @import("std");
+const Allocator = std.mem.Allocator;
+
+const lru = @import("lru.zig");
+const Address = std.Io.net.IpAddress;
+
+pub const RateLimiterQuota = struct {
+    /// How often `max_tokens` fully replenish, in milliseconds.
+    replenish_all_every_ms: u64,
+    /// Instantaneous burst token limit.
+    max_tokens: u32,
+};
+
+pub const Config = struct {
+    global_quota: RateLimiterQuota,
+    by_ip_quota: RateLimiterQuota,
+    /// State keyed by packet source IP is attacker-controlled, so keep it
+    /// bounded even when a peer sprays many spoofed or rotating addresses.
+    by_ip_state_capacity: usize = 4096,
+    banned_ip_capacity: usize = 4096,
+};
+
+pub const Stats = struct {
+    rate_limit_hit_ip_total: u64 = 0,
+    rate_limit_hit_total: u64 = 0,
+};
+
+const banned_ip_duration_ms: u64 = 60_000;
+
+pub const IpKey = struct {
+    family: Address.Family,
+    bytes: [16]u8,
+
+    pub fn fromAddress(addr: Address) IpKey {
+        return switch (addr) {
+            .ip4 => |ip4| blk: {
+                var bytes = [_]u8{0} ** 16;
+                @memcpy(bytes[0..4], &ip4.bytes);
+                break :blk .{ .family = .ip4, .bytes = bytes };
+            },
+            .ip6 => |ip6| .{ .family = .ip6, .bytes = ip6.bytes },
+        };
+    }
+};
+
+pub fn RateLimiterGcra(comptime Key: type) type {
+    return struct {
+        const Self = @This();
+
+        allocator: Allocator,
+        tat_per_key: lru.LruCache(Key, f64),
+        tau_ms: f64,
+        token_interval_ms: f64,
+        ttl_ms: u64,
+
+        pub fn fromQuota(allocator: Allocator, quota: RateLimiterQuota, capacity: usize) !Self {
+            if (quota.max_tokens == 0) return error.InvalidRateLimiterQuota;
+            if (quota.replenish_all_every_ms == 0) return error.InvalidRateLimiterQuota;
+            const tau_ms: f64 = @floatFromInt(quota.replenish_all_every_ms);
+            const max_tokens: f64 = @floatFromInt(quota.max_tokens);
+            return .{
+                .allocator = allocator,
+                .tat_per_key = try lru.LruCache(Key, f64).init(allocator, capacity),
+                .tau_ms = tau_ms,
+                .token_interval_ms = tau_ms / max_tokens,
+                .ttl_ms = quota.replenish_all_every_ms,
+            };
+        }
+
+        pub fn deinit(self: *Self) void {
+            self.tat_per_key.deinit(self.allocator);
+        }
+
+        pub fn allows(self: *Self, key: Key, tokens: u32, ms_since_start: u64) bool {
+            const additional_time = self.token_interval_ms * @as(f64, @floatFromInt(tokens));
+            if (additional_time > self.tau_ms) return false;
+
+            const now: f64 = @floatFromInt(ms_since_start);
+            const now_ns = timestampMsToNs(ms_since_start);
+            const tat = self.tat_per_key.get(key, now_ns) orelse now;
+
+            const earliest_time = tat + additional_time - self.tau_ms;
+            if (now < earliest_time) return false;
+
+            self.tat_per_key.put(key, @max(now, tat) + additional_time, self.ttl_ms, now_ns);
+            return true;
+        }
+
+        pub fn prune(self: *Self, now_ms: u64) void {
+            self.tat_per_key.pruneExpired(timestampMsToNs(now_ms));
+        }
+    };
+}
+
+pub const RateLimiter = struct {
+    allocator: Allocator,
+    global: RateLimiterGcra(u8),
+    by_ip: RateLimiterGcra(IpKey),
+    banned_ips: lru.LruCache(IpKey, u8),
+    expected_responses_by_ip: std.AutoHashMap(IpKey, u32),
+    stats: Stats = .{},
+
+    pub fn init(allocator: Allocator, config: Config) !RateLimiter {
+        var global = try RateLimiterGcra(u8).fromQuota(allocator, config.global_quota, 1);
+        errdefer global.deinit();
+
+        var by_ip = try RateLimiterGcra(IpKey).fromQuota(allocator, config.by_ip_quota, config.by_ip_state_capacity);
+        errdefer by_ip.deinit();
+
+        var banned_ips = try lru.LruCache(IpKey, u8).init(allocator, config.banned_ip_capacity);
+        errdefer banned_ips.deinit(allocator);
+
+        return .{
+            .allocator = allocator,
+            .global = global,
+            .by_ip = by_ip,
+            .banned_ips = banned_ips,
+            .expected_responses_by_ip = std.AutoHashMap(IpKey, u32).init(allocator),
+        };
+    }
+
+    pub fn deinit(self: *RateLimiter) void {
+        self.global.deinit();
+        self.by_ip.deinit();
+        self.banned_ips.deinit(self.allocator);
+        self.expected_responses_by_ip.deinit();
+    }
+
+    pub fn allowEncodedPacket(self: *RateLimiter, addr: Address, now_ms: u64) bool {
+        const ip = IpKey.fromAddress(addr);
+        const now_ns = timestampMsToNs(now_ms);
+        // Correlated responses must remain admissible even if unauthenticated
+        // spoofed traffic has exhausted or temporarily banned the peer's IP.
+        if (self.expectsResponseFromIP(ip)) return true;
+        if (self.banned_ips.get(ip, now_ns) != null) return false;
+
+        if (!self.by_ip.allows(ip, 1, now_ms)) {
+            self.stats.rate_limit_hit_ip_total += 1;
+            self.banned_ips.put(ip, 1, banned_ip_duration_ms, now_ns);
+            return false;
+        }
+
+        if (!self.global.allows(0, 1, now_ms)) {
+            self.stats.rate_limit_hit_total += 1;
+            return false;
+        }
+
+        return true;
+    }
+
+    pub fn addExpectedResponse(self: *RateLimiter, addr: Address) !void {
+        const ip = IpKey.fromAddress(addr);
+        const entry = try self.expected_responses_by_ip.getOrPut(ip);
+        if (!entry.found_existing) entry.value_ptr.* = 0;
+        entry.value_ptr.* += 1;
+    }
+
+    pub fn removeExpectedResponse(self: *RateLimiter, addr: Address) void {
+        const ip = IpKey.fromAddress(addr);
+        const current = self.expected_responses_by_ip.getPtr(ip) orelse return;
+        if (current.* > 1) {
+            current.* -= 1;
+        } else {
+            _ = self.expected_responses_by_ip.remove(ip);
+        }
+    }
+
+    pub fn statsSnapshot(self: *const RateLimiter) Stats {
+        return self.stats;
+    }
+
+    fn expectsResponseFromIP(self: *const RateLimiter, ip: IpKey) bool {
+        return self.expected_responses_by_ip.contains(ip);
+    }
+};
+
+fn timestampMsToNs(ms: u64) i64 {
+    const ns = @as(i128, ms) * std.time.ns_per_ms;
+    return if (ns > std.math.maxInt(i64)) std.math.maxInt(i64) else @intCast(ns);
+}
+
+test "GCRA allows burst then replenishes over time" {
+    var limiter = try RateLimiterGcra(IpKey).fromQuota(std.testing.allocator, .{
+        .replenish_all_every_ms = 1_000,
+        .max_tokens = 2,
+    }, 16);
+    defer limiter.deinit();
+
+    const ip = IpKey.fromAddress(.{ .ip4 = .{ .bytes = .{ 127, 0, 0, 1 }, .port = 9000 } });
+    try std.testing.expect(limiter.allows(ip, 1, 0));
+    try std.testing.expect(limiter.allows(ip, 1, 0));
+    try std.testing.expect(!limiter.allows(ip, 1, 0));
+    try std.testing.expect(limiter.allows(ip, 1, 500));
+}
+
+test "rate limiter bans IP on per-IP quota hit" {
+    var limiter = try RateLimiter.init(std.testing.allocator, .{
+        .global_quota = .{ .replenish_all_every_ms = 1_000, .max_tokens = 100 },
+        .by_ip_quota = .{ .replenish_all_every_ms = 1_000, .max_tokens = 1 },
+    });
+    defer limiter.deinit();
+
+    const addr = Address{ .ip4 = .{ .bytes = .{ 192, 0, 2, 1 }, .port = 9000 } };
+    try std.testing.expect(limiter.allowEncodedPacket(addr, 0));
+    try std.testing.expect(!limiter.allowEncodedPacket(addr, 0));
+    limiter.addExpectedResponse(addr) catch unreachable;
+    try std.testing.expect(limiter.allowEncodedPacket(addr, 0));
+    limiter.removeExpectedResponse(addr);
+    try std.testing.expect(!limiter.allowEncodedPacket(addr, banned_ip_duration_ms - 1));
+    try std.testing.expect(limiter.allowEncodedPacket(addr, banned_ip_duration_ms));
+
+    const stats = limiter.statsSnapshot();
+    try std.testing.expectEqual(@as(u64, 1), stats.rate_limit_hit_ip_total);
+}
+
+test "rate limiter expected response bypasses quotas" {
+    var limiter = try RateLimiter.init(std.testing.allocator, .{
+        .global_quota = .{ .replenish_all_every_ms = 1_000, .max_tokens = 1 },
+        .by_ip_quota = .{ .replenish_all_every_ms = 1_000, .max_tokens = 1 },
+    });
+    defer limiter.deinit();
+
+    const addr = Address{ .ip4 = .{ .bytes = .{ 198, 51, 100, 1 }, .port = 9000 } };
+    try std.testing.expect(limiter.allowEncodedPacket(addr, 0));
+    limiter.addExpectedResponse(addr) catch unreachable;
+    try std.testing.expect(limiter.allowEncodedPacket(addr, 0));
+    limiter.removeExpectedResponse(addr);
+    try std.testing.expect(!limiter.allowEncodedPacket(addr, 0));
+}
+
+test "rate limiter bounds source IP state" {
+    var limiter = try RateLimiter.init(std.testing.allocator, .{
+        .global_quota = .{ .replenish_all_every_ms = 1_000, .max_tokens = 100 },
+        .by_ip_quota = .{ .replenish_all_every_ms = 1_000, .max_tokens = 1 },
+        .by_ip_state_capacity = 2,
+        .banned_ip_capacity = 2,
+    });
+    defer limiter.deinit();
+
+    for (0..8) |i| {
+        const addr = Address{ .ip4 = .{
+            .bytes = .{ 198, 51, 100, @intCast(i + 1) },
+            .port = 9000,
+        } };
+        try std.testing.expect(limiter.allowEncodedPacket(addr, 0));
+        try std.testing.expect(!limiter.allowEncodedPacket(addr, 0));
+        try std.testing.expect(limiter.by_ip.tat_per_key.count() <= 2);
+        try std.testing.expect(limiter.banned_ips.count() <= 2);
+    }
+}

--- a/src/discv5/rlp.zig
+++ b/src/discv5/rlp.zig
@@ -1,0 +1,402 @@
+//! RLP encoder/decoder for discv5 messages
+
+const std = @import("std");
+const Allocator = std.mem.Allocator;
+
+pub const Error = error{
+    Overflow,
+    InvalidEncoding,
+    BufferTooSmall,
+    OutOfMemory,
+    UnexpectedType,
+    TrailingData,
+};
+
+pub const BoundedError = error{BufferTooSmall};
+
+// =========== Writer ===========
+
+pub const Writer = struct {
+    buf: std.ArrayListUnmanaged(u8),
+
+    pub fn init() Writer {
+        return .{ .buf = .empty };
+    }
+
+    pub fn initBuffer(buffer: []u8) Writer {
+        return .{ .buf = std.ArrayListUnmanaged(u8).initBuffer(buffer) };
+    }
+
+    pub fn deinit(self: *Writer, alloc: Allocator) void {
+        self.buf.deinit(alloc);
+    }
+
+    pub fn toOwnedSlice(self: *Writer, alloc: Allocator) ![]u8 {
+        return self.buf.toOwnedSlice(alloc);
+    }
+
+    pub fn bytes(self: *const Writer) []const u8 {
+        return self.buf.items;
+    }
+
+    pub fn writeBytes(self: *Writer, alloc: Allocator, data: []const u8) !void {
+        try self.buf.ensureUnusedCapacity(alloc, try encodedStringLen(data));
+        self.writeBytesBounded(data) catch unreachable;
+    }
+
+    pub fn writeBytesBounded(self: *Writer, data: []const u8) BoundedError!void {
+        if (data.len == 1 and data[0] < 0x80) {
+            try self.appendBounded(data[0]);
+        } else {
+            var prefix: [9]u8 = undefined;
+            const prefix_len = encodeLenPrefix(&prefix, 0x80, 0xb7, data.len);
+            try self.appendSliceBounded(prefix[0..prefix_len]);
+            try self.appendSliceBounded(data);
+        }
+    }
+
+    /// Append a pre-encoded RLP item directly.
+    pub fn writeRawItem(self: *Writer, alloc: Allocator, data: []const u8) !void {
+        try self.buf.ensureUnusedCapacity(alloc, data.len);
+        self.writeRawItemBounded(data) catch unreachable;
+    }
+
+    /// Append a pre-encoded RLP item directly.
+    pub fn writeRawItemBounded(self: *Writer, data: []const u8) BoundedError!void {
+        try self.appendSliceBounded(data);
+    }
+
+    pub fn writeUint64(self: *Writer, alloc: Allocator, v: u64) !void {
+        var tmp: [8]u8 = undefined;
+        try self.writeBytes(alloc, uint64Bytes(&tmp, v));
+    }
+
+    pub fn writeUint64Bounded(self: *Writer, v: u64) BoundedError!void {
+        var tmp: [8]u8 = undefined;
+        try self.writeBytesBounded(uint64Bytes(&tmp, v));
+    }
+
+    pub fn beginList(self: *Writer, alloc: Allocator) !usize {
+        try self.buf.ensureUnusedCapacity(alloc, 4);
+        return self.beginListBounded() catch unreachable;
+    }
+
+    pub fn beginListBounded(self: *Writer) BoundedError!usize {
+        const pos = self.buf.items.len;
+        try self.appendNTimesBounded(0, 4);
+        return pos;
+    }
+
+    pub fn finishList(self: *Writer, start_pos: usize) BoundedError!void {
+        const content_start = start_pos + 4;
+        const content_len = self.buf.items.len - content_start;
+        var prefix: [9]u8 = undefined;
+        const prefix_len = encodeLenPrefix(&prefix, 0xc0, 0xf7, content_len);
+        const old_total = self.buf.items.len;
+        if (prefix_len > 4) return BoundedError.BufferTooSmall;
+        const shift = 4 - prefix_len;
+        if (shift > 0) {
+            @memmove(self.buf.items[start_pos + prefix_len .. old_total - shift], self.buf.items[content_start..old_total]);
+            self.buf.shrinkRetainingCapacity(old_total - shift);
+        }
+        @memcpy(self.buf.items[start_pos .. start_pos + prefix_len], prefix[0..prefix_len]);
+    }
+
+    fn appendBounded(self: *Writer, byte: u8) BoundedError!void {
+        self.buf.appendBounded(byte) catch return BoundedError.BufferTooSmall;
+    }
+
+    fn appendSliceBounded(self: *Writer, data: []const u8) BoundedError!void {
+        self.buf.appendSliceBounded(data) catch return BoundedError.BufferTooSmall;
+    }
+
+    fn appendNTimesBounded(self: *Writer, byte: u8, count: usize) BoundedError!void {
+        self.buf.appendNTimesBounded(byte, count) catch return BoundedError.BufferTooSmall;
+    }
+};
+
+fn encodedStringLen(data: []const u8) Error!usize {
+    if (data.len == 1 and data[0] < 0x80) return 1;
+    return std.math.add(usize, lenPrefixLen(data.len), data.len) catch Error.Overflow;
+}
+
+fn lenPrefixLen(len: usize) usize {
+    return if (len <= 55) 1 else 1 + minBytesForUint(len);
+}
+
+fn uint64Bytes(out: *[8]u8, value: u64) []const u8 {
+    if (value == 0) return out[0..0];
+    std.mem.writeInt(u64, out, value, .big);
+    var start: usize = 0;
+    while (start < 7 and out[start] == 0) start += 1;
+    return out[start..];
+}
+
+fn minBytesForUint(v: usize) usize {
+    if (v == 0) return 1;
+    var n: usize = 0;
+    var vv = v;
+    while (vv > 0) : (vv >>= 8) n += 1;
+    return n;
+}
+
+fn encodeLenPrefix(out: *[9]u8, short_base: u8, long_base: u8, len: usize) usize {
+    if (len <= 55) {
+        out[0] = short_base + @as(u8, @intCast(len));
+        return 1;
+    }
+
+    const len_bytes = minBytesForUint(len);
+    out[0] = long_base + @as(u8, @intCast(len_bytes));
+    var i: usize = 0;
+    var tmp = len;
+    while (i < len_bytes) : (i += 1) {
+        out[1 + len_bytes - 1 - i] = @as(u8, @intCast(tmp & 0xff));
+        tmp >>= 8;
+    }
+    return 1 + len_bytes;
+}
+
+// =========== Reader ===========
+
+pub const Reader = struct {
+    data: []const u8,
+    pos: usize,
+
+    pub fn init(data: []const u8) Reader {
+        return .{ .data = data, .pos = 0 };
+    }
+
+    pub fn remaining(self: *const Reader) usize {
+        return self.data.len - self.pos;
+    }
+
+    pub fn atEnd(self: *const Reader) bool {
+        return self.pos >= self.data.len;
+    }
+
+    pub fn peekIsList(self: *const Reader) bool {
+        if (self.pos >= self.data.len) return false;
+        return self.data[self.pos] >= 0xc0;
+    }
+
+    /// Read the next complete RLP item (string or list) as raw bytes.
+    pub fn readRawItem(self: *Reader) Error![]const u8 {
+        if (self.pos >= self.data.len) return Error.InvalidEncoding;
+        const start = self.pos;
+        const b = self.data[self.pos];
+        if (b < 0x80) {
+            self.pos += 1;
+        } else if (b < 0xb8) {
+            const len: usize = b - 0x80;
+            if (self.pos + 1 + len > self.data.len) return Error.InvalidEncoding;
+            if (len == 1 and self.data[self.pos + 1] < 0x80) return Error.InvalidEncoding;
+            self.pos += 1 + len;
+        } else if (b < 0xc0) {
+            const len_bytes: usize = b - 0xb7;
+            const payload = try readLongPayload(self.data, self.pos + 1, len_bytes);
+            self.pos = payload.end;
+        } else if (b < 0xf8) {
+            const len: usize = b - 0xc0;
+            if (self.pos + 1 + len > self.data.len) return Error.InvalidEncoding;
+            self.pos += 1 + len;
+        } else {
+            const len_bytes: usize = b - 0xf7;
+            const payload = try readLongPayload(self.data, self.pos + 1, len_bytes);
+            self.pos = payload.end;
+        }
+        return self.data[start..self.pos];
+    }
+
+    pub fn readBytes(self: *Reader) Error![]const u8 {
+        if (self.pos >= self.data.len) return Error.InvalidEncoding;
+        const b = self.data[self.pos];
+        if (b < 0x80) {
+            self.pos += 1;
+            return self.data[self.pos - 1 .. self.pos];
+        } else if (b < 0xb8) {
+            const len = b - 0x80;
+            const start = self.pos + 1;
+            if (len > self.data.len - start) return Error.InvalidEncoding;
+            if (len == 1 and self.data[start] < 0x80) return Error.InvalidEncoding;
+            self.pos = start + len;
+            return self.data[start .. start + len];
+        } else if (b < 0xc0) {
+            const len_bytes = b - 0xb7;
+            const payload = try readLongPayload(self.data, self.pos + 1, len_bytes);
+            self.pos = payload.end;
+            return self.data[payload.start..payload.end];
+        } else {
+            return Error.UnexpectedType;
+        }
+    }
+
+    pub fn readUint64(self: *Reader) Error!u64 {
+        const b_slice = try self.readBytes();
+        if (b_slice.len == 0) return 0;
+        if (b_slice.len > 8) return Error.Overflow;
+        if (b_slice[0] == 0) return Error.InvalidEncoding;
+        var v: u64 = 0;
+        for (b_slice) |b| {
+            v = (v << 8) | b;
+        }
+        return v;
+    }
+
+    pub fn readList(self: *Reader) Error!Reader {
+        if (self.pos >= self.data.len) return Error.InvalidEncoding;
+        const b = self.data[self.pos];
+        if (b < 0xc0) return Error.UnexpectedType;
+        if (b < 0xf8) {
+            const len = b - 0xc0;
+            const start = self.pos + 1;
+            if (len > self.data.len - start) return Error.InvalidEncoding;
+            self.pos = start + len;
+            return Reader.init(self.data[start .. start + len]);
+        } else {
+            const len_bytes = b - 0xf7;
+            const payload = try readLongPayload(self.data, self.pos + 1, len_bytes);
+            self.pos = payload.end;
+            return Reader.init(self.data[payload.start..payload.end]);
+        }
+    }
+
+    pub fn skipItem(self: *Reader) Error!void {
+        if (self.pos >= self.data.len) return Error.InvalidEncoding;
+        const b = self.data[self.pos];
+        if (b < 0x80) {
+            self.pos += 1;
+        } else if (b < 0xb8) {
+            const len = b - 0x80;
+            if (self.pos + 1 + len > self.data.len) return Error.InvalidEncoding;
+            if (len == 1 and self.data[self.pos + 1] < 0x80) return Error.InvalidEncoding;
+            self.pos += 1 + len;
+        } else if (b < 0xc0) {
+            const len_bytes = b - 0xb7;
+            const payload = try readLongPayload(self.data, self.pos + 1, len_bytes);
+            self.pos = payload.end;
+        } else if (b < 0xf8) {
+            const len = b - 0xc0;
+            if (self.pos + 1 + len > self.data.len) return Error.InvalidEncoding;
+            self.pos += 1 + len;
+        } else {
+            const len_bytes = b - 0xf7;
+            const payload = try readLongPayload(self.data, self.pos + 1, len_bytes);
+            self.pos = payload.end;
+        }
+    }
+};
+
+const PayloadRange = struct {
+    start: usize,
+    end: usize,
+};
+
+fn readLongPayload(data: []const u8, length_start: usize, length_size: usize) Error!PayloadRange {
+    if (length_start > data.len) return Error.InvalidEncoding;
+    if (length_size == 0) return Error.InvalidEncoding;
+    if (length_size > @sizeOf(usize)) return Error.InvalidEncoding;
+    if (length_size > data.len - length_start) return Error.InvalidEncoding;
+
+    const encoded_length = data[length_start..][0..length_size];
+    if (encoded_length[0] == 0) return Error.InvalidEncoding;
+    const payload_size = readBigEndianUsize(encoded_length);
+    if (payload_size < 56) return Error.InvalidEncoding;
+
+    const payload_start = length_start + length_size;
+    if (payload_size > data.len - payload_start) return Error.InvalidEncoding;
+    return .{ .start = payload_start, .end = payload_start + payload_size };
+}
+
+fn readBigEndianUsize(bytes: []const u8) usize {
+    var v: usize = 0;
+    for (bytes) |b| {
+        v = (v << 8) | b;
+    }
+    return v;
+}
+
+// =========== Tests ===========
+
+test "RLP encode/decode bytes" {
+    var buf: [32]u8 = undefined;
+    var w = Writer.initBuffer(&buf);
+
+    try w.writeBytesBounded(&[_]u8{ 0x01, 0x02, 0x03 });
+    const encoded = w.bytes();
+    try std.testing.expectEqual(@as(u8, 0x83), encoded[0]);
+
+    var r = Reader.init(encoded);
+    const decoded = try r.readBytes();
+    try std.testing.expectEqualSlices(u8, &[_]u8{ 0x01, 0x02, 0x03 }, decoded);
+}
+
+test "RLP encode/decode single byte < 0x80" {
+    var buf: [32]u8 = undefined;
+    var w = Writer.initBuffer(&buf);
+
+    try w.writeBytesBounded(&[_]u8{0x42});
+    const encoded = w.bytes();
+    try std.testing.expectEqual(@as(usize, 1), encoded.len);
+    try std.testing.expectEqual(@as(u8, 0x42), encoded[0]);
+
+    var r = Reader.init(encoded);
+    const decoded = try r.readBytes();
+    try std.testing.expectEqualSlices(u8, &[_]u8{0x42}, decoded);
+}
+
+test "RLP encode/decode uint64" {
+    var buf: [32]u8 = undefined;
+    var w = Writer.initBuffer(&buf);
+
+    try w.writeUint64Bounded(2);
+    const encoded = w.bytes();
+
+    var r = Reader.init(encoded);
+    const v = try r.readUint64();
+    try std.testing.expectEqual(@as(u64, 2), v);
+}
+
+test "RLP encode/decode list" {
+    var buf: [32]u8 = undefined;
+    var w = Writer.initBuffer(&buf);
+
+    const list_start = try w.beginListBounded();
+    try w.writeBytesBounded(&[_]u8{ 0x01, 0x02 });
+    try w.writeUint64Bounded(42);
+    try w.finishList(list_start);
+
+    const encoded = w.bytes();
+
+    var r = Reader.init(encoded);
+    var list = try r.readList();
+    const a = try list.readBytes();
+    try std.testing.expectEqualSlices(u8, &[_]u8{ 0x01, 0x02 }, a);
+    const b = try list.readUint64();
+    try std.testing.expectEqual(@as(u64, 42), b);
+}
+
+test "RLP reader rejects non-canonical encodings" {
+    const encoded_single = [_]u8{ 0x81, 0x01 };
+    var single = Reader.init(&encoded_single);
+    try std.testing.expectError(Error.InvalidEncoding, single.readBytes());
+
+    const long_short_string = [_]u8{ 0xb8, 0x01, 0x80 };
+    var string = Reader.init(&long_short_string);
+    try std.testing.expectError(Error.InvalidEncoding, string.readRawItem());
+
+    const long_short_list = [_]u8{ 0xf8, 0x01, 0xc0 };
+    var list = Reader.init(&long_short_list);
+    try std.testing.expectError(Error.InvalidEncoding, list.readList());
+
+    const leading_zero_integer = [_]u8{0x00};
+    var integer = Reader.init(&leading_zero_integer);
+    try std.testing.expectError(Error.InvalidEncoding, integer.readUint64());
+
+    var skipped = Reader.init(&encoded_single);
+    try std.testing.expectError(Error.InvalidEncoding, skipped.skipItem());
+
+    const oversized_string = [_]u8{0xbf} ++ ([_]u8{0xff} ** 8);
+    var oversized = Reader.init(&oversized_string);
+    try std.testing.expectError(Error.InvalidEncoding, oversized.readRawItem());
+}

--- a/src/discv5/root.zig
+++ b/src/discv5/root.zig
@@ -1,0 +1,63 @@
+//! Discovery v5 protocol implementation
+//!
+//! This module implements the Ethereum Node Discovery Protocol v5 (discv5)
+//! as specified in https://github.com/ethereum/devp2p/tree/master/discv5
+
+const std = @import("std");
+const net = std.Io.net;
+
+pub const enr = @import("enr.zig");
+pub const rlp = @import("rlp.zig");
+pub const packet = @import("protocol/packet.zig");
+pub const session = @import("protocol/session.zig");
+pub const message = @import("protocol/message.zig");
+pub const messages = message;
+pub const kbucket = @import("kbucket.zig");
+pub const protocol = @import("protocol.zig");
+pub const service = @import("service.zig");
+pub const runtime = @import("runtime.zig");
+pub const rate_limit = @import("rate_limit.zig");
+pub const metrics = @import("metrics.zig");
+pub const lru = @import("lru.zig");
+pub const hex = @import("hex");
+pub const secp256k1 = @import("secp256k1.zig");
+
+// Re-export common types
+pub const NodeId = enr.NodeId;
+pub const Enr = enr.Enr;
+pub const RoutingTable = kbucket.RoutingTable;
+pub const Protocol = protocol.Protocol;
+pub const Service = service.Service;
+pub const RuntimeService = runtime.RuntimeService;
+pub const Event = service.Event;
+pub const EventKind = service.EventKind;
+pub const BindAddresses = service.BindAddresses;
+pub const Address = net.IpAddress;
+pub const UdpSocket = net.Socket;
+
+// Include wire test vectors
+test {
+    _ = @import("wire_test_vectors.zig");
+    _ = @import("enr.zig");
+    _ = @import("rlp.zig");
+    _ = @import("protocol/packet.zig");
+    _ = @import("protocol/session.zig");
+    _ = @import("protocol/message.zig");
+    _ = @import("kbucket.zig");
+    _ = @import("protocol.zig");
+    _ = @import("protocol/handshake.zig");
+    _ = @import("protocol/contact_book.zig");
+    _ = @import("protocol/events.zig");
+    _ = @import("protocol/request_tracker.zig");
+    _ = @import("protocol/state.zig");
+    _ = @import("service.zig");
+    _ = @import("service/addr_votes.zig");
+    _ = @import("service/events.zig");
+    _ = @import("service/ingress_queue.zig");
+    _ = @import("service/lookup.zig");
+    _ = @import("runtime.zig");
+    _ = @import("rate_limit.zig");
+    _ = @import("metrics.zig");
+    _ = @import("lru.zig");
+    _ = @import("event_queue.zig");
+}

--- a/src/discv5/runtime.zig
+++ b/src/discv5/runtime.zig
@@ -1,0 +1,646 @@
+const std = @import("std");
+const scoped_log = std.log.scoped(.discv5_runtime_service);
+const Allocator = std.mem.Allocator;
+const Io = std.Io;
+
+const messages = @import("protocol/message.zig");
+const protocol_mod = @import("protocol.zig");
+const service_mod = @import("service.zig");
+const ingress_mod = @import("service/ingress_queue.zig");
+
+const Address = service_mod.Address;
+const Config = service_mod.Config;
+const Event = service_mod.Event;
+const IngressPacket = ingress_mod.IngressPacket;
+const NodeId = service_mod.NodeId;
+const Service = service_mod.Service;
+
+pub const RuntimeService = struct {
+    service: Service,
+    command_queue: CommandQueue,
+    command_buffer: []Command,
+    event_queue: EventQueue,
+    event_buffer: []Event,
+    group: Io.Group = .init,
+    running: std.atomic.Value(bool) = std.atomic.Value(bool).init(false),
+    closed: std.atomic.Value(bool) = std.atomic.Value(bool).init(false),
+    dropped_event_count: std.atomic.Value(u64) = std.atomic.Value(u64).init(0),
+
+    pub const Options = struct {
+        command_queue_capacity: usize = 1024,
+        event_queue_capacity: usize = 1024,
+        maintenance_interval_ms: u64 = 100,
+    };
+
+    pub const Error = error{
+        AlreadyRunning,
+        InvalidQueueCapacity,
+        ServiceNotRunning,
+        ServiceStopped,
+        TooManyDistances,
+    };
+
+    const ReqIdResult = anyerror!messages.ReqId;
+    const LookupIdResult = anyerror!u32;
+    const BoolResult = anyerror!bool;
+    const VoidResult = anyerror!void;
+
+    const ReqIdReply = Io.Queue(ReqIdResult);
+    const LookupIdReply = Io.Queue(LookupIdResult);
+    const BoolReply = Io.Queue(BoolResult);
+    const VoidReply = Io.Queue(VoidResult);
+
+    const CommandQueue = Io.Queue(Command);
+    const EventQueue = Io.Queue(Event);
+
+    const MAX_FINDNODE_DISTANCES: usize = 127;
+
+    const AddNodeCommand = struct {
+        node_id: NodeId,
+        pubkey: ?[33]u8,
+        addr: Address,
+        enr: ?[]u8,
+        reply: *VoidReply,
+    };
+
+    const AddEnrCommand = struct {
+        enr: []u8,
+        reply: *BoolReply,
+    };
+
+    const SetLocalEnrCommand = struct {
+        enr: []u8,
+        reply: *VoidReply,
+    };
+
+    const SendPingCommand = struct {
+        node_id: NodeId,
+        pubkey: [33]u8,
+        addr: Address,
+        enr_seq: u64,
+        reply: *ReqIdReply,
+    };
+
+    const SendFindNodeCommand = struct {
+        node_id: NodeId,
+        pubkey: [33]u8,
+        addr: Address,
+        distances: [MAX_FINDNODE_DISTANCES]u16,
+        distances_len: usize,
+        reply: *ReqIdReply,
+    };
+
+    const SendTalkRequestCommand = struct {
+        node_id: NodeId,
+        pubkey: [33]u8,
+        addr: Address,
+        protocol_name: []u8,
+        request: []u8,
+        reply: *ReqIdReply,
+    };
+
+    const SendTalkResponseCommand = struct {
+        node_id: NodeId,
+        addr: Address,
+        req_id: messages.ReqId,
+        response: []u8,
+        reply: *VoidReply,
+    };
+
+    const StartLookupCommand = struct {
+        target: NodeId,
+        reply: *LookupIdReply,
+    };
+
+    const Command = union(enum) {
+        inbound_packet: IngressPacket,
+        maintenance_tick,
+        shutdown,
+        add_node: AddNodeCommand,
+        add_enr: AddEnrCommand,
+        set_local_enr: SetLocalEnrCommand,
+        send_ping: SendPingCommand,
+        send_findnode: SendFindNodeCommand,
+        send_talk_request: SendTalkRequestCommand,
+        send_talk_response: SendTalkResponseCommand,
+        start_lookup: StartLookupCommand,
+        start_random_lookup: *LookupIdReply,
+    };
+
+    pub fn init(io: Io, allocator: Allocator, config: Config) !RuntimeService {
+        return initWithOptions(io, allocator, config, .{});
+    }
+
+    pub fn initWithOptions(io: Io, allocator: Allocator, config: Config, options: Options) !RuntimeService {
+        if (options.command_queue_capacity == 0 or options.event_queue_capacity == 0) {
+            return Error.InvalidQueueCapacity;
+        }
+
+        var service = try Service.init(io, allocator, config);
+        errdefer service.deinit();
+
+        const command_buffer = try allocator.alloc(Command, options.command_queue_capacity);
+        errdefer allocator.free(command_buffer);
+
+        const event_buffer = try allocator.alloc(Event, options.event_queue_capacity);
+        errdefer allocator.free(event_buffer);
+
+        return .{
+            .service = service,
+            .command_queue = CommandQueue.init(command_buffer),
+            .command_buffer = command_buffer,
+            .event_queue = EventQueue.init(event_buffer),
+            .event_buffer = event_buffer,
+        };
+    }
+
+    pub fn deinit(self: *RuntimeService) void {
+        std.debug.assert(!self.running.load(.acquire));
+        self.stop();
+        self.event_queue.close(self.service.io);
+        self.drainQueuedEvents();
+        self.service.allocator.free(self.event_buffer);
+        self.service.allocator.free(self.command_buffer);
+        self.service.deinit();
+    }
+
+    /// Runs the discv5 actor on the caller task and starts concurrent receive
+    /// and maintenance loops in the supplied `std.Io` implementation. Schedule
+    /// this function with `std.Io.Group.concurrent` when other tasks must call
+    /// the service; do not move it to an unrelated OS thread while sharing an
+    /// event-loop-backed `std.Io`.
+    ///
+    /// To shut down, call `stop`, await the caller-owned group so the actor can
+    /// drain every accepted command, and then call `deinit`. Do not immediately
+    /// cancel the caller-owned group after `stop`; `run` cancels and joins its
+    /// own receive and maintenance workers.
+    ///
+    /// `RuntimeService` is single-shot: after `run` returns, construct a new
+    /// instance to restart the runtime.
+    pub fn run(self: *RuntimeService, options: Options) (Error || Io.ConcurrentError || Io.Cancelable)!void {
+        if (self.closed.load(.acquire)) return Error.ServiceStopped;
+        if (self.running.swap(true, .acq_rel)) return Error.AlreadyRunning;
+        errdefer self.running.store(false, .release);
+        errdefer self.stop();
+        errdefer self.event_queue.close(self.service.io);
+        errdefer self.group.cancel(self.service.io);
+
+        if (self.service.socketForFamily(.ip4) != null) {
+            try self.group.concurrent(self.service.io, receiveLoop, .{ self, Address.Family.ip4 });
+        }
+        if (self.service.socketForFamily(.ip6) != null) {
+            try self.group.concurrent(self.service.io, receiveLoop, .{ self, Address.Family.ip6 });
+        }
+        try self.group.concurrent(self.service.io, maintenanceLoop, .{ self, options.maintenance_interval_ms });
+
+        self.actorLoop() catch |err| switch (err) {
+            error.Canceled => return error.Canceled,
+        };
+
+        self.stop();
+        self.group.cancel(self.service.io);
+        self.event_queue.close(self.service.io);
+        self.running.store(false, .release);
+    }
+
+    pub fn stop(self: *RuntimeService) void {
+        self.closed.store(true, .release);
+        self.command_queue.close(self.service.io);
+    }
+
+    pub fn isRunning(self: *const RuntimeService) bool {
+        return self.running.load(.acquire);
+    }
+
+    pub fn droppedEventCount(self: *const RuntimeService) u64 {
+        return self.dropped_event_count.load(.acquire);
+    }
+
+    pub fn isClosed(self: *const RuntimeService) bool {
+        return self.closed.load(.acquire);
+    }
+
+    pub fn boundAddress(self: *const RuntimeService, family: Address.Family) ?Address {
+        return self.service.boundAddress(family);
+    }
+
+    pub fn nextEvent(self: *RuntimeService) (Io.QueueClosedError || Io.Cancelable)!Event {
+        return self.event_queue.getOne(self.service.io);
+    }
+
+    pub fn popEvent(self: *RuntimeService) ?Event {
+        var buffer: [1]Event = undefined;
+        const received = self.event_queue.getUncancelable(self.service.io, &buffer, 0) catch return null;
+        if (received == 0) return null;
+        return buffer[0];
+    }
+
+    pub fn addNode(
+        self: *RuntimeService,
+        node_id: NodeId,
+        pubkey: ?*const [33]u8,
+        addr: Address,
+        enr: ?[]const u8,
+    ) !void {
+        try self.ensureRunning();
+
+        var owned_enr: ?[]u8 = if (enr) |bytes| try self.service.allocator.dupe(u8, bytes) else null;
+        errdefer if (owned_enr) |bytes| self.service.allocator.free(bytes);
+
+        var reply_buffer: [1]VoidResult = undefined;
+        var reply = VoidReply.init(&reply_buffer);
+        try self.command_queue.putOne(self.service.io, .{ .add_node = .{
+            .node_id = node_id,
+            .pubkey = if (pubkey) |pk| pk.* else null,
+            .addr = addr,
+            .enr = owned_enr,
+            .reply = &reply,
+        } });
+        owned_enr = null;
+
+        return try reply.getOneUncancelable(self.service.io);
+    }
+
+    pub fn addEnr(self: *RuntimeService, enr: []const u8) !bool {
+        try self.ensureRunning();
+
+        var owned_enr: ?[]u8 = try self.service.allocator.dupe(u8, enr);
+        errdefer if (owned_enr) |bytes| self.service.allocator.free(bytes);
+
+        var reply_buffer: [1]BoolResult = undefined;
+        var reply = BoolReply.init(&reply_buffer);
+        try self.command_queue.putOne(self.service.io, .{ .add_enr = .{
+            .enr = owned_enr.?,
+            .reply = &reply,
+        } });
+        owned_enr = null;
+
+        return try reply.getOneUncancelable(self.service.io);
+    }
+
+    pub fn setLocalEnr(self: *RuntimeService, enr: []const u8) !void {
+        try self.ensureRunning();
+
+        var owned_enr: ?[]u8 = try self.service.allocator.dupe(u8, enr);
+        errdefer if (owned_enr) |bytes| self.service.allocator.free(bytes);
+
+        var reply_buffer: [1]VoidResult = undefined;
+        var reply = VoidReply.init(&reply_buffer);
+        try self.command_queue.putOne(self.service.io, .{ .set_local_enr = .{
+            .enr = owned_enr.?,
+            .reply = &reply,
+        } });
+        owned_enr = null;
+
+        return try reply.getOneUncancelable(self.service.io);
+    }
+
+    pub fn sendPing(
+        self: *RuntimeService,
+        node_id: *const NodeId,
+        pubkey: *const [33]u8,
+        addr: Address,
+        enr_seq: u64,
+    ) !messages.ReqId {
+        try self.ensureRunning();
+
+        var reply_buffer: [1]ReqIdResult = undefined;
+        var reply = ReqIdReply.init(&reply_buffer);
+        try self.command_queue.putOne(self.service.io, .{ .send_ping = .{
+            .node_id = node_id.*,
+            .pubkey = pubkey.*,
+            .addr = addr,
+            .enr_seq = enr_seq,
+            .reply = &reply,
+        } });
+
+        return try reply.getOneUncancelable(self.service.io);
+    }
+
+    pub fn sendFindNode(
+        self: *RuntimeService,
+        node_id: *const NodeId,
+        pubkey: *const [33]u8,
+        addr: Address,
+        distances: []const u16,
+    ) !messages.ReqId {
+        try self.ensureRunning();
+        if (distances.len > MAX_FINDNODE_DISTANCES) return Error.TooManyDistances;
+
+        var copied_distances = [_]u16{0} ** MAX_FINDNODE_DISTANCES;
+        @memcpy(copied_distances[0..distances.len], distances);
+
+        var reply_buffer: [1]ReqIdResult = undefined;
+        var reply = ReqIdReply.init(&reply_buffer);
+        try self.command_queue.putOne(self.service.io, .{ .send_findnode = .{
+            .node_id = node_id.*,
+            .pubkey = pubkey.*,
+            .addr = addr,
+            .distances = copied_distances,
+            .distances_len = distances.len,
+            .reply = &reply,
+        } });
+
+        return try reply.getOneUncancelable(self.service.io);
+    }
+
+    pub fn sendTalkRequest(
+        self: *RuntimeService,
+        node_id: *const NodeId,
+        pubkey: *const [33]u8,
+        addr: Address,
+        protocol_name: []const u8,
+        request: []const u8,
+    ) !messages.ReqId {
+        try self.ensureRunning();
+
+        var owned_protocol: ?[]u8 = try self.service.allocator.dupe(u8, protocol_name);
+        errdefer if (owned_protocol) |bytes| self.service.allocator.free(bytes);
+        var owned_request: ?[]u8 = try self.service.allocator.dupe(u8, request);
+        errdefer if (owned_request) |bytes| self.service.allocator.free(bytes);
+
+        var reply_buffer: [1]ReqIdResult = undefined;
+        var reply = ReqIdReply.init(&reply_buffer);
+        try self.command_queue.putOne(self.service.io, .{ .send_talk_request = .{
+            .node_id = node_id.*,
+            .pubkey = pubkey.*,
+            .addr = addr,
+            .protocol_name = owned_protocol.?,
+            .request = owned_request.?,
+            .reply = &reply,
+        } });
+        owned_protocol = null;
+        owned_request = null;
+
+        return try reply.getOneUncancelable(self.service.io);
+    }
+
+    pub fn sendTalkResponse(
+        self: *RuntimeService,
+        node_id: NodeId,
+        addr: Address,
+        req_id: messages.ReqId,
+        response: []const u8,
+    ) !void {
+        try self.ensureRunning();
+
+        var owned_response: ?[]u8 = try self.service.allocator.dupe(u8, response);
+        errdefer if (owned_response) |bytes| self.service.allocator.free(bytes);
+
+        var reply_buffer: [1]VoidResult = undefined;
+        var reply = VoidReply.init(&reply_buffer);
+        try self.command_queue.putOne(self.service.io, .{ .send_talk_response = .{
+            .node_id = node_id,
+            .addr = addr,
+            .req_id = req_id,
+            .response = owned_response.?,
+            .reply = &reply,
+        } });
+        owned_response = null;
+
+        return try reply.getOneUncancelable(self.service.io);
+    }
+
+    pub fn startLookup(self: *RuntimeService, target: *const NodeId) !u32 {
+        try self.ensureRunning();
+
+        var reply_buffer: [1]LookupIdResult = undefined;
+        var reply = LookupIdReply.init(&reply_buffer);
+        try self.command_queue.putOne(self.service.io, .{ .start_lookup = .{
+            .target = target.*,
+            .reply = &reply,
+        } });
+
+        return try reply.getOneUncancelable(self.service.io);
+    }
+
+    pub fn startRandomLookup(self: *RuntimeService) !u32 {
+        try self.ensureRunning();
+
+        var reply_buffer: [1]LookupIdResult = undefined;
+        var reply = LookupIdReply.init(&reply_buffer);
+        try self.command_queue.putOne(self.service.io, .{ .start_random_lookup = &reply });
+
+        return try reply.getOneUncancelable(self.service.io);
+    }
+
+    fn ensureRunning(self: *RuntimeService) Error!void {
+        if (self.closed.load(.acquire)) return Error.ServiceStopped;
+        if (!self.running.load(.acquire)) return Error.ServiceNotRunning;
+    }
+
+    fn actorLoop(self: *RuntimeService) Io.Cancelable!void {
+        while (true) {
+            const command = self.command_queue.getOne(self.service.io) catch |err| switch (err) {
+                error.Closed => return,
+                error.Canceled => return error.Canceled,
+            };
+            try self.handleCommand(command);
+            self.publishServiceEvents() catch return;
+        }
+    }
+
+    fn handleCommand(self: *RuntimeService, command: Command) Io.Cancelable!void {
+        // The reply-driven commands below all mutate protocol state and then
+        // surface the resulting protocol events as service events. That drain
+        // is hoisted to a single call after the switch. The three arms that
+        // return early either drain internally (inbound_packet,
+        // maintenance_tick) or intentionally skip it (shutdown).
+        switch (command) {
+            .inbound_packet => |packet_value| {
+                self.service.handleRuntimeInboundPacket(packet_value);
+                return;
+            },
+            .maintenance_tick => {
+                self.service.runtimeMaintenanceTick();
+                return;
+            },
+            .shutdown => {
+                self.stop();
+                return;
+            },
+            .add_node => |cmd| {
+                defer if (cmd.enr) |bytes| self.service.allocator.free(bytes);
+                var pubkey = cmd.pubkey;
+                self.service.addNode(cmd.node_id, if (pubkey) |*pk| pk else null, cmd.addr, cmd.enr);
+                cmd.reply.putOneUncancelable(self.service.io, {}) catch {};
+            },
+            .add_enr => |cmd| {
+                defer self.service.allocator.free(cmd.enr);
+                cmd.reply.putOneUncancelable(self.service.io, self.service.addEnr(cmd.enr)) catch {};
+            },
+            .set_local_enr => |cmd| {
+                defer self.service.allocator.free(cmd.enr);
+                cmd.reply.putOneUncancelable(self.service.io, self.service.setLocalEnr(cmd.enr)) catch {};
+            },
+            .send_ping => |cmd| {
+                const result = self.service.sendPing(&cmd.node_id, &cmd.pubkey, cmd.addr, cmd.enr_seq);
+                cmd.reply.putOneUncancelable(self.service.io, result) catch {};
+            },
+            .send_findnode => |cmd| {
+                var distances = cmd.distances;
+                const result = self.service.sendFindNode(
+                    &cmd.node_id,
+                    &cmd.pubkey,
+                    cmd.addr,
+                    distances[0..cmd.distances_len],
+                );
+                cmd.reply.putOneUncancelable(self.service.io, result) catch {};
+            },
+            .send_talk_request => |cmd| {
+                defer self.service.allocator.free(cmd.protocol_name);
+                defer self.service.allocator.free(cmd.request);
+                const result = self.service.sendTalkRequest(
+                    &cmd.node_id,
+                    &cmd.pubkey,
+                    cmd.addr,
+                    cmd.protocol_name,
+                    cmd.request,
+                );
+                cmd.reply.putOneUncancelable(self.service.io, result) catch {};
+            },
+            .send_talk_response => |cmd| {
+                defer self.service.allocator.free(cmd.response);
+                const result = self.service.sendTalkResponse(cmd.node_id, cmd.addr, cmd.req_id, cmd.response);
+                cmd.reply.putOneUncancelable(self.service.io, result) catch {};
+            },
+            .start_lookup => |cmd| {
+                cmd.reply.putOneUncancelable(self.service.io, self.service.startLookup(&cmd.target)) catch {};
+            },
+            .start_random_lookup => |reply| {
+                reply.putOneUncancelable(self.service.io, self.service.startRandomLookup()) catch {};
+            },
+        }
+        self.service.drainRuntimeProtocolEvents();
+    }
+
+    fn publishServiceEvents(self: *RuntimeService) Io.QueueClosedError!void {
+        while (self.service.popEvent()) |event| {
+            // Never let an undrained consumer stall the actor and strand
+            // accepted synchronous commands. Runtime events use an explicit
+            // drop-on-full policy, matching the bounded inner service queue.
+            const queued = self.event_queue.putUncancelable(self.service.io, &.{event}, 0) catch |err| {
+                var owned = event;
+                owned.deinit(self.service.allocator);
+                self.dropServiceEvents();
+                return err;
+            };
+            if (queued == 0) {
+                var owned = event;
+                owned.deinit(self.service.allocator);
+                const total = self.dropped_event_count.fetchAdd(1, .acq_rel) + 1;
+                scoped_log.warn("dropped runtime event under queue pressure (total dropped={d})", .{total});
+            }
+        }
+    }
+
+    fn dropServiceEvents(self: *RuntimeService) void {
+        while (self.service.popEvent()) |event| {
+            var owned = event;
+            owned.deinit(self.service.allocator);
+        }
+    }
+
+    fn drainQueuedEvents(self: *RuntimeService) void {
+        var buffer: [16]Event = undefined;
+        while (true) {
+            const received = self.event_queue.getUncancelable(self.service.io, &buffer, 0) catch break;
+            if (received == 0) break;
+            for (buffer[0..received]) |*event| event.deinit(self.service.allocator);
+        }
+    }
+
+    fn receiveLoop(self: *RuntimeService, family: Address.Family) Io.Cancelable!void {
+        const socket = self.service.socketForFamily(family) orelse return;
+
+        var recv_buf: [protocol_mod.MAX_PACKET_SIZE]u8 = undefined;
+        while (!self.closed.load(.acquire)) {
+            const result = socket.receive(self.service.io, &recv_buf) catch |err| switch (err) {
+                error.Canceled => return error.Canceled,
+                else => {
+                    scoped_log.warn("evented receive failed for {s}: {}", .{ @tagName(family), err });
+                    std.Io.sleep(self.service.io, std.Io.Duration.fromMilliseconds(10), .awake) catch return error.Canceled;
+                    continue;
+                },
+            };
+
+            if (!self.service.acceptRuntimeIngress(result.from)) continue;
+
+            var packet = IngressPacket{
+                .from = result.from,
+                .len = result.data.len,
+                .data = undefined,
+            };
+            @memcpy(packet.data[0..result.data.len], result.data);
+
+            self.command_queue.putOne(self.service.io, .{ .inbound_packet = packet }) catch |err| switch (err) {
+                error.Closed => return,
+                error.Canceled => return error.Canceled,
+            };
+        }
+    }
+
+    fn maintenanceLoop(self: *RuntimeService, interval_ms: u64) Io.Cancelable!void {
+        const sleep_ms = @max(interval_ms, 1);
+        while (!self.closed.load(.acquire)) {
+            try std.Io.sleep(self.service.io, std.Io.Duration.fromMilliseconds(@intCast(sleep_ms)), .awake);
+            self.command_queue.putOne(self.service.io, .maintenance_tick) catch |err| switch (err) {
+                error.Closed => return,
+                error.Canceled => return error.Canceled,
+            };
+        }
+    }
+};
+
+test "runtime stop keeps event queue open until actor teardown" {
+    const alloc = std.testing.allocator;
+    const io = std.Options.debug_io;
+    const secp = @import("secp256k1.zig");
+    const enr_mod = @import("enr.zig");
+
+    const sk = [_]u8{0x45} ** 32;
+    const key_pair = try secp.keyPairFromSecret(&sk);
+    const pk = secp.compressedPubkey(&key_pair);
+    const node_id = enr_mod.nodeIdFromCompressedPubkey(&pk);
+    var runtime = try RuntimeService.initWithOptions(io, alloc, .{
+        .bind_addresses = .{ .ip4 = .{ .ip4 = .{ .bytes = .{ 127, 0, 0, 1 }, .port = 0 } } },
+        .protocol_config = .{ .local_key_pair = key_pair, .local_node_id = node_id },
+    }, .{ .command_queue_capacity = 2, .event_queue_capacity = 2 });
+    defer runtime.deinit();
+
+    runtime.stop();
+    var events: [1]Event = undefined;
+    const received = try runtime.event_queue.getUncancelable(io, &events, 0);
+    try std.testing.expectEqual(@as(usize, 0), received);
+}
+
+test "discv5 runtime service requires concurrent std.Io" {
+    const alloc = std.testing.allocator;
+    const io = std.Options.debug_io;
+    const secp = @import("secp256k1.zig");
+    const enr_mod = @import("enr.zig");
+
+    const sk = [_]u8{0x44} ** 32;
+    const key_pair = try secp.keyPairFromSecret(&sk);
+    const pk = secp.compressedPubkey(&key_pair);
+    const node_id = enr_mod.nodeIdFromCompressedPubkey(&pk);
+
+    var runtime = try RuntimeService.initWithOptions(io, alloc, .{
+        .bind_addresses = .{ .ip4 = .{ .ip4 = .{ .bytes = .{ 127, 0, 0, 1 }, .port = 0 } } },
+        .protocol_config = .{
+            .local_key_pair = key_pair,
+            .local_node_id = node_id,
+        },
+    }, .{
+        .command_queue_capacity = 4,
+        .event_queue_capacity = 4,
+        .maintenance_interval_ms = 1,
+    });
+    defer runtime.deinit();
+
+    try std.testing.expectError(error.ConcurrencyUnavailable, runtime.run(.{
+        .command_queue_capacity = 4,
+        .event_queue_capacity = 4,
+        .maintenance_interval_ms = 1,
+    }));
+}

--- a/src/discv5/secp256k1.zig
+++ b/src/discv5/secp256k1.zig
@@ -1,0 +1,99 @@
+//! secp256k1 wrapper for discv5 — ECDH and signing.
+//!
+//! This module intentionally uses Zig std.crypto instead of a libsecp256k1 C
+//! dependency so the discv5 module remains self-contained and testable from the
+//! standalone Lodestar-Z build graph.
+
+const std = @import("std");
+
+const Secp256k1 = std.crypto.ecc.Secp256k1;
+const Ecdsa = std.crypto.sign.ecdsa.EcdsaSecp256k1Sha256;
+
+pub const Error = error{
+    InvalidSecretKey,
+    InvalidPublicKey,
+    InvalidSignature,
+    SigningFailed,
+    EcdhFailed,
+};
+
+/// Compressed public key (33 bytes)
+pub const CompressedPubKey = [33]u8;
+/// Uncompressed public key (65 bytes)
+pub const UncompressedPubKey = [65]u8;
+pub const KeyPair = Ecdsa.KeyPair;
+pub const SecretKey = Ecdsa.SecretKey;
+pub const PublicKey = Ecdsa.PublicKey;
+
+/// Construct a keypair from fixed secret bytes, mainly for protocol vectors and
+/// deterministic fixtures. Runtime code should usually call `KeyPair.generate`.
+pub fn keyPairFromSecret(secret: *const [32]u8) Error!KeyPair {
+    const secret_key = SecretKey.fromBytes(secret.*) catch return Error.InvalidSecretKey;
+    return KeyPair.fromSecretKey(secret_key) catch return Error.InvalidSecretKey;
+}
+
+pub fn compressedPubkey(key_pair: *const KeyPair) CompressedPubKey {
+    return key_pair.public_key.toCompressedSec1();
+}
+
+/// ECDH: pubkey * keypair.secret → compressed shared secret point.
+///
+/// This matches the previous wrapper contract: return the compressed SEC-1
+/// encoding of the scalar-multiplied point, not a KDF output.
+pub fn ecdh(pubkey_bytes: *const [33]u8, key_pair: *const KeyPair) Error![33]u8 {
+    const peer = Secp256k1.fromSec1(pubkey_bytes) catch return Error.InvalidPublicKey;
+    const secret = key_pair.secret_key.toBytes();
+    const shared = peer.mul(secret, .big) catch return Error.EcdhFailed;
+    return shared.toCompressedSec1();
+}
+
+/// Sign a 32-byte message hash with a keypair → compact 64-byte signature.
+pub fn sign(msg_hash: *const [32]u8, key_pair: *const KeyPair) Error![64]u8 {
+    const sig = key_pair.signPrehashed(msg_hash.*, null) catch return Error.SigningFailed;
+    return sig.toBytes();
+}
+
+/// Verify a compact 64-byte signature against msg_hash and compressed pubkey.
+pub fn verify(msg_hash: *const [32]u8, sig_compact: *const [64]u8, pubkey_bytes: *const [33]u8) Error!void {
+    const public_key = PublicKey.fromSec1(pubkey_bytes) catch return Error.InvalidPublicKey;
+    const sig = Ecdsa.Signature.fromBytes(sig_compact.*);
+    sig.verifyPrehashed(msg_hash.*, public_key) catch return Error.InvalidSignature;
+}
+
+/// Decompress a 33-byte compressed public key to 65-byte uncompressed form.
+/// Returns Error.InvalidPublicKey if the key is invalid.
+pub fn uncompressedFromCompressed(compressed: *const [33]u8) Error!UncompressedPubKey {
+    const public_key = PublicKey.fromSec1(compressed) catch return Error.InvalidPublicKey;
+    return public_key.toUncompressedSec1();
+}
+
+test "secp256k1 std.crypto wrapper derives, signs, verifies, and rejects invalid signatures" {
+    const io = std.Options.debug_io;
+    const key_pair = KeyPair.generate(io);
+    const public_key = compressedPubkey(&key_pair);
+
+    var msg_hash = [_]u8{0} ** 32;
+    msg_hash[31] = 42;
+
+    const sig = try sign(&msg_hash, &key_pair);
+    try verify(&msg_hash, &sig, &public_key);
+
+    var bad_sig = sig;
+    bad_sig[0] ^= 1;
+    try std.testing.expectError(Error.InvalidSignature, verify(&msg_hash, &bad_sig, &public_key));
+}
+
+test "secp256k1 std.crypto wrapper computes symmetric raw ECDH point" {
+    const io = std.Options.debug_io;
+    const a_key_pair = KeyPair.generate(io);
+    const b_key_pair = KeyPair.generate(io);
+    const a_public = compressedPubkey(&a_key_pair);
+    const b_public = compressedPubkey(&b_key_pair);
+
+    const ab = try ecdh(&b_public, &a_key_pair);
+    const ba = try ecdh(&a_public, &b_key_pair);
+    try std.testing.expectEqualSlices(u8, &ab, &ba);
+
+    const uncompressed = try uncompressedFromCompressed(&a_public);
+    try std.testing.expectEqual(@as(u8, 0x04), uncompressed[0]);
+}

--- a/src/discv5/service.zig
+++ b/src/discv5/service.zig
@@ -1,0 +1,2239 @@
+//! Higher-level discv5 service with integrated lookup orchestration.
+
+const std = @import("std");
+const scoped_log = std.log.scoped(.discv5_service);
+const Allocator = std.mem.Allocator;
+const Io = std.Io;
+
+const enr_mod = @import("enr.zig");
+const kbucket = @import("kbucket.zig");
+const messages = @import("protocol/message.zig");
+const metrics_mod = @import("metrics.zig");
+const protocol_mod = @import("protocol.zig");
+const rate_limit = @import("rate_limit.zig");
+const secp = @import("secp256k1.zig");
+const event_queue_mod = @import("event_queue.zig");
+const addr_votes_mod = @import("service/addr_votes.zig");
+const ingress_mod = @import("service/ingress_queue.zig");
+const lookup_mod = @import("service/lookup.zig");
+const service_events = @import("service/events.zig");
+const util = @import("util.zig");
+const net = Io.net;
+
+const bindDatagramSocket = util.bindDatagramSocket;
+const shortNodeId = util.shortNodeId;
+const currentTimestampNs = util.nowNs;
+const currentUnixTimeMs = util.nowMs;
+
+pub const Address = net.IpAddress;
+pub const NodeId = enr_mod.NodeId;
+pub const Protocol = protocol_mod.Protocol;
+pub const DiscoveredEnrEvent = service_events.DiscoveredEnrEvent;
+pub const EnrAddedEvent = service_events.EnrAddedEvent;
+pub const Event = service_events.Event;
+pub const EventKind = service_events.EventKind;
+pub const IngressPacket = ingress_mod.IngressPacket;
+pub const IngressStatsSnapshot = ingress_mod.IngressStatsSnapshot;
+pub const LocalEnrUpdatedEvent = service_events.LocalEnrUpdatedEvent;
+pub const LookupFinishedEvent = service_events.LookupFinishedEvent;
+pub const PeerConnectedEvent = service_events.PeerConnectedEvent;
+pub const PeerDisconnectedEvent = service_events.PeerDisconnectedEvent;
+
+const AddrVotes = addr_votes_mod.AddrVotes;
+const IngressQueue = ingress_mod.IngressQueue;
+const Lookup = lookup_mod.Lookup;
+
+pub const MAX_LOOKUP_RESULTS: usize = lookup_mod.MAX_RESULTS;
+
+pub const BindAddresses = struct {
+    ip4: ?Address = null,
+    ip6: ?Address = null,
+
+    fn count(self: *const BindAddresses) usize {
+        var total: usize = 0;
+        if (self.ip4 != null) total += 1;
+        if (self.ip6 != null) total += 1;
+        return total;
+    }
+};
+
+pub const Config = struct {
+    bind_addresses: BindAddresses,
+    protocol_config: protocol_mod.Config,
+    lookup_num_results: usize = MAX_LOOKUP_RESULTS,
+    lookup_parallelism: usize = 3,
+    lookup_request_limit: usize = 3,
+    lookup_timeout_ms: u64 = 60_000,
+    receive_timeout_ms: u64 = 1,
+    ping_interval_ms: u64 = 30_000,
+    enr_update: bool = true,
+    addr_votes_to_update_enr: usize = 10,
+    ingress_queue_capacity: usize = 1024,
+    max_packets_per_poll: usize = 64,
+    ingress_worker_timeout_ms: u64 = 50,
+    rate_limiter: ?rate_limit.Config = .{
+        .global_quota = .{ .replenish_all_every_ms = 1_000, .max_tokens = 256 },
+        .by_ip_quota = .{ .replenish_all_every_ms = 1_000, .max_tokens = 64 },
+    },
+};
+
+const LookupRequestKey = struct {
+    peer_id: NodeId,
+    req_id: messages.ReqId,
+
+    fn from(peer_id: NodeId, req_id: messages.ReqId) LookupRequestKey {
+        return .{
+            .peer_id = peer_id,
+            .req_id = req_id,
+        };
+    }
+};
+
+const ConnectedPeer = struct {
+    addr: Address,
+    next_ping_at_ns: i64,
+    awaiting_ping_response: bool = false,
+};
+
+pub const SetLocalEnrError = Allocator.Error || enr_mod.Error || error{
+    WrongNodeId,
+    StaleEnrSeq,
+    QueueFull,
+};
+
+pub const Service = struct {
+    allocator: Allocator,
+    io: Io,
+    config: Config,
+    socket_ip4: ?net.Socket = null,
+    socket_ip6: ?net.Socket = null,
+    protocol: Protocol,
+    next_lookup_id: u32 = 1,
+    lookup_count: u64 = 0,
+    active_lookups: std.AutoHashMap(u32, Lookup),
+    request_lookup_ids: std.AutoHashMap(LookupRequestKey, u32),
+    expected_response_requests: std.AutoHashMap(LookupRequestKey, Address),
+    connected_peers: std.AutoHashMap(NodeId, ConnectedPeer),
+    owned_local_enr: ?[]u8 = null,
+    addr_votes_ip4: AddrVotes,
+    addr_votes_ip6: AddrVotes,
+    event_queue: event_queue_mod.EventQueue(Event) = .{},
+    dropped_event_count: u64 = 0,
+    ingress_queue: IngressQueue,
+    ingress_shutdown_requested: std.atomic.Value(bool) = std.atomic.Value(bool).init(false),
+    ingress_thread_ip4: ?std.Thread = null,
+    ingress_thread_ip6: ?std.Thread = null,
+    ingress_workers_started: bool = false,
+    next_socket_poll_family: Address.Family = .ip4,
+
+    pub fn init(io: Io, allocator: Allocator, config: Config) !Service {
+        if (config.lookup_num_results == 0 or config.lookup_num_results > lookup_mod.MAX_RESULTS) {
+            return error.InvalidLookupNumResults;
+        }
+        if (config.lookup_parallelism == 0 or config.lookup_parallelism > lookup_mod.MAX_PARALLELISM) {
+            return error.InvalidLookupParallelism;
+        }
+        if (config.bind_addresses.count() == 0) return error.NoBindAddresses;
+        if (config.bind_addresses.ip4) |addr| switch (addr) {
+            .ip4 => {},
+            .ip6 => return error.InvalidBindAddressFamily,
+        };
+        if (config.bind_addresses.ip6) |addr| switch (addr) {
+            .ip4 => return error.InvalidBindAddressFamily,
+            .ip6 => {},
+        };
+
+        var service_config = config;
+        const owned_local_enr = if (service_config.protocol_config.local_enr) |local_enr|
+            try allocator.dupe(u8, local_enr)
+        else
+            null;
+        errdefer if (owned_local_enr) |local_enr| allocator.free(local_enr);
+        if (owned_local_enr) |local_enr| service_config.protocol_config.local_enr = local_enr;
+
+        var socket_ip4: ?net.Socket = null;
+        errdefer if (socket_ip4) |*socket| socket.close(io);
+        if (config.bind_addresses.ip4) |addr| {
+            socket_ip4 = try bindDatagramSocket(io, addr);
+        }
+
+        var socket_ip6: ?net.Socket = null;
+        errdefer if (socket_ip6) |*socket| socket.close(io);
+        if (config.bind_addresses.ip6) |addr| {
+            socket_ip6 = try bindDatagramSocket(io, addr);
+        }
+
+        var protocol = try Protocol.init(io, allocator, service_config.protocol_config);
+        errdefer protocol.deinit();
+
+        var ingress_queue = try IngressQueue.init(allocator, service_config.ingress_queue_capacity, service_config.rate_limiter);
+        errdefer ingress_queue.deinit();
+
+        return .{
+            .allocator = allocator,
+            .io = io,
+            .config = service_config,
+            .socket_ip4 = socket_ip4,
+            .socket_ip6 = socket_ip6,
+            .protocol = protocol,
+            .lookup_count = 0,
+            .active_lookups = std.AutoHashMap(u32, Lookup).init(allocator),
+            .request_lookup_ids = std.AutoHashMap(LookupRequestKey, u32).init(allocator),
+            .expected_response_requests = std.AutoHashMap(LookupRequestKey, Address).init(allocator),
+            .connected_peers = std.AutoHashMap(NodeId, ConnectedPeer).init(allocator),
+            .owned_local_enr = owned_local_enr,
+            .addr_votes_ip4 = AddrVotes.init(allocator, service_config.addr_votes_to_update_enr),
+            .addr_votes_ip6 = AddrVotes.init(allocator, service_config.addr_votes_to_update_enr),
+            .ingress_queue = ingress_queue,
+        };
+    }
+
+    pub fn deinit(self: *Service) void {
+        self.stopIngressWorkers();
+        var lookups = self.active_lookups.iterator();
+        while (lookups.next()) |entry| entry.value_ptr.deinit(self.allocator);
+        self.active_lookups.deinit();
+        self.request_lookup_ids.deinit();
+        self.expected_response_requests.deinit();
+        self.connected_peers.deinit();
+        self.addr_votes_ip4.deinit();
+        self.addr_votes_ip6.deinit();
+        self.event_queue.deinit(self.allocator);
+        self.ingress_queue.deinit();
+        if (self.owned_local_enr) |local_enr| self.allocator.free(local_enr);
+        self.protocol.deinit();
+        if (self.socket_ip4) |*socket| socket.close(self.io);
+        if (self.socket_ip6) |*socket| socket.close(self.io);
+    }
+
+    pub fn addNode(self: *Service, node_id: NodeId, pubkey: ?*const [33]u8, addr: Address, enr: ?[]const u8) void {
+        scoped_log.debug("adding node={s} addr={any} has_pubkey={} has_enr={}", .{
+            &shortNodeId(&node_id),
+            addr,
+            pubkey != null,
+            enr != null,
+        });
+        self.protocol.addNode(node_id, pubkey, addr, enr);
+    }
+
+    pub fn addEnr(self: *Service, enr_bytes: []const u8) bool {
+        const parsed = enr_mod.decode(enr_bytes) catch |err| {
+            scoped_log.debug("rejecting ENR: decode failed: {}", .{err});
+            return false;
+        };
+
+        const node_id = parsed.nodeId() orelse {
+            scoped_log.debug("rejecting ENR: missing node id", .{});
+            return false;
+        };
+        const pubkey = parsed.pubkey orelse {
+            scoped_log.debug("rejecting ENR for node={s}: missing pubkey", .{&shortNodeId(&node_id)});
+            return false;
+        };
+        const addr = self.contactAddressFromParsedEnr(&parsed) orelse {
+            scoped_log.debug("rejecting ENR for node={s}: missing contact address", .{&shortNodeId(&node_id)});
+            return false;
+        };
+
+        const previous_enr = self.dupeEnr(self.allocator, &node_id) catch null;
+        errdefer if (previous_enr) |bytes| self.allocator.free(bytes);
+
+        self.addNode(node_id, &pubkey, addr, enr_bytes);
+
+        const stored_enr = self.findEnr(&node_id) orelse {
+            if (previous_enr) |bytes| self.allocator.free(bytes);
+            scoped_log.debug("failed to store ENR for node={s} addr={any}", .{ &shortNodeId(&node_id), addr });
+            return false;
+        };
+        if (!std.mem.eql(u8, stored_enr, enr_bytes)) {
+            if (previous_enr) |bytes| self.allocator.free(bytes);
+            scoped_log.debug("stored ENR for node={s} addr={any} did not match input", .{ &shortNodeId(&node_id), addr });
+            return false;
+        }
+        if (previous_enr) |bytes| {
+            if (std.mem.eql(u8, bytes, enr_bytes)) {
+                self.allocator.free(bytes);
+                scoped_log.debug("ENR already known for node={s} addr={any}", .{ &shortNodeId(&node_id), addr });
+                return true;
+            }
+        }
+
+        const event_enr = self.allocator.dupe(u8, enr_bytes) catch {
+            if (previous_enr) |bytes| self.allocator.free(bytes);
+            return true;
+        };
+        scoped_log.debug("accepted ENR for node={s} addr={any} replaced={}", .{
+            &shortNodeId(&node_id),
+            addr,
+            previous_enr != null,
+        });
+        self.emitEvent(.{
+            .enr_added = .{
+                .node_id = node_id,
+                .addr = addr,
+                .enr = event_enr,
+                .replaced_enr = previous_enr,
+            },
+        });
+        return true;
+    }
+
+    pub fn localEnr(self: *const Service) ?[]const u8 {
+        return self.protocol.config.local_enr;
+    }
+
+    pub fn localEnrSeq(self: *const Service) u64 {
+        return self.protocol.config.local_enr_seq;
+    }
+
+    pub fn dupeLocalEnr(self: *const Service, alloc: Allocator) Allocator.Error!?[]u8 {
+        const local_enr = self.localEnr() orelse return null;
+        return try alloc.dupe(u8, local_enr);
+    }
+
+    pub fn setLocalEnr(self: *Service, enr_bytes: []const u8) SetLocalEnrError!void {
+        const parsed = try enr_mod.decode(enr_bytes);
+
+        const node_id = parsed.nodeId() orelse return error.InvalidEnr;
+        if (!std.mem.eql(u8, &node_id, &self.protocol.config.local_node_id)) return error.WrongNodeId;
+
+        if (self.protocol.config.local_enr) |current| {
+            if (std.mem.eql(u8, current, enr_bytes)) return;
+        }
+        if (parsed.seq <= self.protocol.config.local_enr_seq) return error.StaleEnrSeq;
+
+        try self.commitLocalEnrBytes(try self.allocator.dupe(u8, enr_bytes), parsed.seq, true);
+    }
+
+    pub fn findEnr(self: *const Service, node_id: *const NodeId) ?[]const u8 {
+        if (std.mem.eql(u8, node_id, &self.protocol.config.local_node_id)) {
+            return self.localEnr();
+        }
+        return self.protocol.findEnr(node_id);
+    }
+
+    pub fn dupeEnr(self: *const Service, alloc: Allocator, node_id: *const NodeId) Allocator.Error!?[]u8 {
+        const enr_bytes = self.findEnr(node_id) orelse return null;
+        return try alloc.dupe(u8, enr_bytes);
+    }
+
+    pub fn boundAddress(self: *const Service, family: Address.Family) ?Address {
+        return switch (family) {
+            .ip4 => if (self.socket_ip4) |socket| socket.address else null,
+            .ip6 => if (self.socket_ip6) |socket| socket.address else null,
+        };
+    }
+
+    pub fn boundPort(self: *const Service, family: Address.Family) ?u16 {
+        const addr = self.boundAddress(family) orelse return null;
+        return addr.getPort();
+    }
+
+    pub fn popEvent(self: *Service) ?Event {
+        return self.event_queue.pop();
+    }
+
+    /// Publish a completed event to consumers. On allocation or queue pressure the event
+    /// is dropped rather than propagated — these call sites run in void
+    /// event-draining paths with nothing to unwind to — but the drop is made
+    /// observable: the event's owned memory is released, the loss is logged,
+    /// and `dropped_event_count` is bumped so embedders can alarm on it.
+    fn emitEvent(self: *Service, event: Event) void {
+        self.event_queue.push(self.allocator, event) catch {
+            var dropped = event;
+            dropped.deinit(self.allocator);
+            self.dropped_event_count += 1;
+            scoped_log.warn("dropped {s} event under queue pressure (total dropped={d})", .{
+                @tagName(std.meta.activeTag(event)),
+                self.dropped_event_count,
+            });
+        };
+    }
+
+    pub fn knownPeerCount(self: *const Service) usize {
+        return self.protocol.routing_table.nodeCount();
+    }
+
+    pub fn connectedPeerCount(self: *const Service) usize {
+        return self.connected_peers.count();
+    }
+
+    fn lookupConfig(self: *const Service) lookup_mod.Config {
+        return .{
+            .num_results = self.config.lookup_num_results,
+            .parallelism = self.config.lookup_parallelism,
+            .request_limit = self.config.lookup_request_limit,
+            .timeout_ms = self.config.lookup_timeout_ms,
+        };
+    }
+
+    pub fn metricsSnapshot(self: *Service) metrics_mod.MetricsSnapshot {
+        const ingress_stats = self.ingress_queue.snapshot();
+        const protocol_metrics = self.protocol.metricsSnapshot();
+        return .{
+            .kad_table_size = self.knownPeerCount(),
+            .active_session_count = self.protocol.activeSessionCount(),
+            .connected_peer_count = self.connectedPeerCount(),
+            .lookup_count = self.lookup_count,
+            .rate_limit_hit_ip = ingress_stats.rate_limit_hit_ip_total,
+            .rate_limit_hit_total = ingress_stats.rate_limit_hit_total,
+            .sent_message_count = protocol_metrics.sent_message_count,
+            .rcvd_message_count = protocol_metrics.rcvd_message_count,
+            .dropped_event_count = self.dropped_event_count,
+        };
+    }
+
+    /// Starts blocking ingress workers on operating-system threads.
+    ///
+    /// The supplied `std.Io` implementation must be safe to use from those
+    /// threads (for example, `std.Io.Threaded`). Event-loop-backed `std.Io`
+    /// implementations should use `RuntimeService`, which schedules receive
+    /// loops with `std.Io.Group` instead.
+    pub fn startIngressWorkers(self: *Service) !void {
+        if (self.ingress_workers_started) return;
+        self.ingress_shutdown_requested.store(false, .release);
+        errdefer self.stopIngressWorkers();
+        if (self.socket_ip4 != null) {
+            self.ingress_thread_ip4 = try std.Thread.spawn(.{}, ingressWorkerMain, .{ self, Address.Family.ip4 });
+        }
+        if (self.socket_ip6 != null) {
+            self.ingress_thread_ip6 = try std.Thread.spawn(.{}, ingressWorkerMain, .{ self, Address.Family.ip6 });
+        }
+        self.ingress_workers_started = true;
+    }
+
+    pub fn stopIngressWorkers(self: *Service) void {
+        self.ingress_shutdown_requested.store(true, .release);
+        if (self.ingress_thread_ip4) |thread| {
+            thread.join();
+            self.ingress_thread_ip4 = null;
+        }
+        if (self.ingress_thread_ip6) |thread| {
+            thread.join();
+            self.ingress_thread_ip6 = null;
+        }
+        self.ingress_workers_started = false;
+    }
+
+    pub fn ingressStatsSnapshot(self: *const Service) IngressStatsSnapshot {
+        return @constCast(&self.ingress_queue).snapshot();
+    }
+
+    pub fn queuedIngressPackets(self: *Service) usize {
+        return self.ingress_queue.queuedLen();
+    }
+
+    pub fn queueInboundPacketForTest(self: *Service, from: Address, data: []const u8) !void {
+        if (!self.ingress_queue.enqueueForTest(from, data)) return error.QueueFull;
+    }
+
+    /// Run a received packet through the protocol handler, logging (not
+    /// propagating) handler errors. Shared by every ingress path.
+    fn dispatchPacket(self: *Service, from: Address, data: []u8, socket: *const net.Socket) void {
+        self.protocol.handlePacket(data, from, socket) catch |err| {
+            scoped_log.debug("handlePacket failed for {any}: {}", .{ from, err });
+        };
+    }
+
+    pub fn processQueuedPackets(self: *Service, max_packets: usize) usize {
+        var processed: usize = 0;
+        while (processed < max_packets) {
+            var packet = self.ingress_queue.pop() orelse break;
+            const socket = self.socketForAddress(packet.from) orelse continue;
+            self.dispatchPacket(packet.from, packet.data[0..packet.len], socket);
+            processed += 1;
+        }
+        const budget_exhausted = processed == max_packets and self.queuedIngressPackets() > 0;
+        self.ingress_queue.noteProcessed(processed, budget_exhausted);
+        return processed;
+    }
+
+    pub fn acceptRuntimeIngress(self: *Service, from: Address) bool {
+        return self.ingress_queue.acceptReceived(from, currentUnixTimeMs(self.io));
+    }
+
+    pub fn handleRuntimeInboundPacket(self: *Service, packet_value: IngressPacket) void {
+        var packet = packet_value;
+        const socket = self.socketForAddress(packet.from) orelse return;
+        self.dispatchPacket(packet.from, packet.data[0..packet.len], socket);
+        self.ingress_queue.noteProcessed(1, false);
+        self.drainProtocolEvents();
+    }
+
+    pub fn runtimeMaintenanceTick(self: *Service) void {
+        self.protocol.pruneExpiredState();
+        self.pruneTimedOutLookups();
+        self.syncConnectedPeers();
+        self.pingDueConnectedPeers();
+        self.drainProtocolEvents();
+    }
+
+    pub fn drainRuntimeProtocolEvents(self: *Service) void {
+        self.drainProtocolEvents();
+    }
+
+    pub fn pollIngress(self: *Service) usize {
+        const processed = if (self.ingress_workers_started)
+            self.processQueuedPackets(self.config.max_packets_per_poll)
+        else
+            self.pollSocketIngressBudgeted(self.config.max_packets_per_poll);
+        self.drainProtocolEvents();
+        return processed;
+    }
+
+    pub fn poll(self: *Service) void {
+        self.drainProtocolEvents();
+        _ = self.pollIngress();
+        self.protocol.pruneExpiredState();
+        self.pruneTimedOutLookups();
+        self.syncConnectedPeers();
+        self.pingDueConnectedPeers();
+        self.drainProtocolEvents();
+    }
+
+    pub fn sendPing(self: *Service, node_id: *const NodeId, pubkey: *const [33]u8, addr: Address, enr_seq: u64) !messages.ReqId {
+        const socket = self.socketForAddress(addr) orelse return error.NoSocketForAddressFamily;
+        const req_id = try self.protocol.sendPing(node_id, pubkey, addr, enr_seq, socket);
+        self.noteExpectedResponse(node_id.*, req_id, addr);
+        return req_id;
+    }
+
+    pub fn sendFindNode(self: *Service, node_id: *const NodeId, pubkey: *const [33]u8, addr: Address, distances: []const u16) !messages.ReqId {
+        const socket = self.socketForAddress(addr) orelse return error.NoSocketForAddressFamily;
+        const req_id = try self.protocol.sendFindNode(node_id, pubkey, addr, distances, socket);
+        self.noteExpectedResponse(node_id.*, req_id, addr);
+        return req_id;
+    }
+
+    pub fn sendTalkRequest(self: *Service, node_id: *const NodeId, pubkey: *const [33]u8, addr: Address, protocol_name: []const u8, request: []const u8) !messages.ReqId {
+        const socket = self.socketForAddress(addr) orelse return error.NoSocketForAddressFamily;
+        const req_id = try self.protocol.sendTalkRequest(node_id, pubkey, addr, protocol_name, request, socket);
+        self.noteExpectedResponse(node_id.*, req_id, addr);
+        return req_id;
+    }
+
+    pub fn sendTalkResponse(self: *Service, node_id: NodeId, addr: Address, req_id: messages.ReqId, response: []const u8) !void {
+        const socket = self.socketForAddress(addr) orelse return error.NoSocketForAddressFamily;
+        try self.protocol.sendTalkResponse(node_id, addr, req_id, response, socket);
+    }
+
+    fn noteExpectedResponse(self: *Service, peer_id: NodeId, req_id: messages.ReqId, addr: Address) void {
+        self.expected_response_requests.put(LookupRequestKey.from(peer_id, req_id), addr) catch {};
+        self.ingress_queue.addExpectedResponse(addr);
+    }
+
+    fn removeExpectedResponse(self: *Service, peer_id: NodeId, req_id: messages.ReqId, fallback_addr: ?Address) void {
+        const key = LookupRequestKey.from(peer_id, req_id);
+        if (self.expected_response_requests.fetchRemove(key)) |entry| {
+            self.ingress_queue.removeExpectedResponse(entry.value);
+        } else if (fallback_addr) |addr| {
+            self.ingress_queue.removeExpectedResponse(addr);
+        }
+    }
+
+    fn maybeUpdateLocalEnrFromVote(self: *Service, voter_addr: Address, observed_addr: Address) void {
+        if (!self.config.enr_update) return;
+        if (self.protocol.config.local_enr == null) return;
+
+        const normalized_addr = normalizeObservedAddress(observed_addr);
+        var votes = switch (normalized_addr) {
+            .ip4 => &self.addr_votes_ip4,
+            .ip6 => &self.addr_votes_ip6,
+        };
+
+        const is_winning_vote = votes.addVote(normalizeObservedAddress(voter_addr), normalized_addr) catch return;
+        if (!is_winning_vote) return;
+
+        const current_addr = self.currentLocalAddressForFamily(switch (normalized_addr) {
+            .ip4 => Address.Family.ip4,
+            .ip6 => Address.Family.ip6,
+        }) orelse {
+            self.updateLocalEnrAddress(normalized_addr) catch return;
+            return;
+        };
+        if (current_addr.eql(&normalized_addr)) return;
+
+        self.updateLocalEnrAddress(normalized_addr) catch return;
+    }
+
+    fn currentLocalAddressForFamily(self: *Service, family: Address.Family) ?Address {
+        const local_enr = self.protocol.config.local_enr orelse return null;
+        const parsed = enr_mod.decode(local_enr) catch return null;
+
+        return switch (family) {
+            .ip4 => parsed.udpAddress4(),
+            .ip6 => parsed.udpAddress6(),
+        };
+    }
+
+    fn updateLocalEnrAddress(self: *Service, addr: Address) !void {
+        const current_enr = self.protocol.config.local_enr orelse return;
+        const parsed = try enr_mod.decode(current_enr);
+
+        const next_seq = @max(parsed.seq, self.protocol.config.local_enr_seq) + 1;
+        var builder = enr_mod.Builder.init(self.allocator, self.protocol.config.local_key_pair, next_seq);
+        builder.ip = parsed.ip;
+        builder.udp = parsed.udp;
+        builder.tcp = parsed.tcp;
+        builder.quic = parsed.quic;
+        builder.ip6 = parsed.ip6;
+        builder.udp6 = parsed.udp6;
+        builder.tcp6 = parsed.tcp6;
+        builder.quic6 = parsed.quic6;
+        builder.attnets = parsed.attnets;
+        builder.syncnets = parsed.syncnets;
+        builder.custody_group_count = parsed.custody_group_count;
+        builder.eth2 = parsed.eth2_raw;
+
+        switch (addr) {
+            .ip4 => |ip4| {
+                builder.ip = ip4.bytes;
+                builder.udp = ip4.port;
+            },
+            .ip6 => |ip6| {
+                builder.ip6 = ip6.bytes;
+                builder.udp6 = ip6.port;
+            },
+        }
+
+        const updated_enr = try builder.encode();
+        try self.commitLocalEnrBytes(updated_enr, next_seq, false);
+    }
+
+    fn pingConnectedPeers(self: *Service) void {
+        self.syncConnectedPeers();
+        const now_ns = currentTimestampNs(self.io);
+        var it = self.connected_peers.iterator();
+        while (it.next()) |entry| {
+            entry.value_ptr.next_ping_at_ns = now_ns;
+        }
+        self.pingDueConnectedPeers();
+    }
+
+    pub fn startLookup(self: *Service, target: *const NodeId) !u32 {
+        var closest: [MAX_LOOKUP_RESULTS]kbucket.Entry = undefined;
+        const found = self.protocol.routing_table.findClosest(target, MAX_LOOKUP_RESULTS, &closest);
+
+        var seeds: std.ArrayListUnmanaged(NodeId) = .empty;
+        defer seeds.deinit(self.allocator);
+        for (closest[0..found]) |entry| {
+            try seeds.append(self.allocator, entry.node_id);
+        }
+
+        const lookup_id = self.next_lookup_id;
+        self.next_lookup_id +%= 1;
+        if (self.next_lookup_id == 0) self.next_lookup_id = 1;
+
+        {
+            var lookup = try Lookup.init(self.allocator, target.*, seeds.items, currentTimestampNs(self.io), self.lookupConfig());
+            errdefer lookup.deinit(self.allocator);
+            try self.active_lookups.put(lookup_id, lookup);
+        }
+        self.lookup_count += 1;
+        scoped_log.debug("started lookup id={d} target={s} seeds={d}", .{
+            lookup_id,
+            &shortNodeId(target),
+            seeds.items.len,
+        });
+        self.pumpLookup(lookup_id);
+        if (self.active_lookups.getPtr(lookup_id)) |active| {
+            if (active.state == .finished) {
+                try self.finishLookup(lookup_id, false);
+            }
+        }
+        return lookup_id;
+    }
+
+    pub fn startRandomLookup(self: *Service) !u32 {
+        var target: NodeId = undefined;
+        self.io.random(&target);
+        scoped_log.debug("starting random lookup target={s}", .{&shortNodeId(&target)});
+        return self.startLookup(&target);
+    }
+
+    fn ingressWorkerMain(self: *Service, family: Address.Family) void {
+        var recv_buf: [protocol_mod.MAX_PACKET_SIZE]u8 = undefined;
+        while (!self.ingress_shutdown_requested.load(.acquire)) {
+            const socket = switch (family) {
+                .ip4 => if (self.socket_ip4) |*bound| bound else return,
+                .ip6 => if (self.socket_ip6) |*bound| bound else return,
+            };
+            const result = socket.receiveTimeout(self.io, &recv_buf, .{
+                .duration = .{
+                    .raw = Io.Duration.fromMilliseconds(@intCast(self.config.ingress_worker_timeout_ms)),
+                    .clock = .awake,
+                },
+            }) catch |err| switch (err) {
+                error.Timeout => continue,
+                else => {
+                    scoped_log.warn("discv5 ingress worker receive failed for {s}: {}", .{ @tagName(family), err });
+                    std.Io.sleep(self.io, std.Io.Duration.fromMilliseconds(10), .awake) catch {};
+                    continue;
+                },
+            };
+            _ = self.ingress_queue.enqueueReceived(result.from, result.data, currentUnixTimeMs(self.io));
+        }
+    }
+
+    fn pollSocketIngressBudgeted(self: *Service, max_packets: usize) usize {
+        if (max_packets == 0) return 0;
+
+        var recv_buf: [protocol_mod.MAX_PACKET_SIZE]u8 = undefined;
+        const first_family = self.next_socket_poll_family;
+        self.next_socket_poll_family = switch (self.next_socket_poll_family) {
+            .ip4 => .ip6,
+            .ip6 => .ip4,
+        };
+
+        var processed = self.pollSocketIngressFamily(first_family, max_packets, &recv_buf);
+        if (processed < max_packets) {
+            const second_family: Address.Family = switch (first_family) {
+                .ip4 => .ip6,
+                .ip6 => .ip4,
+            };
+            processed += self.pollSocketIngressFamily(second_family, max_packets - processed, &recv_buf);
+        }
+        return processed;
+    }
+
+    fn pollSocketIngressFamily(self: *Service, family: Address.Family, max_packets: usize, recv_buf: []u8) usize {
+        if (max_packets == 0) return 0;
+        const socket = switch (family) {
+            .ip4 => if (self.socket_ip4) |*bound| bound else return 0,
+            .ip6 => if (self.socket_ip6) |*bound| bound else return 0,
+        };
+
+        var processed: usize = 0;
+        while (processed < max_packets) {
+            const result = socket.receiveTimeout(self.io, recv_buf, .{
+                .duration = .{
+                    .raw = Io.Duration.fromMilliseconds(@intCast(self.receiveTimeoutPerSocketMs())),
+                    .clock = .awake,
+                },
+            }) catch |err| switch (err) {
+                error.Timeout => break,
+                else => break,
+            };
+
+            if (!self.ingress_queue.acceptReceived(result.from, currentUnixTimeMs(self.io))) continue;
+            self.dispatchPacket(result.from, result.data, socket);
+            processed += 1;
+        }
+        return processed;
+    }
+
+    fn drainProtocolEvents(self: *Service) void {
+        while (self.protocol.popEvent()) |protocol_event| {
+            switch (protocol_event) {
+                .pong => |pong| {
+                    self.removeExpectedResponse(pong.peer_id, pong.req_id, pong.peer_addr);
+                    self.maybeUpdateLocalEnrFromVote(pong.peer_addr, recipientAddress(pong.recipient_ip, pong.recipient_port));
+                    self.notePeerResponsive(pong.peer_id, pong.peer_addr);
+                    self.maybeRequestPeerEnrUpdate(pong.peer_id, pong.peer_addr, pong.enr_seq);
+                    self.emitEvent(.{ .pong = pong });
+                },
+                .nodes => |nodes| {
+                    self.removeExpectedResponse(nodes.peer_id, nodes.req_id, nodes.peer_addr);
+                    self.notePeerResponsive(nodes.peer_id, nodes.peer_addr);
+                    const lookup_id = self.lookupIdForNodes(&nodes);
+                    var discovered_enrs = self.collectDiscoveredEnrs(&nodes);
+                    defer discovered_enrs.deinit(self.allocator);
+                    self.emitDiscoveredEnrs(&nodes, discovered_enrs.items);
+                    self.handleLookupNodes(&nodes, lookup_id, discovered_enrs.items);
+                    self.emitEvent(.{ .nodes = nodes });
+                },
+                .talkreq => |talkreq| {
+                    self.notePeerResponsive(talkreq.peer_id, talkreq.peer_addr);
+                    self.emitEvent(.{ .talkreq = talkreq });
+                },
+                .talkresp => |talkresp| {
+                    self.removeExpectedResponse(talkresp.peer_id, talkresp.req_id, talkresp.peer_addr);
+                    self.notePeerResponsive(talkresp.peer_id, talkresp.peer_addr);
+                    self.emitEvent(.{ .talkresp = talkresp });
+                },
+                .request_timeout => |timeout| {
+                    self.removeExpectedResponse(timeout.peer_id, timeout.req_id, null);
+                    self.handleLookupTimeout(&timeout);
+                    self.handlePeerTimeout(&timeout);
+                    self.emitEvent(.{ .request_timeout = timeout });
+                },
+            }
+        }
+    }
+
+    fn lookupIdForNodes(self: *const Service, nodes: *const protocol_mod.NodesEvent) ?u32 {
+        return self.request_lookup_ids.get(LookupRequestKey.from(nodes.peer_id, nodes.req_id));
+    }
+
+    /// A decoded, validated discovered ENR plus its (already computed) node id, so
+    /// the lookup feed does not have to recompute `nodeId()` (secp + keccak) per ENR.
+    const DiscoveredEnr = struct {
+        raw: enr_mod.RawEnr,
+        enr: enr_mod.Enr,
+        node_id: NodeId,
+    };
+
+    fn collectDiscoveredEnrs(self: *Service, nodes: *const protocol_mod.NodesEvent) std.ArrayListUnmanaged(DiscoveredEnr) {
+        var discovered_enrs: std.ArrayListUnmanaged(DiscoveredEnr) = .empty;
+        for (nodes.enrs) |raw_enr| {
+            const parsed = enr_mod.decode(raw_enr) catch continue;
+
+            const node_id = parsed.nodeId() orelse continue;
+            if (std.mem.eql(u8, &node_id, &self.protocol.config.local_node_id)) continue;
+
+            if (parsed.udpAddress4() == null and parsed.udpAddress6() == null) continue;
+
+            const raw = enr_mod.RawEnr.init(raw_enr) catch continue;
+            discovered_enrs.append(self.allocator, .{ .raw = raw, .enr = parsed, .node_id = node_id }) catch continue;
+        }
+        return discovered_enrs;
+    }
+
+    fn emitDiscoveredEnrs(self: *Service, nodes: *const protocol_mod.NodesEvent, discovered_enrs: []const DiscoveredEnr) void {
+        scoped_log.debug("emitting {d} ENRs from {any}", .{
+            discovered_enrs.len,
+            nodes.peer_addr,
+        });
+        for (discovered_enrs) |discovered| {
+            self.emitEvent(.{ .discovered_enr = .{ .raw = discovered.raw, .enr = discovered.enr } });
+        }
+    }
+
+    fn handleLookupNodes(self: *Service, nodes: *const protocol_mod.NodesEvent, lookup_id: ?u32, discovered_enrs: []const DiscoveredEnr) void {
+        const actual_lookup_id = lookup_id orelse return;
+        const key = LookupRequestKey.from(nodes.peer_id, nodes.req_id);
+        const removed = self.request_lookup_ids.fetchRemove(key) orelse return;
+        if (removed.value != actual_lookup_id) return;
+        const lookup_id_value = removed.value;
+        const lookup = self.active_lookups.getPtr(lookup_id_value) orelse return;
+
+        var closer_peers: std.ArrayListUnmanaged(NodeId) = .empty;
+        defer closer_peers.deinit(self.allocator);
+        for (discovered_enrs) |discovered| {
+            closer_peers.append(self.allocator, discovered.node_id) catch continue;
+        }
+
+        scoped_log.debug("lookup id={d} received {d} candidate ENRs from node={s} addr={any}", .{
+            lookup_id_value,
+            closer_peers.items.len,
+            &shortNodeId(&nodes.peer_id),
+            nodes.peer_addr,
+        });
+        lookup.onSuccess(&nodes.peer_id, closer_peers.items, self.lookupConfig());
+        self.pumpLookup(lookup_id_value);
+        if (lookup.state == .finished) {
+            self.finishLookup(lookup_id_value, false) catch {};
+        }
+    }
+
+    fn handleLookupTimeout(self: *Service, timeout: *const protocol_mod.RequestTimeoutEvent) void {
+        if (timeout.kind != .findnode) return;
+
+        const key = LookupRequestKey.from(timeout.peer_id, timeout.req_id);
+        const removed = self.request_lookup_ids.fetchRemove(key) orelse return;
+        const lookup_id = removed.value;
+        const lookup = self.active_lookups.getPtr(lookup_id) orelse return;
+
+        scoped_log.debug("lookup id={d} request timed out for node={s}", .{
+            lookup_id,
+            &shortNodeId(&timeout.peer_id),
+        });
+        lookup.onFailure(&timeout.peer_id, self.lookupConfig());
+        self.pumpLookup(lookup_id);
+        if (lookup.state == .finished) {
+            self.finishLookup(lookup_id, false) catch {};
+        }
+    }
+
+    fn handlePeerTimeout(self: *Service, timeout: *const protocol_mod.RequestTimeoutEvent) void {
+        self.disconnectPeer(timeout.peer_id);
+    }
+
+    fn pruneTimedOutLookups(self: *Service) void {
+        const now_ns = currentTimestampNs(self.io);
+
+        var timed_out_ids: std.ArrayListUnmanaged(u32) = .empty;
+        defer timed_out_ids.deinit(self.allocator);
+
+        var it = self.active_lookups.iterator();
+        while (it.next()) |entry| {
+            if (!entry.value_ptr.isTimedOut(now_ns, self.lookupConfig())) continue;
+            timed_out_ids.append(self.allocator, entry.key_ptr.*) catch break;
+        }
+
+        for (timed_out_ids.items) |lookup_id| {
+            scoped_log.debug("lookup id={d} reached service timeout", .{lookup_id});
+            self.finishLookup(lookup_id, true) catch {};
+        }
+    }
+
+    fn pumpLookup(self: *Service, lookup_id: u32) void {
+        const lookup = self.active_lookups.getPtr(lookup_id) orelse return;
+
+        const lookup_config = self.lookupConfig();
+        while (lookup.nextPeer(lookup_config)) |peer_id| {
+            const known = self.protocol.getKnownNode(&peer_id) orelse {
+                scoped_log.debug("lookup id={d} missing known node={s}", .{ lookup_id, &shortNodeId(&peer_id) });
+                lookup.onFailure(&peer_id, lookup_config);
+                continue;
+            };
+
+            var distances: [127]u16 = undefined;
+            const count = lookup_mod.findNodeLogDistances(&lookup.target, &peer_id, @min(lookup_config.request_limit, distances.len), &distances);
+            if (count == 0) {
+                scoped_log.debug("lookup id={d} no useful distances for node={s}", .{ lookup_id, &shortNodeId(&peer_id) });
+                lookup.onFailure(&peer_id, lookup_config);
+                continue;
+            }
+
+            const req_id = self.protocol.sendFindNode(
+                &known.node_id,
+                &known.pubkey,
+                known.addr,
+                distances[0..count],
+                self.socketForAddress(known.addr) orelse {
+                    scoped_log.debug("lookup id={d} no socket for node={s} addr={any}", .{
+                        lookup_id,
+                        &shortNodeId(&peer_id),
+                        known.addr,
+                    });
+                    lookup.onFailure(&peer_id, lookup_config);
+                    continue;
+                },
+            ) catch {
+                scoped_log.debug("lookup id={d} failed to send FINDNODE to node={s} addr={any}", .{
+                    lookup_id,
+                    &shortNodeId(&peer_id),
+                    known.addr,
+                });
+                lookup.onFailure(&peer_id, lookup_config);
+                continue;
+            };
+            scoped_log.debug("lookup id={d} sent FINDNODE req_id={x} to node={s} addr={any} distances={d}", .{
+                lookup_id,
+                req_id.slice(),
+                &shortNodeId(&peer_id),
+                known.addr,
+                count,
+            });
+            self.request_lookup_ids.put(LookupRequestKey.from(peer_id, req_id), lookup_id) catch {
+                scoped_log.debug("lookup id={d} failed to track FINDNODE req_id={x} for node={s}", .{
+                    lookup_id,
+                    req_id.slice(),
+                    &shortNodeId(&peer_id),
+                });
+                lookup.onFailure(&peer_id, lookup_config);
+                continue;
+            };
+            self.noteExpectedResponse(peer_id, req_id, known.addr);
+        }
+    }
+
+    fn finishLookup(self: *Service, lookup_id: u32, timed_out: bool) !void {
+        const removed = self.active_lookups.fetchRemove(lookup_id) orelse return;
+        var lookup = removed.value;
+        defer lookup.deinit(self.allocator);
+
+        var stale_requests: std.ArrayListUnmanaged(LookupRequestKey) = .empty;
+        defer stale_requests.deinit(self.allocator);
+        var request_it = self.request_lookup_ids.iterator();
+        while (request_it.next()) |entry| {
+            if (entry.value_ptr.* != lookup_id) continue;
+            try stale_requests.append(self.allocator, entry.key_ptr.*);
+        }
+        for (stale_requests.items) |request_key| {
+            _ = self.request_lookup_ids.remove(request_key);
+        }
+
+        var enrs: std.ArrayListUnmanaged([]u8) = .empty;
+        defer {
+            for (enrs.items) |enr| self.allocator.free(enr);
+            enrs.deinit(self.allocator);
+        }
+
+        var succeeded: usize = 0;
+        for (lookup.peers.items) |peer| {
+            if (peer.state != .succeeded) continue;
+            if (succeeded >= self.config.lookup_num_results) break;
+
+            const enr_bytes = self.findEnr(&peer.node_id) orelse continue;
+            try enrs.append(self.allocator, try self.allocator.dupe(u8, enr_bytes));
+            succeeded += 1;
+        }
+
+        const owned_enrs = try enrs.toOwnedSlice(self.allocator);
+        enrs = .empty;
+
+        scoped_log.debug("finished lookup id={d} target={s} succeeded={d} enrs={d} timed_out={}", .{
+            lookup_id,
+            &shortNodeId(&lookup.target),
+            succeeded,
+            owned_enrs.len,
+            timed_out,
+        });
+        self.emitEvent(.{
+            .lookup_finished = .{
+                .lookup_id = lookup_id,
+                .target = lookup.target,
+                .enrs = owned_enrs,
+                .timed_out = timed_out,
+            },
+        });
+    }
+
+    fn syncConnectedPeers(self: *Service) void {
+        const now_ns = currentTimestampNs(self.io);
+
+        var stale_peers: std.ArrayListUnmanaged(NodeId) = .empty;
+        defer stale_peers.deinit(self.allocator);
+
+        var tracked_it = self.connected_peers.iterator();
+        while (tracked_it.next()) |entry| {
+            const routing_entry = self.routingEntry(&entry.key_ptr.*) orelse {
+                stale_peers.append(self.allocator, entry.key_ptr.*) catch continue;
+                continue;
+            };
+            if (routing_entry.status != .connected) {
+                stale_peers.append(self.allocator, entry.key_ptr.*) catch continue;
+                continue;
+            }
+            entry.value_ptr.addr = routing_entry.addr;
+        }
+
+        for (stale_peers.items) |peer_id| {
+            const removed = self.connected_peers.fetchRemove(peer_id) orelse continue;
+            self.emitEvent(.{
+                .peer_disconnected = .{
+                    .peer_id = removed.key,
+                    .peer_addr = removed.value.addr,
+                },
+            });
+        }
+
+        for (self.protocol.routing_table.buckets) |*bucket| {
+            for (bucket.entries[0..bucket.count]) |entry| {
+                if (entry.status != .connected) continue;
+                if (self.connected_peers.getPtr(entry.node_id)) |tracked| {
+                    tracked.addr = entry.addr;
+                    continue;
+                }
+                self.connected_peers.put(entry.node_id, .{
+                    .addr = entry.addr,
+                    .next_ping_at_ns = now_ns,
+                }) catch continue;
+                self.emitEvent(.{
+                    .peer_connected = .{
+                        .peer_id = entry.node_id,
+                        .peer_addr = entry.addr,
+                    },
+                });
+            }
+        }
+    }
+
+    fn pingDueConnectedPeers(self: *Service) void {
+        if (self.config.ping_interval_ms == 0) return;
+        const now_ns = currentTimestampNs(self.io);
+        const interval_ns: i64 = @intCast(@as(i128, self.config.ping_interval_ms) * std.time.ns_per_ms);
+
+        var it = self.connected_peers.iterator();
+        while (it.next()) |entry| {
+            if (entry.value_ptr.awaiting_ping_response) continue;
+            if (entry.value_ptr.next_ping_at_ns > now_ns) continue;
+
+            const peer = self.protocol.getKnownNode(&entry.key_ptr.*) orelse {
+                entry.value_ptr.next_ping_at_ns = now_ns + interval_ns;
+                continue;
+            };
+
+            _ = self.protocol.sendPing(
+                &peer.node_id,
+                &peer.pubkey,
+                peer.addr,
+                self.protocol.config.local_enr_seq,
+                self.socketForAddress(peer.addr) orelse {
+                    entry.value_ptr.next_ping_at_ns = now_ns + interval_ns;
+                    continue;
+                },
+            ) catch {
+                entry.value_ptr.next_ping_at_ns = now_ns + interval_ns;
+                continue;
+            };
+            entry.value_ptr.addr = peer.addr;
+            entry.value_ptr.awaiting_ping_response = true;
+            entry.value_ptr.next_ping_at_ns = now_ns + interval_ns;
+        }
+    }
+
+    fn notePeerResponsive(self: *Service, peer_id: NodeId, peer_addr: Address) void {
+        if (self.connected_peers.getPtr(peer_id)) |tracked| {
+            tracked.addr = peer_addr;
+            tracked.awaiting_ping_response = false;
+            tracked.next_ping_at_ns = currentTimestampNs(self.io) +
+                @as(i64, @intCast(@as(i128, self.config.ping_interval_ms) * std.time.ns_per_ms));
+        }
+    }
+
+    fn maybeRequestPeerEnrUpdate(self: *Service, peer_id: NodeId, peer_addr: Address, advertised_seq: u64) void {
+        const current_enr = self.findEnr(&peer_id) orelse return;
+        const parsed = enr_mod.decode(current_enr) catch return;
+        if (parsed.seq >= advertised_seq) return;
+        if (self.protocol.hasActiveFindNodeRequest(&peer_id)) return;
+
+        const known = self.protocol.getKnownNode(&peer_id) orelse return;
+        const distances = [_]u16{0};
+        const req_id = self.protocol.sendFindNode(
+            &known.node_id,
+            &known.pubkey,
+            peer_addr,
+            &distances,
+            self.socketForAddress(peer_addr) orelse return,
+        ) catch return;
+        self.noteExpectedResponse(peer_id, req_id, peer_addr);
+    }
+
+    fn routingEntry(self: *const Service, node_id: *const NodeId) ?kbucket.Entry {
+        const entry = self.protocol.routing_table.getEntry(node_id) orelse return null;
+        return entry.*;
+    }
+
+    fn disconnectPeer(self: *Service, peer_id: NodeId) void {
+        const addr = if (self.connected_peers.get(peer_id)) |tracked|
+            tracked.addr
+        else if (self.protocol.getKnownNode(&peer_id)) |known|
+            known.addr
+        else
+            return;
+
+        if (self.protocol.routing_table.getEntryWithPending(&peer_id)) |existing| {
+            var entry = existing.*;
+            entry.addr = addr;
+            entry.last_seen = currentTimestampNs(self.io);
+            entry.status = .disconnected;
+            _ = self.protocol.routing_table.insert(entry);
+        }
+
+        const removed = self.connected_peers.fetchRemove(peer_id) orelse return;
+        self.emitEvent(.{
+            .peer_disconnected = .{
+                .peer_id = removed.key,
+                .peer_addr = removed.value.addr,
+            },
+        });
+    }
+
+    fn commitLocalEnrBytes(self: *Service, updated_enr: []u8, next_seq: u64, clear_votes: bool) !void {
+        errdefer self.allocator.free(updated_enr);
+
+        // Do all fallible work before mutating any state, so a failure here
+        // leaves the current local ENR intact and `updated_enr` reclaimed by the
+        // errdefer above — never a half-applied update or a freed-but-referenced
+        // ENR.
+        const event_enr = try self.allocator.dupe(u8, updated_enr);
+        errdefer self.allocator.free(event_enr);
+        try self.event_queue.push(self.allocator, .{
+            .local_enr_updated = .{
+                .seq = next_seq,
+                .enr = event_enr,
+            },
+        });
+
+        // From here on nothing can fail: take ownership of `updated_enr` and
+        // publish it as the single source of truth for the local ENR. The
+        // protocol reads these fields when deciding whether to attach our ENR to
+        // handshakes; the service's own `config` snapshot is not consulted at
+        // runtime, so it is intentionally not updated here.
+        if (clear_votes) {
+            self.addr_votes_ip4.clear();
+            self.addr_votes_ip6.clear();
+        }
+        if (self.owned_local_enr) |owned| self.allocator.free(owned);
+        self.owned_local_enr = updated_enr;
+        self.protocol.config.local_enr = updated_enr;
+        self.protocol.config.local_enr_seq = next_seq;
+
+        self.pingConnectedPeers();
+    }
+
+    pub fn socketForFamily(self: *Service, family: Address.Family) ?*net.Socket {
+        return switch (family) {
+            .ip4 => if (self.socket_ip4) |*socket| socket else null,
+            .ip6 => if (self.socket_ip6) |*socket| socket else null,
+        };
+    }
+
+    fn socketForAddress(self: *Service, addr: Address) ?*net.Socket {
+        return switch (addr) {
+            .ip4 => if (self.socket_ip4) |*socket| socket else null,
+            .ip6 => if (self.socket_ip6) |*socket| socket else null,
+        };
+    }
+
+    fn socketCount(self: *const Service) usize {
+        var total: usize = 0;
+        if (self.socket_ip4 != null) total += 1;
+        if (self.socket_ip6 != null) total += 1;
+        return total;
+    }
+
+    fn receiveTimeoutPerSocketMs(self: *const Service) u64 {
+        if (self.config.receive_timeout_ms == 0) return 0;
+        const count = self.socketCount();
+        if (count <= 1) return self.config.receive_timeout_ms;
+        return @max(self.config.receive_timeout_ms / count, 1);
+    }
+
+    fn contactAddressFromParsedEnr(self: *const Service, parsed: *const enr_mod.Enr) ?Address {
+        const addr_ip4 = parsed.udpAddress4();
+        const addr_ip6 = parsed.udpAddress6();
+
+        if (self.socket_ip4 != null and self.socket_ip6 == null) return addr_ip4 orelse addr_ip6;
+        if (self.socket_ip6 != null and self.socket_ip4 == null) return addr_ip6 orelse addr_ip4;
+        return addr_ip4 orelse addr_ip6;
+    }
+};
+
+fn normalizeObservedAddress(addr: Address) Address {
+    return switch (addr) {
+        .ip4 => addr,
+        .ip6 => |ip6| Address.fromIp6(ip6),
+    };
+}
+
+fn recipientAddress(recipient_ip: messages.Pong.RecipientIp, port: u16) Address {
+    return switch (recipient_ip) {
+        .ip4 => |ip4| .{ .ip4 = .{ .bytes = ip4, .port = port } },
+        .ip6 => |ip6| .{ .ip6 = .{ .bytes = ip6, .port = port } },
+    };
+}
+
+const TestService = struct {
+    service: Service,
+    pubkey: [33]u8,
+    node_id: NodeId,
+
+    fn init(alloc: Allocator, io: Io, secret_key: [32]u8) !TestService {
+        const key_pair = try secp.keyPairFromSecret(&secret_key);
+        const pubkey = secp.compressedPubkey(&key_pair);
+        const node_id = enr_mod.nodeIdFromCompressedPubkey(&pubkey);
+
+        var service = try Service.init(io, alloc, .{
+            .bind_addresses = .{ .ip4 = .{ .ip4 = .{ .bytes = .{ 127, 0, 0, 1 }, .port = 0 } } },
+            .protocol_config = .{
+                .local_key_pair = key_pair,
+                .local_node_id = node_id,
+            },
+            .lookup_timeout_ms = 2_000,
+        });
+        errdefer service.deinit();
+
+        var builder = enr_mod.Builder.init(alloc, key_pair, 1);
+        builder.ip = .{ 127, 0, 0, 1 };
+        builder.udp = service.boundPort(.ip4) orelse return error.MissingBindAddress;
+        const local_enr = try builder.encode();
+        defer alloc.free(local_enr);
+        try service.setLocalEnr(local_enr);
+
+        return .{
+            .service = service,
+            .pubkey = pubkey,
+            .node_id = node_id,
+        };
+    }
+
+    fn deinit(self: *TestService) void {
+        self.service.deinit();
+    }
+
+    fn addr(self: *const TestService) Address {
+        return self.service.boundAddress(.ip4) orelse unreachable;
+    }
+
+    fn enr(self: *const TestService) []const u8 {
+        return self.service.localEnr() orelse unreachable;
+    }
+
+    fn addKnownEnr(self: *TestService, other: *const TestService) !void {
+        try std.testing.expect(self.service.addEnr(other.enr()));
+    }
+};
+
+fn pollServices(services: []const *Service) void {
+    for (services) |service| {
+        service.poll();
+    }
+}
+
+fn initServiceForAllocationFailureTest(allocator: Allocator) !void {
+    const io = std.Options.debug_io;
+    const hex = @import("hex");
+    const secret_key = hex.hexToBytesComptime(32, "eef77acb6c6a6eebc5b363a475ac583ec7eccdb42b6481424c60f59aa326547f");
+    const key_pair = try secp.keyPairFromSecret(&secret_key);
+    const pubkey = secp.compressedPubkey(&key_pair);
+    const node_id = enr_mod.nodeIdFromCompressedPubkey(&pubkey);
+
+    var service = try Service.init(io, allocator, .{
+        .bind_addresses = .{ .ip4 = .{ .ip4 = .{ .bytes = .{ 127, 0, 0, 1 }, .port = 0 } } },
+        .protocol_config = .{
+            .local_key_pair = key_pair,
+            .local_node_id = node_id,
+            .local_enr = "local-enr",
+            .local_enr_seq = 1,
+            .session_cache_capacity = 2,
+            .challenge_cache_capacity = 2,
+            .whoareyou_rate_capacity = 2,
+        },
+        .ingress_queue_capacity = 2,
+        .rate_limiter = null,
+    });
+    defer service.deinit();
+}
+
+test "service init cleans up every allocation failure" {
+    try std.testing.checkAllAllocationFailures(std.testing.allocator, initServiceForAllocationFailureTest, .{});
+}
+
+test "service init validates bind addresses before copying local ENR" {
+    const io = std.Options.debug_io;
+    const hex = @import("hex");
+    const secret_key = hex.hexToBytesComptime(32, "eef77acb6c6a6eebc5b363a475ac583ec7eccdb42b6481424c60f59aa326547f");
+    const key_pair = try secp.keyPairFromSecret(&secret_key);
+    const pubkey = secp.compressedPubkey(&key_pair);
+    const node_id = enr_mod.nodeIdFromCompressedPubkey(&pubkey);
+    const protocol_config = protocol_mod.Config{
+        .local_key_pair = key_pair,
+        .local_node_id = node_id,
+        .local_enr = "local-enr",
+        .local_enr_seq = 1,
+    };
+
+    try std.testing.expectError(error.NoBindAddresses, Service.init(io, std.testing.allocator, .{
+        .bind_addresses = .{},
+        .protocol_config = protocol_config,
+    }));
+    try std.testing.expectError(error.InvalidBindAddressFamily, Service.init(io, std.testing.allocator, .{
+        .bind_addresses = .{ .ip4 = .{ .ip6 = .{ .bytes = [_]u8{0} ** 16, .port = 0 } } },
+        .protocol_config = protocol_config,
+    }));
+}
+
+test "lookup emits lookup_finished" {
+    const alloc = std.testing.allocator;
+    const io = std.Options.debug_io;
+    const hex = @import("hex");
+
+    const sk_a = hex.hexToBytesComptime(32, "eef77acb6c6a6eebc5b363a475ac583ec7eccdb42b6481424c60f59aa326547f");
+    const key_pair_a = try secp.keyPairFromSecret(&sk_a);
+    const pk_a = secp.compressedPubkey(&key_pair_a);
+    const node_id_a = enr_mod.nodeIdFromCompressedPubkey(&pk_a);
+
+    const sk_b = hex.hexToBytesComptime(32, "66fb62bfbd66b9177a138c1e5cddbe4f7c30c343e94e68df8769459cb14571f7");
+    const key_pair_b = try secp.keyPairFromSecret(&sk_b);
+    const pk_b = secp.compressedPubkey(&key_pair_b);
+    const node_id_b = enr_mod.nodeIdFromCompressedPubkey(&pk_b);
+
+    const sk_c = hex.hexToBytesComptime(32, "7e8107fe766b7f1821c3a7fbc56d18f734f0ebf898f0b85f82412b6d1fa7f4d3");
+    const key_pair_c = try secp.keyPairFromSecret(&sk_c);
+    const pk_c = secp.compressedPubkey(&key_pair_c);
+    const node_id_c = enr_mod.nodeIdFromCompressedPubkey(&pk_c);
+
+    var service_a = try Service.init(io, alloc, .{
+        .bind_addresses = .{ .ip4 = .{ .ip4 = .{ .bytes = .{ 127, 0, 0, 1 }, .port = 0 } } },
+        .protocol_config = .{
+            .local_key_pair = key_pair_a,
+            .local_node_id = node_id_a,
+            .request_retries = 0,
+        },
+        .lookup_timeout_ms = 1_000,
+    });
+    defer service_a.deinit();
+
+    var socket_b = try bindDatagramSocket(io, .{ .ip4 = .{ .bytes = .{ 127, 0, 0, 1 }, .port = 0 } });
+    defer socket_b.close(io);
+
+    const addr_b = socket_b.address;
+    const addr_c = Address{ .ip4 = .{ .bytes = .{ 127, 0, 0, 1 }, .port = 30305 } };
+
+    var a_builder = enr_mod.Builder.init(alloc, key_pair_a, 1);
+    a_builder.ip = .{ 127, 0, 0, 1 };
+    const addr_a = service_a.boundAddress(.ip4) orelse return error.MissingBindAddress;
+    a_builder.udp = addr_a.getPort();
+    const a_enr = try a_builder.encode();
+    defer alloc.free(a_enr);
+    service_a.protocol.config.local_enr = a_enr;
+    service_a.protocol.config.local_enr_seq = 1;
+
+    var b_builder = enr_mod.Builder.init(alloc, key_pair_b, 1);
+    b_builder.ip = .{ 127, 0, 0, 1 };
+    b_builder.udp = addr_b.getPort();
+    const b_enr = try b_builder.encode();
+    defer alloc.free(b_enr);
+
+    var c_builder = enr_mod.Builder.init(alloc, key_pair_c, 1);
+    c_builder.ip = .{ 127, 0, 0, 1 };
+    c_builder.udp = addr_c.getPort();
+    const c_enr = try c_builder.encode();
+    defer alloc.free(c_enr);
+
+    var proto_b = try Protocol.init(io, alloc, .{
+        .local_key_pair = key_pair_b,
+        .local_node_id = node_id_b,
+        .local_enr = b_enr,
+        .local_enr_seq = 1,
+    });
+    defer proto_b.deinit();
+
+    service_a.addNode(node_id_b, &pk_b, addr_b, b_enr);
+    proto_b.addNode(node_id_a, &pk_a, addr_a, a_enr);
+    proto_b.addNode(node_id_c, &pk_c, addr_c, c_enr);
+
+    _ = try service_a.startLookup(&node_id_c);
+
+    var recv_buf_a: [protocol_mod.MAX_PACKET_SIZE]u8 = undefined;
+    var recv_buf_b: [protocol_mod.MAX_PACKET_SIZE]u8 = undefined;
+
+    const inbound_a = try socket_b.receiveTimeout(io, &recv_buf_b, .{
+        .duration = .{
+            .raw = Io.Duration.fromMilliseconds(250),
+            .clock = .awake,
+        },
+    });
+    try proto_b.handlePacket(inbound_a.data, inbound_a.from, &socket_b);
+
+    service_a.poll();
+
+    const handshake = try socket_b.receiveTimeout(io, &recv_buf_b, .{
+        .duration = .{
+            .raw = Io.Duration.fromMilliseconds(250),
+            .clock = .awake,
+        },
+    });
+    try proto_b.handlePacket(handshake.data, handshake.from, &socket_b);
+
+    const socket_a = service_a.socketForAddress(addr_a) orelse return error.MissingBindAddress;
+    const nodes_packet = try socket_a.receiveTimeout(io, &recv_buf_a, .{
+        .duration = .{
+            .raw = Io.Duration.fromMilliseconds(250),
+            .clock = .awake,
+        },
+    });
+    try service_a.protocol.handlePacket(nodes_packet.data, nodes_packet.from, socket_a);
+    service_a.poll();
+
+    var saw_lookup_finished = false;
+    var saw_discovered_c = false;
+    while (service_a.popEvent()) |event| {
+        var owned = event;
+        defer owned.deinit(alloc);
+
+        switch (owned) {
+            .discovered_enr => |discovered| {
+                const discovered_node_id = discovered.enr.nodeId() orelse continue;
+                if (std.mem.eql(u8, &discovered_node_id, &node_id_c)) {
+                    saw_discovered_c = true;
+                }
+            },
+            .lookup_finished => |lookup_finished| {
+                saw_lookup_finished = true;
+                try std.testing.expect(!lookup_finished.timed_out);
+
+                var saw_b = false;
+                for (lookup_finished.enrs) |raw_enr| {
+                    const parsed = try enr_mod.decode(raw_enr);
+                    const node_id = parsed.nodeId() orelse continue;
+                    if (std.mem.eql(u8, &node_id, &node_id_b)) saw_b = true;
+                }
+                try std.testing.expect(saw_b);
+            },
+            else => {},
+        }
+    }
+
+    service_a.protocol.requests.forceAllActiveStartedAtForTest(0);
+    service_a.poll();
+
+    while (service_a.popEvent()) |event| {
+        var owned = event;
+        defer owned.deinit(alloc);
+
+        switch (owned) {
+            .discovered_enr => |discovered| {
+                const discovered_node_id = discovered.enr.nodeId() orelse continue;
+                if (std.mem.eql(u8, &discovered_node_id, &node_id_c)) {
+                    saw_discovered_c = true;
+                }
+            },
+            .lookup_finished => |lookup_finished| {
+                saw_lookup_finished = true;
+                try std.testing.expect(!lookup_finished.timed_out);
+
+                var saw_b = false;
+                for (lookup_finished.enrs) |raw_enr| {
+                    const parsed = try enr_mod.decode(raw_enr);
+                    const node_id = parsed.nodeId() orelse continue;
+                    if (std.mem.eql(u8, &node_id, &node_id_b)) saw_b = true;
+                }
+                try std.testing.expect(saw_b);
+            },
+            else => {},
+        }
+    }
+
+    const known_c = service_a.findEnr(&node_id_c) orelse return error.MissingDiscoveredEnr;
+    try std.testing.expectEqualSlices(u8, c_enr, known_c);
+    try std.testing.expect(saw_discovered_c);
+    try std.testing.expect(saw_lookup_finished);
+}
+
+test "connected peers are pinged and disconnected on timeout" {
+    const alloc = std.testing.allocator;
+    const io = std.Options.debug_io;
+    const hex = @import("hex");
+
+    const sk_a = hex.hexToBytesComptime(32, "eef77acb6c6a6eebc5b363a475ac583ec7eccdb42b6481424c60f59aa326547f");
+    const key_pair_a = try secp.keyPairFromSecret(&sk_a);
+    const pk_a = secp.compressedPubkey(&key_pair_a);
+    const node_id_a = enr_mod.nodeIdFromCompressedPubkey(&pk_a);
+
+    const sk_b = hex.hexToBytesComptime(32, "66fb62bfbd66b9177a138c1e5cddbe4f7c30c343e94e68df8769459cb14571f7");
+    const key_pair_b = try secp.keyPairFromSecret(&sk_b);
+    const pk_b = secp.compressedPubkey(&key_pair_b);
+    const node_id_b = enr_mod.nodeIdFromCompressedPubkey(&pk_b);
+
+    var service_a = try Service.init(io, alloc, .{
+        .bind_addresses = .{ .ip4 = .{ .ip4 = .{ .bytes = .{ 127, 0, 0, 1 }, .port = 0 } } },
+        .protocol_config = .{
+            .local_key_pair = key_pair_a,
+            .local_node_id = node_id_a,
+            .request_timeout_ms = 1_000,
+            .request_retries = 0,
+        },
+        .ping_interval_ms = 30_000,
+    });
+    defer service_a.deinit();
+
+    var socket_b = try bindDatagramSocket(io, .{ .ip4 = .{ .bytes = .{ 127, 0, 0, 1 }, .port = 0 } });
+    defer socket_b.close(io);
+
+    const addr_b = socket_b.address;
+
+    var a_builder = enr_mod.Builder.init(alloc, key_pair_a, 1);
+    a_builder.ip = .{ 127, 0, 0, 1 };
+    const addr_a = service_a.boundAddress(.ip4) orelse return error.MissingBindAddress;
+    a_builder.udp = addr_a.getPort();
+    const a_enr = try a_builder.encode();
+    defer alloc.free(a_enr);
+    try service_a.setLocalEnr(a_enr);
+
+    var b_builder = enr_mod.Builder.init(alloc, key_pair_b, 1);
+    b_builder.ip = .{ 127, 0, 0, 1 };
+    b_builder.udp = addr_b.getPort();
+    const b_enr = try b_builder.encode();
+    defer alloc.free(b_enr);
+
+    var proto_b = try Protocol.init(io, alloc, .{
+        .local_key_pair = key_pair_b,
+        .local_node_id = node_id_b,
+        .local_enr = b_enr,
+        .local_enr_seq = 1,
+    });
+    defer proto_b.deinit();
+
+    service_a.addNode(node_id_b, &pk_b, addr_b, b_enr);
+    proto_b.addNode(node_id_a, &pk_a, addr_a, a_enr);
+
+    _ = try service_a.sendPing(&node_id_b, &pk_b, addr_b, service_a.localEnrSeq());
+
+    var recv_buf_a: [protocol_mod.MAX_PACKET_SIZE]u8 = undefined;
+    var recv_buf_b: [protocol_mod.MAX_PACKET_SIZE]u8 = undefined;
+
+    const inbound_a = try socket_b.receiveTimeout(io, &recv_buf_b, .{
+        .duration = .{
+            .raw = Io.Duration.fromMilliseconds(250),
+            .clock = .awake,
+        },
+    });
+    try proto_b.handlePacket(inbound_a.data, inbound_a.from, &socket_b);
+    service_a.poll();
+
+    const handshake = try socket_b.receiveTimeout(io, &recv_buf_b, .{
+        .duration = .{
+            .raw = Io.Duration.fromMilliseconds(250),
+            .clock = .awake,
+        },
+    });
+    try proto_b.handlePacket(handshake.data, handshake.from, &socket_b);
+
+    const socket_a = service_a.socketForAddress(addr_a) orelse return error.MissingBindAddress;
+    const pong_packet = try socket_a.receiveTimeout(io, &recv_buf_a, .{
+        .duration = .{
+            .raw = Io.Duration.fromMilliseconds(250),
+            .clock = .awake,
+        },
+    });
+    try service_a.protocol.handlePacket(pong_packet.data, pong_packet.from, socket_a);
+    service_a.poll();
+
+    try std.testing.expectEqual(@as(usize, 1), service_a.connectedPeerCount());
+
+    var saw_connected = false;
+    while (service_a.popEvent()) |event| {
+        var owned = event;
+        defer owned.deinit(alloc);
+
+        switch (owned) {
+            .peer_connected => |connected| {
+                saw_connected = true;
+                try std.testing.expectEqual(node_id_b, connected.peer_id);
+                try std.testing.expectEqual(addr_b, connected.peer_addr);
+            },
+            else => {},
+        }
+    }
+    try std.testing.expect(saw_connected);
+
+    try std.testing.expect(service_a.protocol.requests.activeCount() > 0);
+    service_a.protocol.requests.forceAllActiveStartedAtForTest(0);
+
+    service_a.poll();
+
+    try std.testing.expectEqual(@as(usize, 0), service_a.connectedPeerCount());
+
+    var saw_timeout = false;
+    var saw_disconnected = false;
+    while (service_a.popEvent()) |event| {
+        var owned = event;
+        defer owned.deinit(alloc);
+
+        switch (owned) {
+            .request_timeout => |timeout| {
+                if (std.mem.eql(u8, &timeout.peer_id, &node_id_b)) {
+                    saw_timeout = true;
+                    try std.testing.expectEqual(protocol_mod.RequestKind.ping, timeout.kind);
+                }
+            },
+            .peer_disconnected => |disconnected| {
+                saw_disconnected = true;
+                try std.testing.expectEqual(node_id_b, disconnected.peer_id);
+                try std.testing.expectEqual(addr_b, disconnected.peer_addr);
+            },
+            else => {},
+        }
+    }
+
+    try std.testing.expect(saw_timeout);
+    try std.testing.expect(saw_disconnected);
+}
+
+test "setLocalEnr exposes current local ENR" {
+    const alloc = std.testing.allocator;
+    const io = std.Options.debug_io;
+    const hex = @import("hex");
+
+    const sk = hex.hexToBytesComptime(32, "eef77acb6c6a6eebc5b363a475ac583ec7eccdb42b6481424c60f59aa326547f");
+    const key_pair = try secp.keyPairFromSecret(&sk);
+    const pk = secp.compressedPubkey(&key_pair);
+    const node_id = enr_mod.nodeIdFromCompressedPubkey(&pk);
+
+    var builder = enr_mod.Builder.init(alloc, key_pair, 1);
+    builder.ip = .{ 10, 0, 0, 1 };
+    builder.udp = 9000;
+    builder.tcp = 9000;
+    const local_enr = try builder.encode();
+    defer alloc.free(local_enr);
+
+    var service = try Service.init(io, alloc, .{
+        .bind_addresses = .{ .ip4 = .{ .ip4 = .{ .bytes = .{ 127, 0, 0, 1 }, .port = 0 } } },
+        .protocol_config = .{
+            .local_key_pair = key_pair,
+            .local_node_id = node_id,
+            .local_enr = local_enr,
+            .local_enr_seq = 1,
+        },
+    });
+    defer service.deinit();
+
+    try std.testing.expectEqualSlices(u8, local_enr, service.localEnr().?);
+
+    var updated_builder = enr_mod.Builder.init(alloc, key_pair, 2);
+    updated_builder.ip = .{ 203, 0, 113, 9 };
+    updated_builder.udp = 30303;
+    updated_builder.tcp = 9000;
+    updated_builder.ip6 = [_]u8{0} ** 16;
+    updated_builder.udp6 = 9001;
+    const updated_enr = try updated_builder.encode();
+    defer alloc.free(updated_enr);
+
+    try service.setLocalEnr(updated_enr);
+    try std.testing.expectEqualSlices(u8, updated_enr, service.localEnr().?);
+    try std.testing.expectEqual(@as(u64, 2), service.localEnrSeq());
+
+    const local_enr_copy = (try service.dupeLocalEnr(alloc)) orelse return error.MissingLocalEnr;
+    defer alloc.free(local_enr_copy);
+    try std.testing.expectEqualSlices(u8, updated_enr, local_enr_copy);
+
+    var stale_builder = enr_mod.Builder.init(alloc, key_pair, 2);
+    stale_builder.ip = .{ 198, 51, 100, 2 };
+    stale_builder.udp = 40404;
+    const stale_enr = try stale_builder.encode();
+    defer alloc.free(stale_enr);
+    try std.testing.expectError(error.StaleEnrSeq, service.setLocalEnr(stale_enr));
+
+    const other_sk = hex.hexToBytesComptime(32, "66fb62bfbd66b9177a138c1e5cddbe4f7c30c343e94e68df8769459cb14571f7");
+    const other_key_pair = try secp.keyPairFromSecret(&other_sk);
+    var foreign_builder = enr_mod.Builder.init(alloc, other_key_pair, 3);
+    foreign_builder.ip = .{ 192, 0, 2, 10 };
+    foreign_builder.udp = 50505;
+    const foreign_enr = try foreign_builder.encode();
+    defer alloc.free(foreign_enr);
+    try std.testing.expectError(error.WrongNodeId, service.setLocalEnr(foreign_enr));
+
+    var saw_update_event = false;
+    while (service.popEvent()) |event| {
+        var owned = event;
+        defer owned.deinit(alloc);
+        if (owned == .local_enr_updated) {
+            saw_update_event = true;
+            try std.testing.expectEqual(@as(u64, 2), owned.local_enr_updated.seq);
+            try std.testing.expectEqualSlices(u8, updated_enr, owned.local_enr_updated.enr);
+        }
+    }
+    try std.testing.expect(saw_update_event);
+}
+
+test "dual bind exposes both listener families" {
+    const alloc = std.testing.allocator;
+    const io = std.Options.debug_io;
+    const hex = @import("hex");
+
+    const sk = hex.hexToBytesComptime(32, "eef77acb6c6a6eebc5b363a475ac583ec7eccdb42b6481424c60f59aa326547f");
+    const key_pair = try secp.keyPairFromSecret(&sk);
+    const pk = secp.compressedPubkey(&key_pair);
+    const node_id = enr_mod.nodeIdFromCompressedPubkey(&pk);
+
+    var service = try Service.init(io, alloc, .{
+        .bind_addresses = .{
+            .ip4 = .{ .ip4 = .{ .bytes = .{ 127, 0, 0, 1 }, .port = 0 } },
+            .ip6 = .{ .ip6 = .{ .bytes = .{ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1 }, .port = 0 } },
+        },
+        .protocol_config = .{
+            .local_key_pair = key_pair,
+            .local_node_id = node_id,
+        },
+    });
+    defer service.deinit();
+
+    try std.testing.expect(service.boundPort(.ip4) != null);
+    try std.testing.expect(service.boundPort(.ip6) != null);
+    try std.testing.expect(service.boundAddress(.ip4) != null);
+    try std.testing.expect(service.boundAddress(.ip6) != null);
+}
+
+test "addEnr prefers available bind family" {
+    const alloc = std.testing.allocator;
+    const io = std.Options.debug_io;
+    const hex = @import("hex");
+
+    const sk_local = hex.hexToBytesComptime(32, "eef77acb6c6a6eebc5b363a475ac583ec7eccdb42b6481424c60f59aa326547f");
+    const key_pair_local = try secp.keyPairFromSecret(&sk_local);
+    const pk_local = secp.compressedPubkey(&key_pair_local);
+    const node_id_local = enr_mod.nodeIdFromCompressedPubkey(&pk_local);
+
+    const sk_peer = hex.hexToBytesComptime(32, "66fb62bfbd66b9177a138c1e5cddbe4f7c30c343e94e68df8769459cb14571f7");
+    const key_pair_peer = try secp.keyPairFromSecret(&sk_peer);
+    const loopback6 = [_]u8{ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1 };
+    var builder = enr_mod.Builder.init(alloc, key_pair_peer, 1);
+    builder.ip = .{ 127, 0, 0, 1 };
+    builder.udp = 30303;
+    builder.ip6 = loopback6;
+    builder.udp6 = 30304;
+    const peer_enr = try builder.encode();
+    defer alloc.free(peer_enr);
+
+    var service = try Service.init(io, alloc, .{
+        .bind_addresses = .{
+            .ip6 = .{ .ip6 = .{ .bytes = loopback6, .port = 0 } },
+        },
+        .protocol_config = .{
+            .local_key_pair = key_pair_local,
+            .local_node_id = node_id_local,
+        },
+    });
+    defer service.deinit();
+
+    try std.testing.expect(service.addEnr(peer_enr));
+
+    const parsed = try enr_mod.decode(peer_enr);
+    const peer_id = parsed.nodeId() orelse return error.MissingNodeId;
+    const known = service.protocol.getKnownNode(&peer_id) orelse return error.UnknownNode;
+    switch (known.addr) {
+        .ip6 => |ip6| {
+            try std.testing.expectEqual(loopback6, ip6.bytes);
+            try std.testing.expectEqual(@as(u16, 30304), ip6.port);
+        },
+        .ip4 => return error.WrongAddressFamily,
+    }
+}
+
+test "discovered nodes use discv5 UDP ports and retain QUIC availability" {
+    const alloc = std.testing.allocator;
+    const io = std.Options.debug_io;
+    const hex = @import("hex");
+
+    const local_sk = hex.hexToBytesComptime(32, "eef77acb6c6a6eebc5b363a475ac583ec7eccdb42b6481424c60f59aa326547f");
+    const local_key_pair = try secp.keyPairFromSecret(&local_sk);
+    const local_pk = secp.compressedPubkey(&local_key_pair);
+    const local_node_id = enr_mod.nodeIdFromCompressedPubkey(&local_pk);
+    const source_sk = hex.hexToBytesComptime(32, "66fb62bfbd66b9177a138c1e5cddbe4f7c30c343e94e68df8769459cb14571f7");
+    const source_key_pair = try secp.keyPairFromSecret(&source_sk);
+    const source_pk = secp.compressedPubkey(&source_key_pair);
+    const source_node_id = enr_mod.nodeIdFromCompressedPubkey(&source_pk);
+
+    const loopback6 = [_]u8{ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1 };
+
+    var service = try Service.init(io, alloc, .{
+        .bind_addresses = .{
+            .ip4 = .{ .ip4 = .{ .bytes = .{ 127, 0, 0, 1 }, .port = 0 } },
+            .ip6 = .{ .ip6 = .{ .bytes = loopback6, .port = 0 } },
+        },
+        .protocol_config = .{
+            .local_key_pair = local_key_pair,
+            .local_node_id = local_node_id,
+        },
+    });
+    defer service.deinit();
+
+    var peer_builder = enr_mod.Builder.init(alloc, source_key_pair, 1);
+    peer_builder.ip = .{ 127, 0, 0, 1 };
+    peer_builder.udp = 30303;
+    peer_builder.tcp = 30304;
+    peer_builder.quic = 30305;
+    peer_builder.ip6 = loopback6;
+    peer_builder.udp6 = 30403;
+    peer_builder.tcp6 = 30404;
+    peer_builder.quic6 = 30405;
+    const peer_enr = try peer_builder.encode();
+    defer alloc.free(peer_enr);
+
+    var owned_enrs = try alloc.alloc([]u8, 1);
+    defer {
+        for (owned_enrs) |enr| alloc.free(enr);
+        alloc.free(owned_enrs);
+    }
+    owned_enrs[0] = try alloc.dupe(u8, peer_enr);
+
+    const source_addr = Address{ .ip4 = .{ .bytes = .{ 127, 0, 0, 1 }, .port = 9000 } };
+    var nodes = protocol_mod.NodesEvent{
+        .peer_id = source_node_id,
+        .peer_addr = source_addr,
+        .req_id = .{ .bytes = [8]u8{ 0, 0, 0, 1, 0, 0, 0, 0 }, .len = 4 },
+        .enrs = owned_enrs,
+    };
+
+    var discovered_enrs = service.collectDiscoveredEnrs(&nodes);
+    defer discovered_enrs.deinit(alloc);
+
+    try std.testing.expectEqual(@as(usize, 1), discovered_enrs.items.len);
+    const parsed = discovered_enrs.items[0].enr;
+    try std.testing.expectEqualSlices(u8, peer_enr, discovered_enrs.items[0].raw.slice());
+    try std.testing.expect(parsed.quic != null or parsed.quic6 != null);
+    try std.testing.expectEqual(@as(?u16, 30303), parsed.udp);
+    try std.testing.expectEqual(@as(?u16, 30403), parsed.udp6);
+}
+
+test "addr votes update local ENR" {
+    const alloc = std.testing.allocator;
+    const io = std.Options.debug_io;
+    const hex = @import("hex");
+
+    const sk = hex.hexToBytesComptime(32, "eef77acb6c6a6eebc5b363a475ac583ec7eccdb42b6481424c60f59aa326547f");
+    const key_pair = try secp.keyPairFromSecret(&sk);
+    const pk = secp.compressedPubkey(&key_pair);
+    const node_id = enr_mod.nodeIdFromCompressedPubkey(&pk);
+
+    var builder = enr_mod.Builder.init(alloc, key_pair, 1);
+    builder.ip = .{ 10, 0, 0, 1 };
+    builder.udp = 9000;
+    builder.tcp = 9000;
+    builder.ip6 = [_]u8{0} ** 16;
+    builder.udp6 = 9001;
+    const local_enr = try builder.encode();
+    defer alloc.free(local_enr);
+
+    var service = try Service.init(io, alloc, .{
+        .bind_addresses = .{ .ip4 = .{ .ip4 = .{ .bytes = .{ 127, 0, 0, 1 }, .port = 0 } } },
+        .protocol_config = .{
+            .local_key_pair = key_pair,
+            .local_node_id = node_id,
+            .local_enr = local_enr,
+            .local_enr_seq = 1,
+        },
+        .addr_votes_to_update_enr = 2,
+    });
+    defer service.deinit();
+
+    service.maybeUpdateLocalEnrFromVote(.{ .ip4 = .{ .bytes = .{ 198, 51, 100, 11 }, .port = 1001 } }, .{ .ip4 = .{ .bytes = .{ 203, 0, 113, 1 }, .port = 30303 } });
+    try std.testing.expectEqual(@as(u64, 1), service.localEnrSeq());
+
+    service.maybeUpdateLocalEnrFromVote(.{ .ip4 = .{ .bytes = .{ 198, 51, 100, 22 }, .port = 1002 } }, .{ .ip4 = .{ .bytes = .{ 203, 0, 113, 1 }, .port = 30303 } });
+    try std.testing.expectEqual(@as(u64, 2), service.localEnrSeq());
+
+    const updated = try enr_mod.decode(service.localEnr().?);
+    try std.testing.expectEqual([4]u8{ 203, 0, 113, 1 }, updated.ip.?);
+    try std.testing.expectEqual(@as(?u16, 30303), updated.udp);
+    try std.testing.expectEqual(@as(?u16, 9000), updated.tcp);
+    try std.testing.expectEqual(@as(?u16, 9001), updated.udp6);
+
+    var saw_update_event = false;
+    while (service.popEvent()) |event| {
+        var owned = event;
+        defer owned.deinit(alloc);
+        if (owned == .local_enr_updated) {
+            saw_update_event = true;
+            try std.testing.expectEqual(@as(u64, 2), owned.local_enr_updated.seq);
+        }
+    }
+    try std.testing.expect(saw_update_event);
+}
+
+test "ipv4-mapped ipv6 vote normalizes to ipv4" {
+    const alloc = std.testing.allocator;
+    const io = std.Options.debug_io;
+    const hex = @import("hex");
+
+    const sk = hex.hexToBytesComptime(32, "66fb62bfbd66b9177a138c1e5cddbe4f7c30c343e94e68df8769459cb14571f7");
+    const key_pair = try secp.keyPairFromSecret(&sk);
+    const pk = secp.compressedPubkey(&key_pair);
+    const node_id = enr_mod.nodeIdFromCompressedPubkey(&pk);
+
+    var builder = enr_mod.Builder.init(alloc, key_pair, 1);
+    builder.ip = .{ 10, 0, 0, 1 };
+    builder.udp = 9000;
+    const local_enr = try builder.encode();
+    defer alloc.free(local_enr);
+
+    var service = try Service.init(io, alloc, .{
+        .bind_addresses = .{ .ip4 = .{ .ip4 = .{ .bytes = .{ 127, 0, 0, 1 }, .port = 0 } } },
+        .protocol_config = .{
+            .local_key_pair = key_pair,
+            .local_node_id = node_id,
+            .local_enr = local_enr,
+            .local_enr_seq = 1,
+        },
+        .addr_votes_to_update_enr = 1,
+    });
+    defer service.deinit();
+
+    service.maybeUpdateLocalEnrFromVote(.{ .ip4 = .{ .bytes = .{ 198, 51, 100, 33 }, .port = 1003 } }, .{
+        .ip6 = .{
+            .bytes = .{ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xff, 0xff, 198, 51, 100, 2 },
+            .port = 40404,
+        },
+    });
+
+    const updated = try enr_mod.decode(service.localEnr().?);
+    try std.testing.expectEqual([4]u8{ 198, 51, 100, 2 }, updated.ip.?);
+    try std.testing.expectEqual(@as(?u16, 40404), updated.udp);
+}
+
+test "live lookup discovers node through intermediary" {
+    const alloc = std.testing.allocator;
+    const io = std.Options.debug_io;
+    const hex = @import("hex");
+
+    const sk_0 = hex.hexToBytesComptime(32, "eef77acb6c6a6eebc5b363a475ac583ec7eccdb42b6481424c60f59aa326547f");
+    const sk_1 = hex.hexToBytesComptime(32, "66fb62bfbd66b9177a138c1e5cddbe4f7c30c343e94e68df8769459cb14571f7");
+    const sk_2 = hex.hexToBytesComptime(32, "7e8107fe766b7f1821c3a7fbc56d18f734f0ebf898f0b85f82412b6d1fa7f4d3");
+
+    var node_0 = try TestService.init(alloc, io, sk_0);
+    defer node_0.deinit();
+    var node_1 = try TestService.init(alloc, io, sk_1);
+    defer node_1.deinit();
+    var node_2 = try TestService.init(alloc, io, sk_2);
+    defer node_2.deinit();
+
+    try node_0.addKnownEnr(&node_1);
+    try node_1.addKnownEnr(&node_2);
+    const lookup_id = try node_0.service.startLookup(&node_2.node_id);
+    const services = [_]*Service{ &node_0.service, &node_1.service, &node_2.service };
+
+    var saw_discovered_target = false;
+    var saw_lookup_finished = false;
+    var lookup_included_intermediary = false;
+
+    for (0..192) |_| {
+        pollServices(services[0..]);
+
+        while (node_0.service.popEvent()) |event| {
+            var owned = event;
+            defer owned.deinit(alloc);
+
+            switch (owned) {
+                .discovered_enr => |discovered| {
+                    const discovered_node_id = discovered.enr.nodeId() orelse continue;
+                    if (std.mem.eql(u8, &discovered_node_id, &node_2.node_id)) {
+                        saw_discovered_target = true;
+                    }
+                },
+                .lookup_finished => |lookup_finished| {
+                    saw_lookup_finished = true;
+                    try std.testing.expectEqual(lookup_id, lookup_finished.lookup_id);
+                    try std.testing.expect(!lookup_finished.timed_out);
+
+                    for (lookup_finished.enrs) |raw_enr| {
+                        const parsed = try enr_mod.decode(raw_enr);
+                        const node_id = parsed.nodeId() orelse continue;
+                        if (std.mem.eql(u8, &node_id, &node_1.node_id)) {
+                            lookup_included_intermediary = true;
+                        }
+                    }
+                },
+                else => {},
+            }
+        }
+
+        while (node_1.service.popEvent()) |event| {
+            var owned = event;
+            defer owned.deinit(alloc);
+        }
+        while (node_2.service.popEvent()) |event| {
+            var owned = event;
+            defer owned.deinit(alloc);
+        }
+
+        if (saw_discovered_target and saw_lookup_finished) break;
+    }
+
+    const discovered_enr = node_0.service.findEnr(&node_2.node_id) orelse return error.MissingDiscoveredEnr;
+    try std.testing.expectEqualSlices(u8, node_2.enr(), discovered_enr);
+    try std.testing.expect(saw_discovered_target);
+    try std.testing.expect(saw_lookup_finished);
+    try std.testing.expect(lookup_included_intermediary);
+}
+
+test "live TALKREQ TALKRESP round-trip" {
+    const alloc = std.testing.allocator;
+    const io = std.Options.debug_io;
+    const hex = @import("hex");
+
+    const sk_0 = hex.hexToBytesComptime(32, "eef77acb6c6a6eebc5b363a475ac583ec7eccdb42b6481424c60f59aa326547f");
+    const sk_1 = hex.hexToBytesComptime(32, "66fb62bfbd66b9177a138c1e5cddbe4f7c30c343e94e68df8769459cb14571f7");
+
+    var node_0 = try TestService.init(alloc, io, sk_0);
+    defer node_0.deinit();
+    var node_1 = try TestService.init(alloc, io, sk_1);
+    defer node_1.deinit();
+
+    try node_0.addKnownEnr(&node_1);
+
+    const req_id = try node_0.service.sendTalkRequest(
+        &node_1.node_id,
+        &node_1.pubkey,
+        node_1.addr(),
+        "/eth2/test",
+        "ping",
+    );
+
+    const services = [_]*Service{ &node_0.service, &node_1.service };
+    var saw_request = false;
+    var saw_response = false;
+
+    for (0..192) |_| {
+        pollServices(services[0..]);
+
+        while (node_1.service.popEvent()) |event| {
+            var owned = event;
+            defer owned.deinit(alloc);
+
+            switch (owned) {
+                .talkreq => |talkreq| {
+                    saw_request = true;
+                    try std.testing.expectEqual(node_0.node_id, talkreq.peer_id);
+                    try std.testing.expectEqualSlices(u8, req_id.slice(), talkreq.req_id.slice());
+                    try std.testing.expectEqualStrings("/eth2/test", talkreq.protocol);
+                    try std.testing.expectEqualStrings("ping", talkreq.request);
+                    try node_1.service.sendTalkResponse(talkreq.peer_id, talkreq.peer_addr, talkreq.req_id, "pong");
+                },
+                else => {},
+            }
+        }
+
+        while (node_0.service.popEvent()) |event| {
+            var owned = event;
+            defer owned.deinit(alloc);
+
+            switch (owned) {
+                .talkresp => |talkresp| {
+                    saw_response = true;
+                    try std.testing.expectEqual(node_1.node_id, talkresp.peer_id);
+                    try std.testing.expectEqualSlices(u8, req_id.slice(), talkresp.req_id.slice());
+                    try std.testing.expectEqualStrings("pong", talkresp.response);
+                },
+                else => {},
+            }
+        }
+
+        if (saw_request and saw_response) break;
+    }
+
+    try std.testing.expect(saw_request);
+    try std.testing.expect(saw_response);
+}
+
+test "discv5 service ingress uses TS-style rate limiter" {
+    const io = std.Options.debug_io;
+    const hex = @import("hex");
+    const secret = hex.hexToBytesComptime(32, "ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80");
+    var fixture = try TestService.init(std.testing.allocator, io, secret);
+    defer fixture.deinit();
+
+    fixture.service.ingress_queue.deinit();
+    fixture.service.ingress_queue = try IngressQueue.init(std.testing.allocator, 4, .{
+        .global_quota = .{ .replenish_all_every_ms = 1_000, .max_tokens = 100 },
+        .by_ip_quota = .{ .replenish_all_every_ms = 1_000, .max_tokens = 1 },
+    });
+
+    const from = Address{ .ip4 = .{ .bytes = .{ 203, 0, 113, 9 }, .port = 9000 } };
+    const payload = [_]u8{0xaa} ** 16;
+    try std.testing.expect(fixture.service.ingress_queue.enqueueReceived(from, &payload, 0));
+    try std.testing.expect(!fixture.service.ingress_queue.enqueueReceived(from, &payload, 0));
+
+    const stats = fixture.service.ingressStatsSnapshot();
+    try std.testing.expectEqual(@as(u64, 2), stats.received_total);
+    try std.testing.expectEqual(@as(u64, 1), stats.filtered_total);
+    try std.testing.expectEqual(@as(u64, 1), stats.rate_limit_hit_ip_total);
+}
+
+test "discv5 service ingress expected response bypasses rate limit" {
+    const io = std.Options.debug_io;
+    const hex = @import("hex");
+    const secret = hex.hexToBytesComptime(32, "b71c71a67e1177ad42eb5a1d7d0892b262a09b10d06c26fbb05d4eb671838a75");
+    var fixture = try TestService.init(std.testing.allocator, io, secret);
+    defer fixture.deinit();
+
+    fixture.service.ingress_queue.deinit();
+    fixture.service.ingress_queue = try IngressQueue.init(std.testing.allocator, 4, .{
+        .global_quota = .{ .replenish_all_every_ms = 1_000, .max_tokens = 1 },
+        .by_ip_quota = .{ .replenish_all_every_ms = 1_000, .max_tokens = 1 },
+    });
+
+    const from = Address{ .ip4 = .{ .bytes = .{ 203, 0, 113, 10 }, .port = 9000 } };
+    const payload = [_]u8{0xbb} ** 16;
+    try std.testing.expect(fixture.service.ingress_queue.enqueueReceived(from, &payload, 0));
+    fixture.service.ingress_queue.addExpectedResponse(from);
+    try std.testing.expect(fixture.service.ingress_queue.enqueueReceived(from, &payload, 0));
+    fixture.service.ingress_queue.removeExpectedResponse(from);
+    try std.testing.expect(!fixture.service.ingress_queue.enqueueReceived(from, &payload, 0));
+}
+
+test "discv5 service addEnr emits TS-style enrAdded API event" {
+    const alloc = std.testing.allocator;
+    const io = std.Options.debug_io;
+
+    var service_a = try TestService.init(alloc, io, [_]u8{0x11} ** 32);
+    defer service_a.deinit();
+    var service_b = try TestService.init(alloc, io, [_]u8{0x12} ** 32);
+    defer service_b.deinit();
+
+    while (service_a.service.popEvent()) |startup_event_value| {
+        var startup_event = startup_event_value;
+        startup_event.deinit(alloc);
+    }
+    try std.testing.expect(service_a.service.addEnr(service_b.enr()));
+
+    var event = service_a.service.popEvent() orelse return error.MissingEnrAddedEvent;
+    defer event.deinit(alloc);
+    try std.testing.expectEqual(EventKind.enr_added, event.kind());
+    try std.testing.expectEqualStrings("enrAdded", event.tsEventName());
+    switch (event) {
+        .enr_added => |enr_added| {
+            try std.testing.expectEqual(service_b.node_id, enr_added.node_id);
+            try std.testing.expectEqualSlices(u8, service_b.enr(), enr_added.enr);
+            try std.testing.expect(enr_added.replaced_enr == null);
+        },
+        else => return error.UnexpectedEvent,
+    }
+    try std.testing.expect(service_a.service.popEvent() == null);
+}
+
+test "discv5 service API event names mirror ChainSafe TS surface" {
+    const alloc = std.testing.allocator;
+    const node_id = [_]u8{0x22} ** 32;
+    const addr = Address{ .ip4 = .{ .bytes = .{ 127, 0, 0, 1 }, .port = 9000 } };
+
+    var talkreq = Event{ .talkreq = .{
+        .peer_id = node_id,
+        .peer_addr = addr,
+        .req_id = .{ .bytes = [_]u8{0x01} ** 8, .len = 8 },
+        .protocol = try alloc.dupe(u8, "eth2"),
+        .request = try alloc.dupe(u8, "payload"),
+    } };
+    defer talkreq.deinit(alloc);
+    try std.testing.expectEqual(EventKind.talk_req_received, talkreq.kind());
+    try std.testing.expectEqualStrings("talkReqReceived", talkreq.tsEventName());
+
+    var timeout = Event{ .request_timeout = .{
+        .peer_id = node_id,
+        .req_id = .{ .bytes = [_]u8{0x02} ** 8, .len = 8 },
+        .kind = .ping,
+    } };
+    defer timeout.deinit(alloc);
+    try std.testing.expectEqual(EventKind.request_failed, timeout.kind());
+    try std.testing.expectEqualStrings("requestFailed", timeout.tsEventName());
+
+    var local = Event{ .local_enr_updated = .{
+        .seq = 2,
+        .enr = try alloc.dupe(u8, "enr"),
+    } };
+    defer local.deinit(alloc);
+    try std.testing.expectEqual(EventKind.multiaddr_updated, local.kind());
+    try std.testing.expectEqualStrings("multiaddrUpdated", local.tsEventName());
+}
+
+test "discv5 service metrics snapshot mirrors TS gauges and rate-limit counters" {
+    const io = std.Options.debug_io;
+    const sk = [_]u8{0x02} ** 32;
+    var fixture = try TestService.init(std.testing.allocator, io, sk);
+    defer fixture.deinit();
+
+    fixture.service.ingress_queue.deinit();
+    fixture.service.ingress_queue = try IngressQueue.init(std.testing.allocator, 4, .{
+        .global_quota = .{ .replenish_all_every_ms = 1_000, .max_tokens = 100 },
+        .by_ip_quota = .{ .replenish_all_every_ms = 1_000, .max_tokens = 1 },
+    });
+
+    const from = Address{ .ip4 = .{ .bytes = .{ 203, 0, 113, 11 }, .port = 9000 } };
+    const payload = [_]u8{0xcc} ** 16;
+    try std.testing.expect(fixture.service.ingress_queue.enqueueReceived(from, &payload, 0));
+    try std.testing.expect(!fixture.service.ingress_queue.enqueueReceived(from, &payload, 0));
+
+    var target = [_]u8{0x42} ** 32;
+    _ = try fixture.service.startLookup(&target);
+
+    const snapshot = fixture.service.metricsSnapshot();
+    try std.testing.expectEqual(fixture.service.knownPeerCount(), snapshot.kad_table_size);
+    try std.testing.expectEqual(fixture.service.connectedPeerCount(), snapshot.connected_peer_count);
+    try std.testing.expectEqual(fixture.service.protocol.activeSessionCount(), snapshot.active_session_count);
+    try std.testing.expectEqual(@as(u64, 1), snapshot.lookup_count);
+    try std.testing.expectEqual(@as(u64, 1), snapshot.rate_limit_hit_ip);
+    try std.testing.expectEqual(@as(u64, 0), snapshot.rate_limit_hit_total);
+}
+
+test "queued ingress respects processing budget" {
+    const alloc = std.testing.allocator;
+    const io = std.Options.debug_io;
+    const hex = @import("hex");
+
+    const sk = hex.hexToBytesComptime(32, "eef77acb6c6a6eebc5b363a475ac583ec7eccdb42b6481424c60f59aa326547f");
+    var node = try TestService.init(alloc, io, sk);
+    defer node.deinit();
+
+    try node.service.queueInboundPacketForTest(node.addr(), &[_]u8{0x00});
+    try node.service.queueInboundPacketForTest(node.addr(), &[_]u8{0x01});
+
+    try std.testing.expectEqual(@as(usize, 2), node.service.queuedIngressPackets());
+    try std.testing.expectEqual(@as(usize, 1), node.service.processQueuedPackets(1));
+    try std.testing.expectEqual(@as(usize, 1), node.service.queuedIngressPackets());
+    try std.testing.expectEqual(@as(usize, 1), node.service.processQueuedPackets(8));
+    try std.testing.expectEqual(@as(usize, 0), node.service.queuedIngressPackets());
+}

--- a/src/discv5/service/addr_votes.zig
+++ b/src/discv5/service/addr_votes.zig
@@ -1,0 +1,189 @@
+const std = @import("std");
+const Allocator = std.mem.Allocator;
+const Io = std.Io;
+const Address = Io.net.IpAddress;
+
+pub const MAX_ADDR_VOTES: usize = 200;
+
+const SourceKey = struct {
+    family: Address.Family,
+    bytes: [16]u8,
+
+    fn fromAddress(addr: Address) SourceKey {
+        return switch (addr) {
+            .ip4 => |ip4| blk: {
+                var bytes = [_]u8{0} ** 16;
+                @memcpy(bytes[0..4], &ip4.bytes);
+                break :blk .{ .family = .ip4, .bytes = bytes };
+            },
+            .ip6 => |ip6| .{ .family = .ip6, .bytes = ip6.bytes },
+        };
+    }
+};
+
+const VoteKey = struct {
+    family: Address.Family,
+    bytes: [16]u8,
+    port: u16,
+
+    fn fromAddress(addr: Address) VoteKey {
+        return switch (addr) {
+            .ip4 => |ip4| blk: {
+                var bytes = [_]u8{0} ** 16;
+                @memcpy(bytes[0..4], &ip4.bytes);
+                break :blk .{ .family = .ip4, .bytes = bytes, .port = ip4.port };
+            },
+            .ip6 => |ip6| .{ .family = .ip6, .bytes = ip6.bytes, .port = ip6.port },
+        };
+    }
+};
+
+const VoterRecord = struct {
+    vote_key: VoteKey,
+};
+
+const VoteOrderEntry = struct {
+    source: SourceKey,
+    vote_key: VoteKey,
+};
+
+pub const AddrVotes = struct {
+    allocator: Allocator,
+    threshold: usize,
+    voters: std.AutoHashMap(SourceKey, VoterRecord),
+    tallies: std.AutoHashMap(VoteKey, usize),
+    order: std.ArrayListUnmanaged(VoteOrderEntry) = .empty,
+
+    pub fn init(allocator: Allocator, threshold: usize) AddrVotes {
+        return .{
+            .allocator = allocator,
+            .threshold = threshold,
+            .voters = std.AutoHashMap(SourceKey, VoterRecord).init(allocator),
+            .tallies = std.AutoHashMap(VoteKey, usize).init(allocator),
+        };
+    }
+
+    pub fn deinit(self: *AddrVotes) void {
+        self.voters.deinit();
+        self.tallies.deinit();
+        self.order.deinit(self.allocator);
+    }
+
+    pub fn clear(self: *AddrVotes) void {
+        self.voters.clearRetainingCapacity();
+        self.tallies.clearRetainingCapacity();
+        self.order.clearRetainingCapacity();
+    }
+
+    /// Record one external-address vote per source IP. Node IDs are cheap to
+    /// generate, so counting them independently would let one remote host meet
+    /// the ENR-update threshold with local sybils.
+    pub fn addVote(self: *AddrVotes, source_addr: Address, observed_addr: Address) !bool {
+        const source = SourceKey.fromAddress(source_addr);
+        const vote_key = VoteKey.fromAddress(observed_addr);
+        const previous = self.voters.get(source);
+
+        if (previous) |record| {
+            if (std.meta.eql(record.vote_key, vote_key)) return false;
+        }
+
+        const tally = (self.tallies.get(vote_key) orelse 0) + 1;
+        if (tally >= self.threshold) {
+            self.clear();
+            return true;
+        }
+
+        try self.tallies.ensureUnusedCapacity(1);
+        try self.voters.ensureUnusedCapacity(1);
+        if (previous == null) try self.order.ensureUnusedCapacity(self.allocator, 1);
+
+        if (previous) |record| self.decrementTally(record.vote_key);
+        self.tallies.putAssumeCapacity(vote_key, tally);
+        self.voters.putAssumeCapacity(source, .{ .vote_key = vote_key });
+
+        if (previous == null) {
+            self.order.appendAssumeCapacity(.{ .source = source, .vote_key = vote_key });
+        } else {
+            for (self.order.items) |*entry| {
+                if (!std.meta.eql(entry.source, source)) continue;
+                entry.vote_key = vote_key;
+                break;
+            } else unreachable;
+        }
+
+        self.evictOverflow();
+        return false;
+    }
+
+    pub fn currentVoteCount(self: *const AddrVotes) usize {
+        return self.voters.count();
+    }
+
+    fn decrementTally(self: *AddrVotes, vote_key: VoteKey) void {
+        const tally = self.tallies.getPtr(vote_key) orelse return;
+        std.debug.assert(tally.* > 0);
+        if (tally.* == 1) {
+            _ = self.tallies.remove(vote_key);
+        } else {
+            tally.* -= 1;
+        }
+    }
+
+    fn evictOverflow(self: *AddrVotes) void {
+        while (self.voters.count() > MAX_ADDR_VOTES and self.order.items.len > 0) {
+            const evicted = self.order.orderedRemove(0);
+            const current = self.voters.get(evicted.source) orelse continue;
+            if (!std.meta.eql(current.vote_key, evicted.vote_key)) continue;
+            _ = self.voters.remove(evicted.source);
+            self.decrementTally(evicted.vote_key);
+        }
+    }
+};
+
+fn testIp4(last: u8, port: u16) Address {
+    return .{ .ip4 = .{ .bytes = .{ 127, 0, 0, last }, .port = port } };
+}
+
+test "address votes replace a source IP's previous tally" {
+    var votes = AddrVotes.init(std.testing.allocator, 3);
+    defer votes.deinit();
+
+    const address_a = testIp4(10, 9000);
+    const address_b = testIp4(11, 9000);
+
+    try std.testing.expect(!try votes.addVote(testIp4(1, 1001), address_a));
+    try std.testing.expect(!try votes.addVote(testIp4(2, 1002), address_a));
+    try std.testing.expect(!try votes.addVote(testIp4(1, 2001), address_b));
+    try std.testing.expect(!try votes.addVote(testIp4(3, 1003), address_a));
+    try std.testing.expect(try votes.addVote(testIp4(4, 1004), address_a));
+}
+
+test "address votes count one vote per source IP despite port changes" {
+    var votes = AddrVotes.init(std.testing.allocator, 2);
+    defer votes.deinit();
+
+    const observed = testIp4(10, 9000);
+    try std.testing.expect(!try votes.addVote(testIp4(1, 1001), observed));
+    try std.testing.expect(!try votes.addVote(testIp4(1, 2002), observed));
+    try std.testing.expectEqual(@as(usize, 1), votes.currentVoteCount());
+    try std.testing.expect(try votes.addVote(testIp4(2, 1002), observed));
+}
+
+test "address vote replacement keeps ordering storage bounded" {
+    var votes = AddrVotes.init(std.testing.allocator, 10);
+    defer votes.deinit();
+
+    const source = testIp4(1, 1001);
+    for (0..500) |index| {
+        const address: Address = .{
+            .ip4 = .{
+                .bytes = .{ 127, 0, 0, @intCast(index % 255) },
+                .port = @intCast(1 + index),
+            },
+        };
+        try std.testing.expect(!try votes.addVote(source, address));
+    }
+
+    try std.testing.expectEqual(@as(usize, 1), votes.currentVoteCount());
+    try std.testing.expectEqual(@as(usize, 1), votes.order.items.len);
+}

--- a/src/discv5/service/events.zig
+++ b/src/discv5/service/events.zig
@@ -1,0 +1,132 @@
+const std = @import("std");
+const Allocator = std.mem.Allocator;
+const Io = std.Io;
+const Address = Io.net.IpAddress;
+
+const enr_mod = @import("../enr.zig");
+const protocol_mod = @import("../protocol.zig");
+
+pub const NodeId = enr_mod.NodeId;
+
+pub const LookupFinishedEvent = struct {
+    lookup_id: u32,
+    target: NodeId,
+    enrs: [][]u8,
+    timed_out: bool,
+
+    pub fn deinit(self: *LookupFinishedEvent, alloc: Allocator) void {
+        for (self.enrs) |enr| alloc.free(enr);
+        alloc.free(self.enrs);
+    }
+};
+
+pub const DiscoveredEnrEvent = struct {
+    raw: enr_mod.RawEnr,
+    enr: enr_mod.Enr,
+
+    pub fn deinit(_: *DiscoveredEnrEvent, _: Allocator) void {}
+};
+
+pub const EnrAddedEvent = struct {
+    node_id: NodeId,
+    addr: Address,
+    enr: []u8,
+    replaced_enr: ?[]u8 = null,
+
+    pub fn deinit(self: *EnrAddedEvent, alloc: Allocator) void {
+        alloc.free(self.enr);
+        if (self.replaced_enr) |replaced| alloc.free(replaced);
+    }
+};
+
+pub const LocalEnrUpdatedEvent = struct {
+    seq: u64,
+    enr: []u8,
+
+    pub fn deinit(self: *LocalEnrUpdatedEvent, alloc: Allocator) void {
+        alloc.free(self.enr);
+    }
+};
+
+pub const PeerConnectedEvent = struct {
+    peer_id: NodeId,
+    peer_addr: Address,
+};
+
+pub const PeerDisconnectedEvent = struct {
+    peer_id: NodeId,
+    peer_addr: Address,
+};
+
+pub const EventKind = enum {
+    discovered,
+    enr_added,
+    multiaddr_updated,
+    talk_req_received,
+    talk_resp_received,
+    session_established,
+    request_failed,
+    response_received,
+    lookup_finished,
+    peer_disconnected,
+};
+
+pub const Event = union(enum) {
+    pong: protocol_mod.PongEvent,
+    nodes: protocol_mod.NodesEvent,
+    talkreq: protocol_mod.TalkReqEvent,
+    talkresp: protocol_mod.TalkRespEvent,
+    request_timeout: protocol_mod.RequestTimeoutEvent,
+    discovered_enr: DiscoveredEnrEvent,
+    enr_added: EnrAddedEvent,
+    lookup_finished: LookupFinishedEvent,
+    local_enr_updated: LocalEnrUpdatedEvent,
+    peer_connected: PeerConnectedEvent,
+    peer_disconnected: PeerDisconnectedEvent,
+
+    pub fn kind(self: *const Event) EventKind {
+        return switch (self.*) {
+            .discovered_enr => .discovered,
+            .enr_added => .enr_added,
+            .local_enr_updated => .multiaddr_updated,
+            .talkreq => .talk_req_received,
+            .talkresp => .talk_resp_received,
+            .peer_connected => .session_established,
+            .request_timeout => .request_failed,
+            .pong, .nodes => .response_received,
+            .lookup_finished => .lookup_finished,
+            .peer_disconnected => .peer_disconnected,
+        };
+    }
+
+    pub fn tsEventName(self: *const Event) []const u8 {
+        return switch (self.kind()) {
+            .discovered => "discovered",
+            .enr_added => "enrAdded",
+            .multiaddr_updated => "multiaddrUpdated",
+            .talk_req_received => "talkReqReceived",
+            .talk_resp_received => "talkRespReceived",
+            .session_established => "established",
+            .request_failed => "requestFailed",
+            .response_received => "response",
+            .lookup_finished => "lookupFinished",
+            .peer_disconnected => "disconnected",
+        };
+    }
+
+    pub fn deinit(self: *Event, alloc: Allocator) void {
+        switch (self.*) {
+            // Events that own no heap memory.
+            .pong, .request_timeout, .peer_connected, .peer_disconnected => {},
+            // The remaining payloads own their deinit; call it directly rather
+            // than round-tripping through a reconstructed protocol_mod.Event.
+            .nodes => |*nodes| nodes.deinit(alloc),
+            .talkreq => |*talkreq| talkreq.deinit(alloc),
+            .talkresp => |*talkresp| talkresp.deinit(alloc),
+            .discovered_enr => |*discovered_enr| discovered_enr.deinit(alloc),
+            .enr_added => |*enr_added| enr_added.deinit(alloc),
+            .lookup_finished => |*lookup_finished| lookup_finished.deinit(alloc),
+            .local_enr_updated => |*local_enr_updated| local_enr_updated.deinit(alloc),
+        }
+    }
+};

--- a/src/discv5/service/ingress_queue.zig
+++ b/src/discv5/service/ingress_queue.zig
@@ -1,0 +1,163 @@
+const std = @import("std");
+const Allocator = std.mem.Allocator;
+const Io = std.Io;
+const Address = Io.net.IpAddress;
+
+const protocol_mod = @import("../protocol.zig");
+const rate_limit = @import("../rate_limit.zig");
+
+pub const IngressPacket = struct {
+    from: Address,
+    len: usize,
+    data: [protocol_mod.MAX_PACKET_SIZE]u8,
+};
+
+pub const IngressStatsSnapshot = struct {
+    received_total: u64 = 0,
+    filtered_total: u64 = 0,
+    dropped_queue_full_total: u64 = 0,
+    processed_total: u64 = 0,
+    budget_exhausted_total: u64 = 0,
+    queue_depth: usize = 0,
+    max_queue_depth: usize = 0,
+    rate_limit_hit_ip_total: u64 = 0,
+    rate_limit_hit_total: u64 = 0,
+};
+
+pub const IngressQueue = struct {
+    allocator: Allocator,
+    packets: []IngressPacket,
+    head: usize = 0,
+    len: usize = 0,
+    rate_limiter: ?rate_limit.RateLimiter = null,
+    mutex: std.atomic.Mutex = .unlocked,
+    stats: IngressStatsSnapshot = .{},
+
+    fn acquire(self: *IngressQueue) void {
+        while (!self.mutex.tryLock()) {
+            std.atomic.spinLoopHint();
+        }
+    }
+
+    pub fn init(allocator: Allocator, capacity: usize, rate_limiter_config: ?rate_limit.Config) !IngressQueue {
+        if (capacity == 0) return error.InvalidQueueCapacity;
+        const packets = try allocator.alloc(IngressPacket, capacity);
+        errdefer allocator.free(packets);
+        return .{
+            .allocator = allocator,
+            .packets = packets,
+            .rate_limiter = if (rate_limiter_config) |cfg| try rate_limit.RateLimiter.init(allocator, cfg) else null,
+        };
+    }
+
+    pub fn deinit(self: *IngressQueue) void {
+        if (self.rate_limiter) |*limiter| limiter.deinit();
+        self.allocator.free(self.packets);
+    }
+
+    pub fn snapshot(self: *IngressQueue) IngressStatsSnapshot {
+        self.acquire();
+        defer self.mutex.unlock();
+        return self.stats;
+    }
+
+    pub fn queuedLen(self: *IngressQueue) usize {
+        self.acquire();
+        defer self.mutex.unlock();
+        return self.len;
+    }
+
+    pub fn enqueueReceived(self: *IngressQueue, from: Address, data: []const u8, now_ms: u64) bool {
+        self.acquire();
+        defer self.mutex.unlock();
+
+        return self.acceptReceivedUnlocked(from, now_ms) and self.enqueueUnlocked(from, data);
+    }
+
+    pub fn acceptReceived(self: *IngressQueue, from: Address, now_ms: u64) bool {
+        self.acquire();
+        defer self.mutex.unlock();
+        return self.acceptReceivedUnlocked(from, now_ms);
+    }
+
+    fn acceptReceivedUnlocked(self: *IngressQueue, from: Address, now_ms: u64) bool {
+        self.stats.received_total += 1;
+        if (self.rate_limiter) |*limiter| {
+            if (!limiter.allowEncodedPacket(from, now_ms)) {
+                self.stats.filtered_total += 1;
+                const rate_stats = limiter.statsSnapshot();
+                self.stats.rate_limit_hit_ip_total = rate_stats.rate_limit_hit_ip_total;
+                self.stats.rate_limit_hit_total = rate_stats.rate_limit_hit_total;
+                return false;
+            }
+        }
+        return true;
+    }
+
+    pub fn addExpectedResponse(self: *IngressQueue, addr: Address) void {
+        self.acquire();
+        defer self.mutex.unlock();
+        if (self.rate_limiter) |*limiter| limiter.addExpectedResponse(addr) catch {};
+    }
+
+    pub fn removeExpectedResponse(self: *IngressQueue, addr: Address) void {
+        self.acquire();
+        defer self.mutex.unlock();
+        if (self.rate_limiter) |*limiter| limiter.removeExpectedResponse(addr);
+    }
+
+    pub fn enqueueForTest(self: *IngressQueue, from: Address, data: []const u8) bool {
+        self.acquire();
+        defer self.mutex.unlock();
+        return self.enqueueUnlocked(from, data);
+    }
+
+    fn enqueueUnlocked(self: *IngressQueue, from: Address, data: []const u8) bool {
+        if (data.len > protocol_mod.MAX_PACKET_SIZE) return false;
+        if (self.len >= self.packets.len) {
+            self.stats.dropped_queue_full_total += 1;
+            return false;
+        }
+
+        const index = (self.head + self.len) % self.packets.len;
+        self.packets[index].from = from;
+        self.packets[index].len = data.len;
+        @memcpy(self.packets[index].data[0..data.len], data);
+        self.len += 1;
+        self.stats.queue_depth = self.len;
+        if (self.len > self.stats.max_queue_depth) self.stats.max_queue_depth = self.len;
+        return true;
+    }
+
+    pub fn pop(self: *IngressQueue) ?IngressPacket {
+        self.acquire();
+        defer self.mutex.unlock();
+        if (self.len == 0) return null;
+
+        const packet = self.packets[self.head];
+        self.head = (self.head + 1) % self.packets.len;
+        self.len -= 1;
+        self.stats.queue_depth = self.len;
+        return packet;
+    }
+
+    pub fn noteProcessed(self: *IngressQueue, processed: usize, budget_exhausted: bool) void {
+        if (processed == 0 and !budget_exhausted) return;
+        self.acquire();
+        defer self.mutex.unlock();
+        self.stats.processed_total += processed;
+        if (budget_exhausted) self.stats.budget_exhausted_total += 1;
+    }
+};
+
+test "ingress queue rejects invalid capacity and oversized packets" {
+    try std.testing.expectError(error.InvalidQueueCapacity, IngressQueue.init(std.testing.allocator, 0, null));
+
+    var queue = try IngressQueue.init(std.testing.allocator, 1, null);
+    defer queue.deinit();
+
+    const from: Address = .{ .ip4 = .{ .bytes = .{ 127, 0, 0, 1 }, .port = 9000 } };
+    const oversized = [_]u8{0} ** (protocol_mod.MAX_PACKET_SIZE + 1);
+    try std.testing.expect(!queue.enqueueForTest(from, &oversized));
+    try std.testing.expectEqual(@as(usize, 0), queue.queuedLen());
+}

--- a/src/discv5/service/lookup.zig
+++ b/src/discv5/service/lookup.zig
@@ -1,0 +1,360 @@
+const std = @import("std");
+const Allocator = std.mem.Allocator;
+const NodeId = @import("../enr.zig").NodeId;
+const kbucket = @import("../kbucket.zig");
+
+pub const MAX_RESULTS: usize = kbucket.K;
+pub const MAX_PARALLELISM: usize = kbucket.K;
+/// Bound the closest-candidate frontier while retaining contacted/in-flight
+/// entries so eviction cannot erase request history and cause repeated queries.
+pub const MAX_CANDIDATES: usize = MAX_RESULTS + MAX_PARALLELISM;
+
+pub const Config = struct {
+    num_results: usize,
+    parallelism: usize,
+    request_limit: usize,
+    timeout_ms: u64,
+};
+
+pub const PeerState = enum {
+    not_contacted,
+    waiting,
+    succeeded,
+    failed,
+};
+
+pub const Peer = struct {
+    node_id: NodeId,
+    peers_returned: usize = 0,
+    state: PeerState = .not_contacted,
+};
+
+pub const State = enum {
+    iterating,
+    stalled,
+    finished,
+};
+
+pub const Lookup = struct {
+    target: NodeId,
+    started_at_ns: i64,
+    state: State = .iterating,
+    no_progress: usize = 0,
+    num_waiting: usize = 0,
+    peers: std.ArrayListUnmanaged(Peer) = .empty,
+
+    pub fn init(alloc: Allocator, target: NodeId, seeds: []const NodeId, started_at_ns: i64, config: Config) !Lookup {
+        if (config.num_results == 0 or config.num_results > MAX_RESULTS) return error.InvalidNumResults;
+        if (config.parallelism == 0 or config.parallelism > MAX_PARALLELISM) return error.InvalidParallelism;
+        if (seeds.len > MAX_RESULTS) return error.TooManySeeds;
+
+        var lookup = Lookup{
+            .target = target,
+            .started_at_ns = started_at_ns,
+        };
+        errdefer lookup.deinit(alloc);
+        try lookup.peers.ensureTotalCapacityPrecise(alloc, MAX_CANDIDATES);
+
+        for (seeds) |seed| {
+            _ = lookup.insertCandidate(seed);
+        }
+        lookup.truncateCandidates(config.num_results);
+        return lookup;
+    }
+
+    pub fn deinit(self: *Lookup, alloc: Allocator) void {
+        self.peers.deinit(alloc);
+    }
+
+    pub fn isTimedOut(self: *const Lookup, now_ns: i64, config: Config) bool {
+        const elapsed_ns: i128 = @as(i128, now_ns) - @as(i128, self.started_at_ns);
+        return elapsed_ns >= @as(i128, config.timeout_ms) * std.time.ns_per_ms;
+    }
+
+    pub fn atCapacity(self: *const Lookup, config: Config) bool {
+        return switch (self.state) {
+            .iterating => self.num_waiting >= config.parallelism,
+            .stalled => self.num_waiting >= config.num_results,
+            .finished => true,
+        };
+    }
+
+    fn insertCandidate(self: *Lookup, node_id: NodeId) ?usize {
+        std.debug.assert(self.peers.items.len <= MAX_CANDIDATES);
+        std.debug.assert(self.peers.capacity >= MAX_CANDIDATES);
+
+        for (self.peers.items) |peer| {
+            if (std.mem.eql(u8, &peer.node_id, &node_id)) return null;
+        }
+
+        const candidate_distance = kbucket.xorDistance(&self.target, &node_id);
+        var insert_at = self.peers.items.len;
+        for (self.peers.items, 0..) |peer, i| {
+            const peer_distance = kbucket.xorDistance(&self.target, &peer.node_id);
+            if (std.mem.lessThan(u8, &candidate_distance, &peer_distance)) {
+                insert_at = i;
+                break;
+            }
+        }
+
+        if (self.peers.items.len == MAX_CANDIDATES) {
+            // Only an uncontacted candidate can be replaced. Keeping waiting,
+            // succeeded, and failed peers prevents a later response from
+            // reintroducing the same NodeId as fresh work.
+            var evict_index = self.peers.items.len;
+            while (evict_index > 0) {
+                evict_index -= 1;
+                if (self.peers.items[evict_index].state == .not_contacted) break;
+            } else return null;
+
+            if (insert_at > evict_index) return null;
+            _ = self.peers.orderedRemove(evict_index);
+        }
+
+        self.peers.insertAssumeCapacity(insert_at, .{ .node_id = node_id });
+        return insert_at;
+    }
+
+    pub fn findPeerIndex(self: *const Lookup, node_id: *const NodeId) ?usize {
+        for (self.peers.items, 0..) |peer, i| {
+            if (std.mem.eql(u8, &peer.node_id, node_id)) return i;
+        }
+        return null;
+    }
+
+    pub fn truncateCandidates(self: *Lookup, max_candidates: usize) void {
+        if (self.peers.items.len <= max_candidates) return;
+        self.peers.shrinkRetainingCapacity(max_candidates);
+    }
+
+    pub fn onSuccess(self: *Lookup, node_id: *const NodeId, closer_peers: []const NodeId, config: Config) void {
+        if (self.state == .finished) return;
+
+        const peer_index = self.findPeerIndex(node_id) orelse {
+            self.maybeFinish(config);
+            return;
+        };
+
+        const accepted_peers = closer_peers[0..@min(closer_peers.len, kbucket.K)];
+        if (self.peers.items[peer_index].state == .waiting) {
+            self.num_waiting -= 1;
+            self.peers.items[peer_index].peers_returned += accepted_peers.len;
+            self.peers.items[peer_index].state = .succeeded;
+        }
+
+        const had_few_results = self.peers.items.len < config.num_results;
+        var progress = false;
+        for (accepted_peers) |peer_id| {
+            if (self.insertCandidate(peer_id)) |insert_index| {
+                if (insert_index == 0 or had_few_results) progress = true;
+            }
+        }
+
+        switch (self.state) {
+            .iterating => {
+                self.no_progress = if (progress) 0 else self.no_progress + 1;
+                if (self.no_progress >= config.parallelism) self.state = .stalled;
+            },
+            .stalled => {
+                if (progress) {
+                    self.state = .iterating;
+                    self.no_progress = 0;
+                }
+            },
+            .finished => {},
+        }
+
+        self.maybeFinish(config);
+    }
+
+    pub fn onFailure(self: *Lookup, node_id: *const NodeId, config: Config) void {
+        if (self.state == .finished) return;
+
+        if (self.findPeerIndex(node_id)) |index| {
+            if (self.peers.items[index].state == .waiting) {
+                self.num_waiting -= 1;
+                self.peers.items[index].state = .failed;
+            }
+        }
+
+        self.maybeFinish(config);
+    }
+
+    pub fn nextPeer(self: *Lookup, config: Config) ?NodeId {
+        if (self.state == .finished or self.atCapacity(config)) return null;
+
+        for (self.peers.items) |*peer| {
+            if (peer.state != .not_contacted) continue;
+            peer.state = .waiting;
+            self.num_waiting += 1;
+            return peer.node_id;
+        }
+
+        self.maybeFinish(config);
+        return null;
+    }
+
+    fn maybeFinish(self: *Lookup, config: Config) void {
+        if (self.state == .finished) return;
+
+        const limit = @min(config.num_results, self.peers.items.len);
+        var blocked = false;
+        var succeeded: usize = 0;
+        for (self.peers.items[0..limit]) |peer| {
+            switch (peer.state) {
+                .succeeded => succeeded += 1,
+                .waiting, .not_contacted => {
+                    blocked = true;
+                    break;
+                },
+                .failed => {},
+            }
+        }
+        if (!blocked and succeeded == limit) {
+            self.state = .finished;
+            return;
+        }
+
+        if (self.num_waiting == 0) {
+            for (self.peers.items) |peer| {
+                if (peer.state == .not_contacted) return;
+            }
+            self.state = .finished;
+        }
+    }
+};
+
+fn appendUniqueDistance(out: []u16, len: *usize, distance: u16) void {
+    for (out[0..len.*]) |existing| {
+        if (existing == distance) return;
+    }
+    out[len.*] = distance;
+    len.* += 1;
+}
+
+pub fn findNodeLogDistances(target: *const NodeId, peer_id: *const NodeId, max_distances: usize, out: []u16) usize {
+    if (max_distances == 0) return 0;
+
+    var len: usize = 0;
+    var wire_distance: u16 = 1;
+    if (kbucket.logDistance(target, peer_id)) |distance| {
+        wire_distance = @as(u16, distance) + 1;
+    }
+
+    appendUniqueDistance(out, &len, wire_distance);
+
+    var diff: u16 = 1;
+    while (len < max_distances and diff <= 256) : (diff += 1) {
+        if (wire_distance + diff <= 256) appendUniqueDistance(out, &len, wire_distance + diff);
+        if (len >= max_distances) break;
+        if (wire_distance > diff) appendUniqueDistance(out, &len, wire_distance - diff);
+    }
+    return len;
+}
+
+fn testNodeId(last_byte: u8) NodeId {
+    var node_id = [_]u8{0} ** 32;
+    node_id[31] = last_byte;
+    return node_id;
+}
+
+fn testConfig(num_results: usize, parallelism: usize) Config {
+    return .{
+        .num_results = num_results,
+        .parallelism = parallelism,
+        .request_limit = 3,
+        .timeout_ms = 60_000,
+    };
+}
+
+test "discv5 lookup: initial peers are bounded to requested result count" {
+    const alloc = std.testing.allocator;
+    const config = testConfig(3, 2);
+    const target = testNodeId(0);
+    const seeds = [_]NodeId{
+        testNodeId(1),
+        testNodeId(2),
+        testNodeId(3),
+        testNodeId(4),
+        testNodeId(5),
+    };
+
+    var lookup = try Lookup.init(alloc, target, &seeds, 0, config);
+    defer lookup.deinit(alloc);
+
+    try std.testing.expectEqual(config.num_results, lookup.peers.items.len);
+    try std.testing.expectEqual(testNodeId(1), lookup.peers.items[0].node_id);
+    try std.testing.expectEqual(testNodeId(2), lookup.peers.items[1].node_id);
+    try std.testing.expectEqual(testNodeId(3), lookup.peers.items[2].node_id);
+}
+
+test "discv5 lookup: success from unknown peer does not add candidates" {
+    const alloc = std.testing.allocator;
+    const config = testConfig(3, 2);
+    const target = testNodeId(0);
+    const seeds = [_]NodeId{testNodeId(10)};
+    const returned = [_]NodeId{ testNodeId(1), testNodeId(2) };
+
+    var lookup = try Lookup.init(alloc, target, &seeds, 0, config);
+    defer lookup.deinit(alloc);
+
+    lookup.onSuccess(&testNodeId(99), &returned, config);
+
+    try std.testing.expectEqual(@as(usize, 1), lookup.peers.items.len);
+    try std.testing.expectEqual(testNodeId(10), lookup.peers.items[0].node_id);
+}
+
+test "discv5 lookup: candidate growth is bounded across responses" {
+    const alloc = std.testing.allocator;
+    const config = testConfig(3, 2);
+    const target = testNodeId(0);
+    const seeds = [_]NodeId{testNodeId(250)};
+    const first_batch = [_]NodeId{
+        testNodeId(33), testNodeId(34), testNodeId(35), testNodeId(36),
+        testNodeId(37), testNodeId(38), testNodeId(39), testNodeId(40),
+        testNodeId(41), testNodeId(42), testNodeId(43), testNodeId(44),
+        testNodeId(45), testNodeId(46), testNodeId(47), testNodeId(48),
+    };
+    const second_batch = [_]NodeId{
+        testNodeId(1),  testNodeId(2),  testNodeId(3),  testNodeId(4),
+        testNodeId(5),  testNodeId(6),  testNodeId(7),  testNodeId(8),
+        testNodeId(9),  testNodeId(10), testNodeId(11), testNodeId(12),
+        testNodeId(13), testNodeId(14), testNodeId(15), testNodeId(16),
+    };
+    const third_batch = [_]NodeId{
+        testNodeId(17), testNodeId(18), testNodeId(19), testNodeId(20),
+        testNodeId(21), testNodeId(22), testNodeId(23), testNodeId(24),
+        testNodeId(25), testNodeId(26), testNodeId(27), testNodeId(28),
+        testNodeId(29), testNodeId(30), testNodeId(31), testNodeId(32),
+    };
+
+    var lookup = try Lookup.init(alloc, target, &seeds, 0, config);
+    defer lookup.deinit(alloc);
+
+    const first_peer = lookup.nextPeer(config).?;
+    lookup.onSuccess(&first_peer, &first_batch, config);
+    const second_peer = lookup.nextPeer(config).?;
+    lookup.onSuccess(&second_peer, &second_batch, config);
+    const third_peer = lookup.nextPeer(config).?;
+    lookup.onSuccess(&third_peer, &third_batch, config);
+
+    try std.testing.expectEqual(MAX_CANDIDATES, lookup.peers.items.len);
+    const first_index = lookup.findPeerIndex(&first_peer) orelse return error.ContactedPeerEvicted;
+    try std.testing.expectEqual(PeerState.succeeded, lookup.peers.items[first_index].state);
+    for (lookup.peers.items[1..], lookup.peers.items[0 .. lookup.peers.items.len - 1]) |peer, previous| {
+        const peer_distance = kbucket.xorDistance(&target, &peer.node_id);
+        const previous_distance = kbucket.xorDistance(&target, &previous.node_id);
+        try std.testing.expect(!std.mem.lessThan(u8, &peer_distance, &previous_distance));
+    }
+}
+
+test "discv5 lookup: invalid bounds fail before allocation" {
+    const alloc = std.testing.allocator;
+    const target = testNodeId(0);
+    const no_seeds = [_]NodeId{};
+
+    try std.testing.expectError(error.InvalidNumResults, Lookup.init(alloc, target, &no_seeds, 0, testConfig(0, 1)));
+    try std.testing.expectError(error.InvalidNumResults, Lookup.init(alloc, target, &no_seeds, 0, testConfig(MAX_RESULTS + 1, 1)));
+    try std.testing.expectError(error.InvalidParallelism, Lookup.init(alloc, target, &no_seeds, 0, testConfig(1, 0)));
+    try std.testing.expectError(error.InvalidParallelism, Lookup.init(alloc, target, &no_seeds, 0, testConfig(1, MAX_PARALLELISM + 1)));
+}

--- a/src/discv5/util.zig
+++ b/src/discv5/util.zig
@@ -1,0 +1,34 @@
+//! Small cross-cutting helpers shared by the discv5 protocol and service layers.
+
+const std = @import("std");
+const Io = std.Io;
+const net = Io.net;
+const Address = net.IpAddress;
+const NodeId = @import("enr.zig").NodeId;
+
+/// Bind a UDP (datagram) socket to `address`, restricting IPv6 sockets to v6-only.
+pub fn bindDatagramSocket(io: Io, address: Address) !net.Socket {
+    return try net.IpAddress.bind(&address, io, .{
+        .mode = .dgram,
+        .ip6_only = switch (address) {
+            .ip4 => false,
+            .ip6 => true,
+        },
+    });
+}
+
+/// First 4 bytes of a node id as lowercase hex, for compact logging.
+pub fn shortNodeId(node_id: *const NodeId) [8]u8 {
+    return std.fmt.bytesToHex(node_id[0..4].*, .lower);
+}
+
+/// Current real-clock time in nanoseconds.
+pub fn nowNs(io: Io) i64 {
+    return @intCast(Io.Timestamp.now(io, .real).toNanoseconds());
+}
+
+/// Current real-clock Unix time in milliseconds (clamped at 0).
+pub fn nowMs(io: Io) u64 {
+    const ms = Io.Timestamp.now(io, .real).toMilliseconds();
+    return if (ms < 0) 0 else @intCast(ms);
+}

--- a/src/discv5/wire_test_vectors.zig
+++ b/src/discv5/wire_test_vectors.zig
@@ -1,0 +1,229 @@
+//! Official discv5 wire test vectors
+//!
+//! Tests from discv5-wire-test-vectors.md
+
+const std = @import("std");
+const hex = @import("hex");
+const packet = @import("protocol/packet.zig");
+const secp = @import("secp256k1.zig");
+const session = @import("protocol/session.zig");
+const Aes128Gcm = std.crypto.aead.aes_gcm.Aes128Gcm;
+
+const node_a_id = hex.hexToBytesComptime(32, "aaaa8419e9f49d0083561b48287df592939a8d19947d8c0ef88f2a4856a69fbb");
+const node_b_id = hex.hexToBytesComptime(32, "bbbb9d047f0488c0b5a93c1c3f2d8bafc7c8ff337024a55434a0d0555de64db9");
+
+// =========== Packet decoding test vectors ===========
+
+test "discv5 wire: ping message packet (flag 0)" {
+    // 95 bytes (190 hex chars)
+    const raw_hex =
+        "00000000000000000000000000000000088b3d4342774649325f313964a39e55" ++
+        "ea96c005ad52be8c7560413a7008f16c9e6d2f43bbea8814a546b7409ce783d3" ++
+        "4c4f53245d08dab84102ed931f66d1492acb308fa1c6715b9d139b81acbdcc";
+    var raw: [95]u8 = undefined;
+    _ = try std.fmt.hexToBytes(&raw, raw_hex);
+
+    const parsed = try packet.decode(&raw, &node_b_id);
+
+    try std.testing.expectEqual(packet.FLAG_MESSAGE, parsed.static_header.flag);
+
+    const expected_nonce = hex.hexToBytesComptime(12, "ffffffffffffffffffffffff");
+    try std.testing.expectEqualSlices(u8, &expected_nonce, &parsed.static_header.nonce);
+
+    // Decrypt: read-key = 0x00000000000000000000000000000000
+    const read_key = [_]u8{0} ** 16;
+    var pt_buf: [packet.MAX_PACKET_SIZE]u8 = undefined;
+    var ad_buf: [packet.MAX_PACKET_SIZE]u8 = undefined;
+    const pt = try packet.decryptMessageInto(
+        &pt_buf,
+        &ad_buf,
+        &read_key,
+        &parsed.static_header.nonce,
+        parsed.message_ciphertext,
+        &parsed.masking_iv,
+        parsed.header_raw,
+    );
+
+    try std.testing.expectEqual(@as(u8, 0x01), pt[0]);
+
+    const msg = @import("protocol/message.zig");
+    const ping = try msg.Ping.decode(pt);
+    try std.testing.expectEqualSlices(u8, &[_]u8{ 0x00, 0x00, 0x00, 0x01 }, ping.req_id.slice());
+    try std.testing.expectEqual(@as(u64, 2), ping.enr_seq);
+}
+
+test "discv5 wire: WHOAREYOU packet (flag 1)" {
+    const raw_hex =
+        "00000000000000000000000000000000088b3d434277464933a1ccc59f5967ad" ++
+        "1d6035f15e528627dde75cd68292f9e6c27d6b66c8100a873fcbaed4e16b8d";
+    var raw: [63]u8 = undefined;
+    _ = try std.fmt.hexToBytes(&raw, raw_hex);
+
+    const parsed = try packet.decode(&raw, &node_b_id);
+
+    try std.testing.expectEqual(packet.FLAG_WHOAREYOU, parsed.static_header.flag);
+    try std.testing.expectEqual(@as(u16, 24), parsed.static_header.authdata_size);
+
+    const id_nonce = parsed.authdata_raw[0..16];
+    const expected_nonce = hex.hexToBytesComptime(16, "0102030405060708090a0b0c0d0e0f10");
+    try std.testing.expectEqualSlices(u8, &expected_nonce, id_nonce);
+
+    const enr_seq_bytes = parsed.authdata_raw[16..24];
+    const enr_seq = std.mem.readInt(u64, enr_seq_bytes[0..8], .big);
+    try std.testing.expectEqual(@as(u64, 0), enr_seq);
+}
+
+test "discv5 wire: ping handshake packet (flag 2, no ENR)" {
+    const raw_hex =
+        "00000000000000000000000000000000088b3d4342774649305f313964a39e55" ++
+        "ea96c005ad521d8c7560413a7008f16c9e6d2f43bbea8814a546b7409ce783d3" ++
+        "4c4f53245d08da4bb252012b2cba3f4f374a90a75cff91f142fa9be3e0a5f3ef" ++
+        "268ccb9065aeecfd67a999e7fdc137e062b2ec4a0eb92947f0d9a74bfbf44dfb" ++
+        "a776b21301f8b65efd5796706adff216ab862a9186875f9494150c4ae06fa4d1" ++
+        "f0396c93f215fa4ef524f1eadf5f0f4126b79336671cbcf7a885b1f8bd2a5d83" ++
+        "9cf8";
+    var raw: [194]u8 = undefined;
+    _ = try std.fmt.hexToBytes(&raw, raw_hex);
+
+    const parsed = try packet.decode(&raw, &node_b_id);
+
+    try std.testing.expectEqual(packet.FLAG_HANDSHAKE, parsed.static_header.flag);
+
+    const authdata = parsed.authdata_raw;
+    const src_id = authdata[0..32];
+    try std.testing.expectEqualSlices(u8, &node_a_id, src_id);
+
+    const sig_size = authdata[32];
+    const eph_key_size = authdata[33];
+    try std.testing.expectEqual(@as(u8, 64), sig_size);
+    try std.testing.expectEqual(@as(u8, 33), eph_key_size);
+
+    const eph_pubkey = authdata[34 + sig_size .. 34 + sig_size + eph_key_size];
+    const expected_eph_pubkey = hex.hexToBytesComptime(33, "039a003ba6517b473fa0cd74aefe99dadfdb34627f90fec6362df85803908f53a5");
+    try std.testing.expectEqualSlices(u8, &expected_eph_pubkey, eph_pubkey);
+
+    // Decrypt: read-key = 0x4f9fac6de7567d1e3b1241dffe90f662
+    const read_key = hex.hexToBytesComptime(16, "4f9fac6de7567d1e3b1241dffe90f662");
+    const nonce = hex.hexToBytesComptime(12, "ffffffffffffffffffffffff");
+
+    var pt_buf: [packet.MAX_PACKET_SIZE]u8 = undefined;
+    var ad_buf: [packet.MAX_PACKET_SIZE]u8 = undefined;
+    const pt = try packet.decryptMessageInto(
+        &pt_buf,
+        &ad_buf,
+        &read_key,
+        &nonce,
+        parsed.message_ciphertext,
+        &parsed.masking_iv,
+        parsed.header_raw,
+    );
+
+    try std.testing.expectEqual(@as(u8, 0x01), pt[0]);
+    const msg = @import("protocol/message.zig");
+    const ping = try msg.Ping.decode(pt);
+    try std.testing.expectEqual(@as(u64, 1), ping.enr_seq);
+}
+
+test "discv5 wire: ping handshake with ENR (flag 2)" {
+    const raw_hex =
+        "00000000000000000000000000000000088b3d4342774649305f313964a39e55" ++
+        "ea96c005ad539c8c7560413a7008f16c9e6d2f43bbea8814a546b7409ce783d3" ++
+        "4c4f53245d08da4bb23698868350aaad22e3ab8dd034f548a1c43cd246be9856" ++
+        "2fafa0a1fa86d8e7a3b95ae78cc2b988ded6a5b59eb83ad58097252188b902b2" ++
+        "1481e30e5e285f19735796706adff216ab862a9186875f9494150c4ae06fa4d1" ++
+        "f0396c93f215fa4ef524e0ed04c3c21e39b1868e1ca8105e585ec17315e755e6" ++
+        "cfc4dd6cb7fd8e1a1f55e49b4b5eb024221482105346f3c82b15fdaae36a3bb1" ++
+        "2a494683b4a3c7f2ae41306252fed84785e2bbff3b022812d0882f06978df84a" ++
+        "80d443972213342d04b9048fc3b1d5fcb1df0f822152eced6da4d3f6df27e70e" ++
+        "4539717307a0208cd208d65093ccab5aa596a34d7511401987662d8cf62b1394" ++
+        "71";
+    var raw: [321]u8 = undefined;
+    _ = try std.fmt.hexToBytes(&raw, raw_hex);
+
+    const parsed = try packet.decode(&raw, &node_b_id);
+
+    try std.testing.expectEqual(packet.FLAG_HANDSHAKE, parsed.static_header.flag);
+
+    const authdata = parsed.authdata_raw;
+    const sig_size = authdata[32];
+    const eph_key_size = authdata[33];
+
+    const record_start = 34 + sig_size + eph_key_size;
+    try std.testing.expect(authdata.len > record_start);
+
+    // Decrypt: read-key = 0x53b1c075f41876423154e157470c2f48
+    const read_key = hex.hexToBytesComptime(16, "53b1c075f41876423154e157470c2f48");
+    const nonce = hex.hexToBytesComptime(12, "ffffffffffffffffffffffff");
+
+    var pt_buf: [packet.MAX_PACKET_SIZE]u8 = undefined;
+    var ad_buf: [packet.MAX_PACKET_SIZE]u8 = undefined;
+    const pt = try packet.decryptMessageInto(
+        &pt_buf,
+        &ad_buf,
+        &read_key,
+        &nonce,
+        parsed.message_ciphertext,
+        &parsed.masking_iv,
+        parsed.header_raw,
+    );
+
+    try std.testing.expectEqual(@as(u8, 0x01), pt[0]);
+    const msg = @import("protocol/message.zig");
+    const ping = try msg.Ping.decode(pt);
+    try std.testing.expectEqual(@as(u64, 1), ping.enr_seq);
+}
+
+// =========== Cryptographic primitive test vectors ===========
+
+test "discv5 crypto: ECDH" {
+    const public_key = hex.hexToBytesComptime(33, "039961e4c2356d61bedb83052c115d311acb3a96f5777296dcf297351130266231");
+    const secret_key = hex.hexToBytesComptime(32, "fb757dc581730490a1d7a00deea65e9b1936924caaea8f44d476014856b68736");
+    const key_pair = try secp.keyPairFromSecret(&secret_key);
+    const expected = hex.hexToBytesComptime(33, "033b11a2a1f214567e1537ce5e509ffd9b21373247f2a3ff6841f4976f53165e7e");
+
+    const shared = try session.ecdh(&public_key, &key_pair);
+    try std.testing.expectEqualSlices(u8, &expected, &shared);
+}
+
+test "discv5 crypto: key derivation (HKDF)" {
+    const eph_key = hex.hexToBytesComptime(32, "fb757dc581730490a1d7a00deea65e9b1936924caaea8f44d476014856b68736");
+    const eph_key_pair = try secp.keyPairFromSecret(&eph_key);
+    const dest_pubkey = hex.hexToBytesComptime(33, "0317931e6e0840220642f230037d285d122bc59063221ef3226b1f403ddc69ca91");
+    const challenge_data = hex.hexToBytesComptime(63, "000000000000000000000000000000006469736376350001010102030405060708090a0b0c00180102030405060708090a0b0c0d0e0f100000000000000000");
+
+    const expected_initiator = hex.hexToBytesComptime(16, "dccc82d81bd610f4f76d3ebe97a40571");
+    const expected_recipient = hex.hexToBytesComptime(16, "ac74bb8773749920b0d3a8881c173ec5");
+
+    const keys = try session.deriveKeys(&eph_key_pair, &dest_pubkey, &node_a_id, &node_b_id, &challenge_data);
+    try std.testing.expectEqualSlices(u8, &expected_initiator, &keys.initiator_key);
+    try std.testing.expectEqualSlices(u8, &expected_recipient, &keys.recipient_key);
+}
+
+test "discv5 crypto: id-nonce signing" {
+    const static_key_pair = secp.KeyPair.generate(std.Options.debug_io);
+    const static_pubkey = secp.compressedPubkey(&static_key_pair);
+    const challenge_data = hex.hexToBytesComptime(63, "000000000000000000000000000000006469736376350001010102030405060708090a0b0c00180102030405060708090a0b0c0d0e0f100000000000000000");
+    const eph_key_pair = secp.KeyPair.generate(std.Options.debug_io);
+    const eph_pubkey = secp.compressedPubkey(&eph_key_pair);
+
+    const sig = try session.signIdNonce(&static_key_pair, &challenge_data, &eph_pubkey, &node_b_id);
+    try session.verifyIdSignature(&sig, &static_pubkey, &challenge_data, &eph_pubkey, &node_b_id);
+}
+
+test "discv5 crypto: AES-GCM encryption" {
+    const enc_key = hex.hexToBytesComptime(16, "9f2d77db7004bf8a1a85107ac686990b");
+    const nonce = hex.hexToBytesComptime(12, "27b5af763c446acd2749fe8e");
+    const pt = hex.hexToBytesComptime(4, "01c20101");
+    const ad = hex.hexToBytesComptime(32, "93a7400fa0d6a694ebc24d5cf570f65d04215b6ac00757875e3f3a5f42107903");
+    const expected_ct = hex.hexToBytesComptime(20, "a5d12a2d94b8ccb3ba55558229867dc13bfa3648");
+
+    var ct_buf: [4]u8 = undefined;
+    var tag: [16]u8 = undefined;
+    Aes128Gcm.encrypt(&ct_buf, &tag, &pt, &ad, nonce, enc_key);
+
+    var result: [20]u8 = undefined;
+    @memcpy(result[0..4], &ct_buf);
+    @memcpy(result[4..], &tag);
+
+    try std.testing.expectEqualSlices(u8, &expected_ct, &result);
+}


### PR DESCRIPTION
Adds a standalone Discovery v5 implementation built around Zig 0.16 `std.Io`.

The module includes packet and message codecs, ENR and canonical RLP handling, handshake and session recovery, routing-table and lookup behavior, TALK requests, address voting, rate limiting, bounded ingress and event queues, and a generic actor runtime. Packet-facing state and parsing are explicitly bounded, malformed remote inputs are rejected without assertions, and FINDNODE only relays locally trusted or endpoint-verified ENRs.

Adds a `std.Io.Threaded` discovery example and build targets. Runtime shutdown follows caller ownership: stop admission, await the caller-owned task group, then deinitialize.