### PR TITLE
chore: upgrade zapi to v4.0.0

### DIFF
--- a/bindings/napi/bls_verifier.zig
+++ b/bindings/napi/bls_verifier.zig
@@ -1,4 +1,3 @@
-const std = @import("std");
 const zapi = @import("zapi:zapi");
 const js = zapi.js;
 const bls = @import("bls");
@@ -39,16 +38,6 @@ const SameMessageSet = struct {
     signature: js.Uint8Array,
 };
 
-// TODO(zapi): Replace with value.toU32Exact() after next zapi release: see https://github.com/ChainSafe/zapi/pull/71
-fn uint32(value: js.Number) !u32 {
-    const number = try value.toF64();
-    const max_u32: f64 = @floatFromInt(std.math.maxInt(u32));
-    if (!std.math.isFinite(number) or number < 0 or number > max_u32 or @floor(number) != number) {
-        return error.InvalidUint32;
-    }
-    return @intFromFloat(number);
-}
-
 /// Verify indexed, aggregate, and raw-pubkey signature sets synchronously.
 ///
 /// Returns false on cryptographic failure. Throws for malformed inputs and
@@ -64,7 +53,7 @@ pub fn verifySignatureSets(sets: js.Array) !js.Boolean {
     for (0..count) |i| {
         const value = try sets.get(@intCast(i));
         const set = try (try value.asObject(CommonSet)).get();
-        const set_type: SetType = switch (try uint32(set.type)) {
+        const set_type: SetType = switch (try set.type.toU32Exact()) {
             @intFromEnum(SetType.indexed) => .indexed,
             @intFromEnum(SetType.aggregate) => .aggregate,
             @intFromEnum(SetType.single) => .single,
@@ -78,7 +67,7 @@ pub fn verifySignatureSets(sets: js.Array) !js.Boolean {
             .indexed => blk: {
                 if (!pubkeys.state.initialized) return error.PubkeyIndexNotInitialized;
                 const indexed = try (try value.asObject(IndexedSet)).get();
-                const index = try uint32(indexed.index);
+                const index = try indexed.index.toU32Exact();
                 break :blk pubkeys.state.cache.getPubkey(io, index) orelse
                     return error.PubkeyIndexNotFound;
             },
@@ -130,7 +119,7 @@ pub fn verifySignatureSetsSameMessage(sets: js.Array, message: js.Uint8Array) !j
     for (0..count) |i| {
         const value = try sets.get(@intCast(i));
         const set = try (try value.asObject(SameMessageSet)).get();
-        const index = try uint32(set.index);
+        const index = try set.index.toU32Exact();
         const public_key = pubkeys.state.cache.getPubkey(io, index) orelse
             return error.PubkeyIndexNotFound;
 

--- a/bindings/napi/blst.zig
+++ b/bindings/napi/blst.zig
@@ -14,6 +14,7 @@ const builtin = @import("builtin");
 const zapi = @import("zapi:zapi");
 const js = zapi.js;
 const napi = zapi.napi;
+const addon_identity = @import("zapi_addon_identity");
 const bls = @import("bls");
 const bls_verifier = bls.verifier;
 
@@ -100,7 +101,16 @@ fn formatHex(bytes: []const u8) !js.String {
 
 fn unwrapClass(comptime T: type, value: js.Value) !*T {
     const raw = value.toValue();
-    return js.convertArg(*T, raw.value, raw.env);
+    return js.convertArg(*T, addon_identity, raw.value, raw.env);
+}
+
+/// Materializes a DSL class instance as a low-level `napi.Value`.
+///
+/// The DSL cannot convert these for us: both callers assemble a plain
+/// `{pk, sig}` object, and one runs in an async completion callback outside
+/// the DSL's callback context.
+fn classToValue(comptime T: type, env: napi.Env, instance: T) napi.Value {
+    return .{ .env = env.env, .value = js.convertReturn(T, addon_identity, instance, env.env) };
 }
 
 pub const PublicKey = struct {
@@ -647,8 +657,8 @@ pub fn aggregateWithRandomness(sets: js.Array) !js.Value {
     var result_sig: NativeSignature = .{};
     bls.c.blst_p2_to_affine(&result_sig.point, &p2_ret);
 
-    const pk_value = napi.Value{ .env = env.env, .value = js.convertReturn(PublicKey, .{ .raw = result_pk }, env.env) };
-    const sig_value = napi.Value{ .env = env.env, .value = js.convertReturn(Signature, .{ .raw = result_sig }, env.env) };
+    const pk_value = classToValue(PublicKey, env, .{ .raw = result_pk });
+    const sig_value = classToValue(Signature, env, .{ .raw = result_sig });
 
     const result = try env.createObject();
     try result.setNamedProperty("pk", pk_value);
@@ -734,8 +744,8 @@ fn settle(env: napi.Env, status: napi.status.Status, data: *AsyncAggRandData) !v
         return rejectWithError(env, data.deferred, "asyncAggregateWithRandomness", @errorName(err));
     }
 
-    const pk_value = napi.Value{ .env = env.env, .value = js.convertReturn(PublicKey, .{ .raw = data.pk_out }, env.env) };
-    const sig_value = napi.Value{ .env = env.env, .value = js.convertReturn(Signature, .{ .raw = data.sig_out }, env.env) };
+    const pk_value = classToValue(PublicKey, env, .{ .raw = data.pk_out });
+    const sig_value = classToValue(Signature, env, .{ .raw = data.sig_out });
 
     const result = try env.createObject();
     try result.setNamedProperty("pk", pk_value);

--- a/bindings/napi/pool.zig
+++ b/bindings/napi/pool.zig
@@ -56,7 +56,7 @@ pub fn ensureCapacity(new_size: js.Number) !void {
         return error.PoolNotInitialized;
     }
 
-    const requested = new_size.assertU32();
+    const requested = try new_size.toU32Exact();
     const old_size = state.pool().nodes.capacity;
     if (requested <= old_size) {
         return;

--- a/bindings/napi/pubkeys.zig
+++ b/bindings/napi/pubkeys.zig
@@ -75,7 +75,7 @@ pub fn load(file_path: js.String, max_capacity: js.Number) !void {
 
     const path = try file_path.toOwnedSlice(allocator);
     defer allocator.free(path);
-    const capacity_limit = try max_capacity.toU32();
+    const capacity_limit = try max_capacity.toU32Exact();
     const io = js.io();
 
     const file = try std.Io.Dir.openFile(.cwd(), io, path, .{});
@@ -126,7 +126,7 @@ pub fn getIndex(pubkey: js.Uint8Array) !js.Value {
 pub fn get(index: js.Number) !?blst_bindings.PublicKey {
     if (!state.initialized) return error.PubkeyIndexNotInitialized;
 
-    const idx = try index.toU32();
+    const idx = try index.toU32Exact();
     const io = js.io();
     const public_key = state.cache.getPubkey(io, idx) orelse return null;
     return .{ .raw = public_key };
@@ -136,7 +136,7 @@ pub fn get(index: js.Number) !?blst_bindings.PublicKey {
 pub fn getPubkeyBytes(index: js.Number) !?js.Uint8Array {
     if (!state.initialized) return error.PubkeyIndexNotInitialized;
 
-    const idx = try index.toU32();
+    const idx = try index.toU32Exact();
     const io = js.io();
     const pubkey_bytes = state.cache.getPubkeyBytes(io, idx) orelse return null;
     return js.Uint8Array.from(pubkey_bytes[0..]);
@@ -165,7 +165,7 @@ pub fn aggregate(indices: js.Array) !blst_bindings.PublicKey {
     defer if (len > indices_stack.len) allocator.free(exact_indices);
 
     for (0..len) |i| {
-        exact_indices[i] = try (try indices.getNumber(@intCast(i))).toU32();
+        exact_indices[i] = try (try indices.getNumber(@intCast(i))).toU32Exact();
     }
 
     const io = js.io();
@@ -184,7 +184,7 @@ pub fn aggregate(indices: js.Array) !blst_bindings.PublicKey {
 pub fn append(index: js.Number, pubkey: js.Uint8Array) !void {
     if (!state.initialized) return error.PubkeyIndexNotInitialized;
 
-    const idx = try index.toU32();
+    const idx = try index.toU32Exact();
     const io = js.io();
 
     const pubkey_slice = try pubkey.toSlice();
@@ -239,7 +239,7 @@ pub fn size() !js.Number {
 pub fn ensureCapacity(new_size: js.Number) !void {
     if (!state.initialized) return error.PubkeyIndexNotInitialized;
 
-    const requested = try new_size.toU32();
+    const requested = try new_size.toU32Exact();
     const io = js.io();
     try state.cache.ensureTotalCapacity(io, requested);
 }

--- a/bindings/napi/root.zig
+++ b/bindings/napi/root.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 const builtin = @import("builtin");
 const js = @import("zapi:zapi").js;
+const addon_identity = @import("zapi_addon_identity");
 pub const pool = @import("./pool.zig");
 pub const shuffle = @import("./shuffle.zig");
 pub const config = @import("./config.zig");
@@ -70,5 +71,9 @@ fn cleanup(new_ref_count: u32) void {
 }
 
 comptime {
-    js.exportModule(@This(), .{ .init = init, .cleanup = cleanup });
+    js.exportModule(@This(), .{
+        .identity = addon_identity,
+        .init = init,
+        .cleanup = cleanup,
+    });
 }

--- a/bindings/test/bls-verifier.test.ts
+++ b/bindings/test/bls-verifier.test.ts
@@ -171,8 +171,8 @@ describe("bls verifier", () => {
             type: BLS_VERIFIER_SET_TYPE.indexed,
           },
         ])
-      ).toThrow("InvalidUint32");
-      expect(() => verifySignatureSetsSameMessage([{index, signature}], signingRoot)).toThrow("InvalidUint32");
+      ).toThrow("InvalidUnsignedInteger");
+      expect(() => verifySignatureSetsSameMessage([{index, signature}], signingRoot)).toThrow("InvalidUnsignedInteger");
     }
   });
 

--- a/bindings/test/pubkeys.test.ts
+++ b/bindings/test/pubkeys.test.ts
@@ -251,4 +251,24 @@ describe("pubkeys", () => {
     expect(() => pubkeyCache.append(pubkeyCache.capacity, keypairs[0].pubkeyBytes)).toThrow();
     expect(pubkeyCache.size).toBe(sizeBefore);
   });
+
+  // Validator indices and capacities must not be coerced: ToUint32 would wrap
+  // -1 to 2**32-1 and truncate fractions, silently addressing the wrong entry
+  // or reserving an absurd allocation.
+  it("rejects non-integer indices and capacities instead of coercing them", () => {
+    const sizeBefore = pubkeyCache.size;
+    const capacityBefore = pubkeyCache.capacity;
+
+    for (const index of [-1, 0.5, 2 ** 32, Number.NaN, Number.POSITIVE_INFINITY]) {
+      expect(() => pubkeyCache.get(index)).toThrow("InvalidUnsignedInteger");
+      expect(() => pubkeyCache.getPubkeyBytes(index)).toThrow("InvalidUnsignedInteger");
+      expect(() => pubkeyCache.aggregate([index])).toThrow("InvalidUnsignedInteger");
+      expect(() => pubkeyCache.append(index, keypairs[0].pubkeyBytes)).toThrow("InvalidUnsignedInteger");
+      expect(() => pubkeyCache.ensureCapacity(index)).toThrow("InvalidUnsignedInteger");
+    }
+
+    expect(pubkeyCache.size).toBe(sizeBefore);
+    expect(pubkeyCache.capacity).toBe(capacityBefore);
+    expectCacheContents();
+  });
 });

--- a/build.zig
+++ b/build.zig
@@ -1,7 +1,13 @@
 const std = @import("std");
+const zapi = @import("zapi");
 const zbuild = @import("zbuild");
 
 pub fn build(b: *std.Build) !void {
     @setEvalBranchQuota(200_000);
-    _ = try zbuild.configureBuild(b, @import("build.zig.zon"), .{});
+    const manifest = @import("build.zig.zon");
+    const result = try zbuild.configureBuild(b, manifest, .{});
+
+    // zapi derives each DSL class's `napi_type_tag` from this identity, so class
+    // objects from a differently-built addon are rejected instead of unwrapped.
+    zapi.addAddonIdentity(b, result.library("bindings").?, manifest);
 }

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -40,8 +40,8 @@
             .hash = "zig_yaml-0.1.0-C1161kFWAwDxjKAFmklKwWVDvz2mmq0Q__bDhGGjeyd3",
         },
         .zapi = .{
-            .url = "https://github.com/ChainSafe/zapi/archive/ab42ab08de92e1ea1f9f8a3f124e5c4bf55d564d.tar.gz",
-            .hash = "zapi-3.1.0-rIqzUXatBABpDFl_itCopyVIJdcEHttbhye7WfTNoHCR",
+            .url = "https://github.com/ChainSafe/zapi/archive/ca55a240a07cbeaba7ac543125a108bca4076a5a.tar.gz",
+            .hash = "zapi-4.0.0-rIqzUasFBQBedS0-MCZXl1BnemstdjIhb5OUdGD305rI",
         },
         .zbench = .{
             .url = "git+https://github.com/hendriknielaender/zBench#b2b89c475e3ef1bb2bd71255c80478a82d3e0ca8",


### PR DESCRIPTION
Upgrades zapi from our pin at `ab42ab0` to the `v4.0.0` tag.

### Breaking: addon identity (zapi#67)
- Class `napi_type_tag` now derives from package name/version/fingerprint + addon name, not just the Zig type name.
- `build.zig` calls `addAddonIdentity`, which generates the `zapi_addon_identity` module — no source file to look for.
- `exportModule` consumes it once, covering all 4 DSL classes and every DSL function.
- `blst.zig` needs it explicitly at 5 low-level `convertArg`/`convertReturn` sites, funnelled through `unwrapClass` and a new `classToValue`.

### Adopted: `Number.toU32Exact()` (zapi#71)
- Replaces the hand-rolled validator in `bls_verifier.zig` that had a `TODO(zapi)` waiting on it.
- Closes the same unguarded gap in 5 other places: `toU32()`/`assertU32()` coerce via `ToUint32`, wrapping `-1` to `4294967295` and truncating fractions.
  - `pubkeys.append(-1, …)` → appends at index 4294967295
  - `pubkeys.ensureCapacity(-1)` / `pool.ensureCapacity(-1)` → reserves ~4.29e9 entries
  - `pubkeys.load(path, -1)` → capacity limit effectively unbounded
  - `pubkeys.aggregate([1.5])` → silently aggregates validator 1, no error
- **API change:** thrown code moves from `InvalidUint32` to zapi's `InvalidUnsignedInteger`.

### Evaluated, not adopted
- Owned typed arrays (zapi#68) — no win; we already write straight into the JS-heap ArrayBuffer via `alloc` + `serializeIntoBytes`.
- Const/enum export (zapi#73) — nothing to adopt; confirmed our surface is unchanged.

### Testing
- 203/203 runnable tests pass. Debug + ReleaseSafe builds, `zig fmt --check`, `biome check` clean.
- `beaconStateView.test.ts` and `teardown.test.ts` did not run — need `fixtures/era/*.era`, host unreachable locally. This is the one DSL class path untested.
- Dep hash computed from a local `git archive` of `zapi-v4.0.0` (`zig fetch` couldn't reach codeload). Should match, but a clean CI fetch is the real check.
