### PR TITLE
chore: prepare 1.0.0 release

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -7,8 +7,6 @@
   "versioning": "default",
   "prerelease": false,
   "prerelease-type": "rc",
-  "bump-minor-pre-major": true,
-  "bump-patch-for-minor-pre-major": true,
   "pull-request-title-pattern": "chore: release ${version}",
   "changelog-sections": [
     {


### PR DESCRIPTION
- remove the pre-1.0 minor and patch bump overrides
- direct Release Please to update the pending release from 0.1.3 to 1.0.0
- retain the temporary `last-release-sha` bootstrap anchor until the first automated release completes

The implementation and repository analysis were primarily AI-authored and validated locally.

Release-As: 1.0.0