### PR TITLE
refactor(shuffle): drop JS signature comments and fix balance param name

### DIFF
--- a/bindings/napi/shuffle.zig
+++ b/bindings/napi/shuffle.zig
@@ -18,8 +18,6 @@ fn byteCountFromJs(rand_byte_count: js.Number) !sons.ByteCount {
     };
 }
 
-/// JS: innerShuffleList(out: Uint32Array, seed: Uint8Array, rounds: number, forwards: boolean): void
-///
 /// Shuffles `out` in place, no allocation.
 pub fn innerShuffleList(list: js.Uint32Array, seed: js.Uint8Array, rounds: js.Number, forwards: js.Boolean) !void {
     const list_u32 = try list.toSlice();
@@ -34,8 +32,6 @@ pub fn innerShuffleList(list: js.Uint32Array, seed: js.Uint8Array, rounds: js.Nu
     try sons.innerShuffleList(u32, list_u32, seed_slice, rounds_i32, is_forwards);
 }
 
-/// JS: unshuffleList(activeIndices: Uint32Array, seed: Uint8Array, rounds: number): Uint32Array
-///
 /// Copies the input array and un-shuffles the copy.
 ///
 /// Returns the copy.
@@ -50,13 +46,12 @@ pub fn unshuffleList(active_indices: js.Uint32Array, seed: js.Uint8Array, rounds
     return out_array;
 }
 
-/// JS: computeProposerIndex(seed, activeIndices, effectiveBalanceIncrements, randByteCount, maxEffectiveBalanceElectra, effectiveBalanceIncrement, rounds): number
 pub fn computeProposerIndex(
     seed: js.Uint8Array,
     active_indices: js.Uint32Array,
     effective_balance_increments: js.Uint16Array,
     rand_byte_count: js.Number,
-    max_effective_balance_electra: js.Number,
+    max_effective_balance: js.Number,
     effective_balance_increment: js.Number,
     rounds: js.Number,
 ) !js.Number {
@@ -66,21 +61,20 @@ pub fn computeProposerIndex(
         try active_indices.toSlice(),
         try effective_balance_increments.toSlice(),
         try byteCountFromJs(rand_byte_count),
-        max_effective_balance_electra.assertI64(),
+        max_effective_balance.assertI64(),
         effective_balance_increment.assertI64(),
         rounds.assertU32(),
     );
     return js.Number.from(result);
 }
 
-/// JS: computeSyncCommitteeIndices(seed, activeIndices, effectiveBalanceIncrements, randByteCount, syncCommitteeSize, maxEffectiveBalanceElectra, effectiveBalanceIncrement, rounds): Uint32Array
 pub fn computeSyncCommitteeIndices(
     seed: js.Uint8Array,
     active_indices: js.Uint32Array,
     effective_balance_increments: js.Uint16Array,
     rand_byte_count: js.Number,
     sync_committee_size: js.Number,
-    max_effective_balance_electra: js.Number,
+    max_effective_balance: js.Number,
     effective_balance_increment: js.Number,
     rounds: js.Number,
 ) !js.Uint32Array {
@@ -91,7 +85,7 @@ pub fn computeSyncCommitteeIndices(
         try effective_balance_increments.toSlice(),
         try byteCountFromJs(rand_byte_count),
         sync_committee_size.assertU32(),
-        max_effective_balance_electra.assertI64(),
+        max_effective_balance.assertI64(),
         effective_balance_increment.assertI64(),
         rounds.assertU32(),
     );

--- a/src/swap_or_not_shuffle/root.zig
+++ b/src/swap_or_not_shuffle/root.zig
@@ -368,7 +368,7 @@ pub fn computeProposerIndex(
     active_indices: []const u32,
     effective_balance_increments: []const u16,
     rand_byte_count: ByteCount,
-    max_effective_balance_electra: i64,
+    max_effective_balance: i64,
     effective_balance_increment: i64,
     rounds: u32,
 ) !u32 {
@@ -379,7 +379,7 @@ pub fn computeProposerIndex(
         active_indices,
         effective_balance_increments,
         rand_byte_count,
-        max_effective_balance_electra,
+        max_effective_balance,
         effective_balance_increment,
         rounds,
     );
@@ -415,7 +415,7 @@ pub fn computeSyncCommitteeIndices(
     effective_balance_increments: []const u16,
     rand_byte_count: ByteCount,
     sync_committee_size: u32,
-    max_effective_balance_electra: i64,
+    max_effective_balance: i64,
     effective_balance_increment: i64,
     rounds: u32,
 ) ![]u32 {
@@ -426,7 +426,7 @@ pub fn computeSyncCommitteeIndices(
         active_indices,
         effective_balance_increments,
         rand_byte_count,
-        max_effective_balance_electra,
+        max_effective_balance,
         effective_balance_increment,
         rounds,
     );


### PR DESCRIPTION
## Summary

Removes the `/// JS: <signature>` comments from the shuffle binding and fixes a name they had drifted on.

- The comments duplicated `bindings/src/index.d.ts`, which is the contract consumers actually read; the pattern is used in a few small binding files but absent from the larger ones (`BeaconStateView.zig`, `blst.zig`).
- They had already drifted: `computeProposerIndex` and `computeSyncCommitteeIndices` called the balance argument `maxEffectiveBalanceElectra`, but those take an explicit `randByteCount` and the pre-electra path passes `MAX_EFFECTIVE_BALANCE`.
- Renames that parameter to `max_effective_balance` in the binding and module, keeping `_electra` only on the Electra wrappers, where it is accurate.

No behavior change; parameters are positional, so no call site moves.

## Testing

- `zig build test:swap_or_not_shuffle`, `test:state_transition`, bindings build, and the shuffle vitest suite all pass.

AI assistance was used for drafting and implementation support.