### PR TITLE
fix(shuffle): reject out-of-range numbers instead of coercing

### DIFF
--- a/bindings/napi/shuffle.zig
+++ b/bindings/napi/shuffle.zig
@@ -10,6 +10,19 @@ const sons = @import("swap_or_not_shuffle");
 var gpa: std.heap.DebugAllocator(.{}) = .init;
 const allocator = if (builtin.mode == .Debug) gpa.allocator() else std.heap.c_allocator;
 
+/// `assertI32`/`assertU32` coerce with ToInt32/ToUint32, which wrap: a caller
+/// passing 2**32 + 10 would silently be given 10. Require an exact integer so
+/// out-of-range values are rejected instead.
+fn exactI32(value: js.Number) !i32 {
+    const f = try value.toF64();
+    if (!std.math.isFinite(f) or @trunc(f) != f or
+        f < @as(f64, std.math.minInt(i32)) or f > @as(f64, std.math.maxInt(i32)))
+    {
+        return error.InvalidInteger;
+    }
+    return @intFromFloat(f);
+}
+
 fn byteCountFromJs(rand_byte_count: js.Number) !sons.ByteCount {
     return switch (rand_byte_count.assertI32()) {
         1 => .one,
@@ -25,7 +38,7 @@ pub fn innerShuffleList(list: js.Uint32Array, seed: js.Uint8Array, rounds: js.Nu
     const list_u32 = try list.toSlice();
     const seed_slice = try seed.toSlice();
 
-    const rounds_i32 = rounds.assertI32();
+    const rounds_i32 = exactI32(rounds) catch return error.InvalidRoundsSize;
     if (rounds_i32 < 0) return error.InvalidRoundsSize;
     if (rounds_i32 > 255) return error.InvalidRoundsSize;
 
@@ -46,7 +59,7 @@ pub fn unshuffleList(active_indices: js.Uint32Array, seed: js.Uint8Array, rounds
     @memcpy(out, input);
 
     const forwards = false;
-    try sons.innerShuffleList(u32, out, try seed.toSlice(), rounds.assertI32(), forwards);
+    try sons.innerShuffleList(u32, out, try seed.toSlice(), try exactI32(rounds), forwards);
     return out_array;
 }
 
@@ -68,7 +81,7 @@ pub fn computeProposerIndex(
         try byteCountFromJs(rand_byte_count),
         max_effective_balance_electra.assertI64(),
         effective_balance_increment.assertI64(),
-        rounds.assertU32(),
+        try rounds.toU32Exact(),
     );
     return js.Number.from(result);
 }
@@ -90,10 +103,10 @@ pub fn computeSyncCommitteeIndices(
         try active_indices.toSlice(),
         try effective_balance_increments.toSlice(),
         try byteCountFromJs(rand_byte_count),
-        sync_committee_size.assertU32(),
+        try sync_committee_size.toU32Exact(),
         max_effective_balance_electra.assertI64(),
         effective_balance_increment.assertI64(),
-        rounds.assertU32(),
+        try rounds.toU32Exact(),
     );
     defer allocator.free(result);
     return js.Uint32Array.from(result);

--- a/bindings/test/shuffle.test.ts
+++ b/bindings/test/shuffle.test.ts
@@ -115,6 +115,26 @@ describe("shuffle", () => {
     expect(() => shuffle.unshuffleList(test.input, test.seed, 256)).to.throw("InvalidNumberOfRounds");
   });
 
+  it("should reject out-of-range numbers instead of coercing them", () => {
+    const seed = new Uint8Array(32);
+    const indices = getInputArray(64);
+    const increments = new Uint16Array(64).fill(32);
+    const maxEb = 2_048_000_000_000;
+    const increment = 1_000_000_000;
+
+    // ToUint32 would wrap these into huge sizes / round counts
+    for (const size of [-1, 2 ** 32]) {
+      expect(() =>
+        shuffle.computeSyncCommitteeIndices(seed, indices, increments, 2, size, maxEb, increment, 90)
+      ).to.throw("InvalidUnsignedInteger");
+    }
+    expect(() => shuffle.computeProposerIndex(seed, indices, increments, 2, maxEb, increment, -1)).to.throw(
+      "InvalidUnsignedInteger"
+    );
+    // ToInt32 would wrap this to 10 rounds
+    expect(() => innerShuffleList(indices.slice(), seed, 2 ** 32 + 10, false)).to.throw("InvalidRoundsSize");
+  });
+
   it("should skip validation for empty and single-element lists (reference validation order)", () => {
     const invalidSeed = Buffer.alloc(31, 0xac);
     expect(Array.from(shuffle.unshuffleList(new Uint32Array([]), invalidSeed, 10))).toEqual([]);


### PR DESCRIPTION
## Summary

The shuffle binding read sizes and round counts with `assertU32`/`assertI32`, which coerce through ToUint32/ToInt32 and therefore wrap instead of rejecting.

- A negative `syncCommitteeSize` became ~4.29e9 and asked for a 17 GB allocation rather than throwing.
- A `rounds` value of `2**32 + 10` silently shuffled with 10 rounds, so a caller bug produced a wrong result instead of an error.
- Sizes and round counts now require exact integers, using zapi 4.0's `toU32Exact` plus a small helper for the two signed sites.

`unshuffleList` still forwards in-range negatives to the module, so empty and single-element lists keep returning before rounds validation, matching the reference's validation order.

## Testing

- Added a JS case covering the coercion paths above; existing validation-order cases still pass (a single-element list with a 31-byte seed and `rounds = -1` still returns unchanged).
- `zig build test:swap_or_not_shuffle`, bindings build, shuffle vitest suite, and biome all pass.

AI assistance was used for drafting and implementation support.