### PR TITLE
fix(ssz): make variable tree conversions failure-atomic

### DIFF
--- a/src/ssz/memory_safety_test.zig
+++ b/src/ssz/memory_safety_test.zig
@@ -5,14 +5,140 @@ const ChunkedLeafType = pmt.ChunkedLeaf;
 const DoubleFreeDetectAllocator = @import("testing_allocators").DoubleFreeDetectAllocator;
 const ArmOnSizeAllocator = @import("testing_allocators").ArmOnSizeAllocator;
 const FixedContainerType = @import("type/container.zig").FixedContainerType;
+const VariableContainerType = @import("type/container.zig").VariableContainerType;
 const FixedListType = @import("type/list.zig").FixedListType;
+const VariableListType = @import("type/list.zig").VariableListType;
+const VariableVectorType = @import("type/vector.zig").VariableVectorType;
 const UintType = @import("type/uint.zig").UintType;
+const ByteListType = @import("type/byte_list.zig").ByteListType;
 const ByteVectorType = @import("type/byte_vector.zig").ByteVectorType;
 
 const Checkpoint = FixedContainerType(struct {
     epoch: UintType(64),
     root: ByteVectorType(32),
 });
+
+test "VariableContainerType tree.toValue OOM resets output" {
+    const allocator = std.testing.allocator;
+    const Bytes = ByteListType(32);
+    const Container = VariableContainerType(struct {
+        first: Bytes,
+        second: Bytes,
+    });
+
+    var pool = try Node.Pool.init(.{
+        .page_allocator = allocator,
+        .allocator = allocator,
+        .pool_size = 256,
+    });
+    defer pool.deinit();
+
+    var source = Container.default_value;
+    defer Container.deinit(allocator, &source);
+
+    try source.first.appendSlice(allocator, &.{1});
+    try source.second.appendSlice(allocator, &.{2});
+
+    const root = try Container.tree.fromValue(&pool, &source);
+    defer pool.unref(root);
+
+    // Fail the second field after the first field owns its decoded bytes.
+    var failing = std.testing.FailingAllocator.init(allocator, .{
+        .fail_index = 2,
+        .resize_fail_index = 0,
+    });
+    const failing_allocator = failing.allocator();
+
+    var out = Container.default_value;
+    defer Container.deinit(failing_allocator, &out);
+
+    try std.testing.expectError(
+        error.OutOfMemory,
+        Container.tree.toValue(failing_allocator, root, &pool, &out),
+    );
+    try std.testing.expect(Container.equals(&out, &Container.default_value));
+    try std.testing.expectEqual(failing.allocated_bytes, failing.freed_bytes);
+}
+
+test "VariableVectorType tree.toValue OOM resets output" {
+    const allocator = std.testing.allocator;
+    const Bytes = ByteListType(32);
+    const Vector = VariableVectorType(Bytes, 2);
+
+    var pool = try Node.Pool.init(.{
+        .page_allocator = allocator,
+        .allocator = allocator,
+        .pool_size = 256,
+    });
+    defer pool.deinit();
+
+    var source = Vector.default_value;
+    defer Vector.deinit(allocator, &source);
+
+    try source[0].appendSlice(allocator, &.{1});
+    try source[1].appendSlice(allocator, &.{2});
+
+    const root = try Vector.tree.fromValue(&pool, &source);
+    defer pool.unref(root);
+
+    // Fail the second element after the first element owns its decoded bytes.
+    var failing = std.testing.FailingAllocator.init(allocator, .{
+        .fail_index = 2,
+        .resize_fail_index = 0,
+    });
+    const failing_allocator = failing.allocator();
+
+    var out = Vector.default_value;
+    defer Vector.deinit(failing_allocator, &out);
+
+    try std.testing.expectError(
+        error.OutOfMemory,
+        Vector.tree.toValue(failing_allocator, root, &pool, &out),
+    );
+    try std.testing.expect(Vector.equals(&out, &Vector.default_value));
+    try std.testing.expectEqual(failing.allocated_bytes, failing.freed_bytes);
+}
+
+test "VariableListType tree.toValue OOM resets output" {
+    const allocator = std.testing.allocator;
+    const Bytes = ByteListType(32);
+    const List = VariableListType(Bytes, 2);
+
+    var pool = try Node.Pool.init(.{
+        .page_allocator = allocator,
+        .allocator = allocator,
+        .pool_size = 256,
+    });
+    defer pool.deinit();
+
+    var source: List.Type = .empty;
+    defer List.deinit(allocator, &source);
+
+    try source.append(allocator, Bytes.default_value);
+    try source.append(allocator, Bytes.default_value);
+    try source.items[0].appendSlice(allocator, &.{1});
+    try source.items[1].appendSlice(allocator, &.{2});
+
+    const root = try List.tree.fromValue(&pool, &source);
+    defer pool.unref(root);
+
+    // Fail the second element after the output list and first element own allocations.
+    var failing = std.testing.FailingAllocator.init(allocator, .{
+        .fail_index = 4,
+        .resize_fail_index = 0,
+    });
+    const failing_allocator = failing.allocator();
+
+    var out = List.default_value;
+    defer List.deinit(failing_allocator, &out);
+
+    try std.testing.expectError(
+        error.OutOfMemory,
+        List.tree.toValue(failing_allocator, root, &pool, &out),
+    );
+    try std.testing.expect(List.equals(&out, &List.default_value));
+    try std.testing.expectEqual(failing.allocated_bytes, failing.freed_bytes);
+}
 
 // std.testing.allocator can't see pool-slot leaks, so check getNodesInUse() against a baseline.
 test "TreeView composite list sliceTo does not leak pool nodes" {

--- a/src/ssz/type/container.zig
+++ b/src/ssz/type/container.zig
@@ -786,7 +786,13 @@ pub fn VariableContainerType(comptime ST: type) type {
                 return try Node.fillWithContents(pool, &nodes, chunk_depth);
             }
 
+            /// Requires initialized, logically empty `out`; on error, resets it to `default_value`.
             pub fn toValue(allocator: std.mem.Allocator, node: Node.Id, pool: *Node.Pool, out: *Type) !void {
+                errdefer {
+                    deinit(allocator, out);
+                    out.* = default_value;
+                }
+
                 var nodes: [chunk_count]Node.Id = undefined;
                 try node.getNodesAtDepth(pool, chunk_depth, 0, &nodes);
                 inline for (fields, 0..) |field, i| {

--- a/src/ssz/type/list.zig
+++ b/src/ssz/type/list.zig
@@ -921,7 +921,13 @@ pub fn VariableListType(comptime ST: type, comptime _limit: comptime_int) type {
                 return std.mem.readInt(usize, hash[0..8], .little);
             }
 
+            /// Requires initialized, logically empty `out`; on error, resets it to `default_value`.
             pub fn toValue(allocator: std.mem.Allocator, node: Node.Id, pool: *Node.Pool, out: *Type) !void {
+                errdefer {
+                    deinit(allocator, out);
+                    out.* = default_value;
+                }
+
                 const len = try length(node, pool);
                 const chunk_count = len;
                 if (chunk_count == 0) {

--- a/src/ssz/type/vector.zig
+++ b/src/ssz/type/vector.zig
@@ -580,7 +580,13 @@ pub fn VariableVectorType(comptime ST: type, comptime _length: comptime_int) typ
                 return try Node.fillWithContents(pool, &nodes, chunk_depth);
             }
 
+            /// Requires initialized, logically empty `out`; on error, resets it to `default_value`.
             pub fn toValue(allocator: std.mem.Allocator, node: Node.Id, pool: *Node.Pool, out: *Type) !void {
+                errdefer {
+                    deinit(allocator, out);
+                    out.* = default_value;
+                }
+
                 var nodes: [chunk_count]Node.Id = undefined;
 
                 try node.getNodesAtDepth(pool, chunk_depth, 0, &nodes);


### PR DESCRIPTION
## Motivation

Variable container, vector, and list tree conversions populate caller-owned values in place. If conversion of a later child failed, earlier decoded children remained allocated and `out` was left partially initialized. Direct callers could not safely clean up without knowing how far conversion progressed.

## Description

- Define the shared variable `tree.toValue()` contract: `out` starts logically empty and any error resets it to `default_value`.
- Reclaim partially decoded output in `VariableContainerType.tree.toValue()`.
- Apply the same failure-atomic behavior to `VariableVectorType` and `VariableListType`.
- Preserve the existing in-place success path, allocation behavior, and error ordering.
- Add deterministic direct OOM regressions for all three type implementations.

The default-on-error postcondition composes with the caller-side cleanup in #579: an outer `deinit` only sees the reset value and cannot double-free nested fields.

## Validation

- Three focused OOM tests (3/3 each)
- `zig build test:ssz` (243/243 passed)
- `zig build build-lib:bindings -Doptimize=ReleaseSafe`
- `zig fmt --check src test bindings bench examples scripts build.zig build.zig.zon`
- `pnpm lint` (passed with existing warnings in `bindings/src/index.d.ts`)
- `git diff --check`

The regressions fail on the old implementation because the first decoded child remains allocated and `out` is not reset. Full `zig fmt --check .` still reports five pre-existing formatting issues under `zig-pkg`; no dependency files were changed.

This changes ownership cleanup within the existing SSZ conversion boundary. It does not alter a trust assumption, supported integration, or external input contract, so no security-document update is required.

## AI assistance

The implementation and regression tests were primarily AI-authored and independently reviewed with AI assistance.
