### PR TITLE
feat(ssz): add getReadonlyByRange for composite tree views

### DIFF
--- a/src/ssz/tree_view/array_composite.zig
+++ b/src/ssz/tree_view/array_composite.zig
@@ -144,6 +144,17 @@ pub fn ArrayCompositeTreeView(comptime ST: type) type {
             return self.chunks.getAllReadonly(allocator, length);
         }
 
+        /// Read-only views for elements [start_index, start_index + count), fetched in a
+        /// single tree traversal. Caller owns the returned slice and must free it with
+        /// `allocator`; the views are borrowed — same borrow/invalidation rules as
+        /// getReadonly().
+        pub fn getReadonlyByRange(self: *Self, allocator: Allocator, start_index: usize, count: usize) ![]Element {
+            if (start_index > length or count > length - start_index) {
+                return error.IndexOutOfBounds;
+            }
+            return self.chunks.getReadonlyByRange(allocator, start_index, count);
+        }
+
         pub fn getAllReadonlyValues(self: *Self, allocator: Allocator) ![]ST.Element.Type {
             return self.chunks.getAllValues(allocator, length);
         }
@@ -583,4 +594,46 @@ test "ArrayCompositeTreeView - get and set" {
     const bytes1_written = try elem1.serializeIntoBytes(&bytes1);
     try std.testing.expectEqual(bytes1.len, bytes1_written);
     try std.testing.expectEqualSlices(u8, &new_val, &bytes1);
+}
+
+test "TreeView vector composite getReadonlyByRange returns range views" {
+    const allocator = std.testing.allocator;
+
+    const Root32 = ByteVectorType(32);
+    const VecRootsType = FixedVectorType(Root32, 4, .{});
+
+    var pool = try Node.Pool.init(.{ .page_allocator = allocator, .allocator = allocator, .pool_size = 1024 });
+    defer pool.deinit();
+
+    const value = [4][32]u8{
+        [_]u8{0xaa} ** 32,
+        [_]u8{0xbb} ** 32,
+        [_]u8{0xcc} ** 32,
+        [_]u8{0xdd} ** 32,
+    };
+
+    const tree_node = try VecRootsType.tree.fromValue(&pool, &value);
+    var view = try VecRootsType.TreeView.init(allocator, &pool, tree_node);
+    defer view.deinit();
+
+    const views = try view.getReadonlyByRange(allocator, 1, 2);
+    defer allocator.free(views);
+
+    try std.testing.expectEqual(@as(usize, 2), views.len);
+    for (views, 1..) |elem, i| {
+        var bytes: [Root32.fixed_size]u8 = undefined;
+        const written = try elem.serializeIntoBytes(&bytes);
+        try std.testing.expectEqual(bytes.len, written);
+        try std.testing.expectEqualSlices(u8, &value[i], &bytes);
+    }
+
+    // Range views are borrowed from the same cache as getReadonly().
+    try std.testing.expectEqual(try view.getReadonly(1), views[0]);
+
+    try std.testing.expectError(error.IndexOutOfBounds, view.getReadonlyByRange(allocator, 3, 2));
+    try std.testing.expectError(error.IndexOutOfBounds, view.getReadonlyByRange(allocator, 5, 0));
+
+    const empty = try view.getReadonlyByRange(allocator, 4, 0);
+    defer allocator.free(empty);
+    try std.testing.expectEqual(@as(usize, 0), empty.len);
 }

--- a/src/ssz/tree_view/chunks.zig
+++ b/src/ssz/tree_view/chunks.zig
@@ -478,12 +478,43 @@ pub fn CompositeChunks(
 
         /// Get all child views without tracking changes (read-only).
         pub fn getAllReadonly(self: *Self, allocator: Allocator, len: usize) ![]ElementPtr {
-            const views = try allocator.alloc(ElementPtr, len);
+            return self.getReadonlyByRange(allocator, 0, len);
+        }
+
+        /// Get child views for indices [start_index, start_index + count) without tracking
+        /// changes (read-only). The committed nodes for the range are fetched in a single
+        /// traversal instead of one root-to-leaf walk per index.
+        /// Caller owns the returned slice and must free it with `allocator`; the views are
+        /// borrowed — same borrow/invalidation rules as getReadonly().
+        pub fn getReadonlyByRange(self: *Self, allocator: Allocator, start_index: usize, count: usize) ![]ElementPtr {
+            const views = try allocator.alloc(ElementPtr, count);
             errdefer allocator.free(views);
-            for (0..len) |i| {
-                views[i] = try self.getReadonly(i);
+
+            try self.populateNodesByRange(start_index, count);
+
+            for (views, start_index..) |*view, i| {
+                view.* = try self.getReadonly(i);
             }
             return views;
+        }
+
+        /// Bulk-fetch committed nodes for [start_index, start_index + count) into the
+        /// children_nodes cache. Staged entries (uncommitted set/setValue) are left untouched.
+        fn populateNodesByRange(self: *Self, start_index: usize, count: usize) !void {
+            if (count == 0) return;
+
+            const nodes = try self.state.allocator.alloc(Node.Id, count);
+            defer self.state.allocator.free(nodes);
+
+            try self.state.root.getNodesAtDepth(self.state.pool, chunk_depth, start_index, nodes);
+
+            for (nodes, start_index..) |node, index| {
+                const gindex = Gindex.fromDepth(chunk_depth, index);
+                const gop = try self.state.children_nodes.getOrPut(self.state.allocator, gindex);
+                if (!gop.found_existing) {
+                    gop.value_ptr.* = node;
+                }
+            }
         }
 
         pub const Value = ST.Element.Type;

--- a/src/ssz/tree_view/list_composite.zig
+++ b/src/ssz/tree_view/list_composite.zig
@@ -174,6 +174,18 @@ pub fn ListCompositeTreeView(comptime ST: type) type {
             return self.chunks.getAllReadonly(allocator, list_length);
         }
 
+        /// Read-only views for elements [start_index, start_index + count), fetched in a
+        /// single tree traversal. Caller owns the returned slice and must free it with
+        /// `allocator`; the views are borrowed — same borrow/invalidation rules as
+        /// getReadonly().
+        pub fn getReadonlyByRange(self: *Self, allocator: Allocator, start_index: usize, count: usize) ![]Element {
+            const list_length = try self.length();
+            if (start_index > list_length or count > list_length - start_index) {
+                return error.IndexOutOfBounds;
+            }
+            return self.chunks.getReadonlyByRange(allocator, start_index, count);
+        }
+
         pub fn getAllReadonlyValues(self: *Self, allocator: Allocator) ![]ST.Element.Type {
             const list_length = try self.length();
             return self.chunks.getAllValues(allocator, list_length);
@@ -1227,4 +1239,86 @@ test "ListCompositeTreeView - push and serialize" {
     try view.hashTreeRootInto(&hash_root);
     const expected_root = [_]u8{ 0x0c, 0xb9, 0x47, 0x37, 0x7e, 0x17, 0x7f, 0x77, 0x47, 0x19, 0xea, 0xd8, 0xd2, 0x10, 0xaf, 0x9c, 0x64, 0x61, 0xf4, 0x1b, 0xaf, 0x5b, 0x40, 0x82, 0xf8, 0x6a, 0x39, 0x11, 0x45, 0x48, 0x31, 0xb8 };
     try std.testing.expectEqualSlices(u8, &expected_root, &hash_root);
+}
+
+test "TreeView composite list getReadonlyByRange returns range views" {
+    const allocator = std.testing.allocator;
+    var pool = try Node.Pool.init(.{ .page_allocator = allocator, .allocator = allocator, .pool_size = 512 });
+    defer pool.deinit();
+
+    const ListType = FixedListType(Checkpoint, 16, .{});
+
+    var list: ListType.Type = .empty;
+    defer list.deinit(allocator);
+    for (0..6) |i| try list.append(allocator, .{ .epoch = @intCast(i + 1), .root = [_]u8{@intCast(i)} ** 32 });
+
+    const root_node = try ListType.tree.fromValue(&pool, &list);
+    var view = try ListType.TreeView.init(allocator, &pool, root_node);
+    defer view.deinit();
+
+    const views = try view.getReadonlyByRange(allocator, 2, 3);
+    defer allocator.free(views);
+
+    try std.testing.expectEqual(@as(usize, 3), views.len);
+    for (views, 2..) |elem, i| {
+        var value: Checkpoint.Type = undefined;
+        try elem.toValue(undefined, &value);
+        try std.testing.expectEqual(@as(u64, @intCast(i + 1)), value.epoch);
+        try std.testing.expectEqual(@as(u8, @intCast(i)), value.root[0]);
+    }
+
+    // Range views are borrowed from the same cache as getReadonly().
+    try std.testing.expectEqual(try view.getReadonly(2), views[0]);
+}
+
+test "TreeView composite list getReadonlyByRange bounds" {
+    const allocator = std.testing.allocator;
+    var pool = try Node.Pool.init(.{ .page_allocator = allocator, .allocator = allocator, .pool_size = 512 });
+    defer pool.deinit();
+
+    const ListType = FixedListType(Checkpoint, 16, .{});
+
+    var list: ListType.Type = .empty;
+    defer list.deinit(allocator);
+    for (0..4) |i| try list.append(allocator, .{ .epoch = @intCast(i), .root = [_]u8{0} ** 32 });
+
+    const root_node = try ListType.tree.fromValue(&pool, &list);
+    var view = try ListType.TreeView.init(allocator, &pool, root_node);
+    defer view.deinit();
+
+    try std.testing.expectError(error.IndexOutOfBounds, view.getReadonlyByRange(allocator, 0, 5));
+    try std.testing.expectError(error.IndexOutOfBounds, view.getReadonlyByRange(allocator, 5, 0));
+    try std.testing.expectError(error.IndexOutOfBounds, view.getReadonlyByRange(allocator, 3, 2));
+
+    const empty = try view.getReadonlyByRange(allocator, 4, 0);
+    defer allocator.free(empty);
+    try std.testing.expectEqual(@as(usize, 0), empty.len);
+}
+
+test "TreeView composite list getReadonlyByRange sees uncommitted setValue" {
+    const allocator = std.testing.allocator;
+    var pool = try Node.Pool.init(.{ .page_allocator = allocator, .allocator = allocator, .pool_size = 512 });
+    defer pool.deinit();
+
+    const ListType = FixedListType(Checkpoint, 16, .{});
+
+    var list: ListType.Type = .empty;
+    defer list.deinit(allocator);
+    for (0..4) |i| try list.append(allocator, .{ .epoch = @intCast(i), .root = [_]u8{0} ** 32 });
+
+    const root_node = try ListType.tree.fromValue(&pool, &list);
+    var view = try ListType.TreeView.init(allocator, &pool, root_node);
+    defer view.deinit();
+
+    const staged: Checkpoint.Type = .{ .epoch = 99, .root = [_]u8{9} ** 32 };
+    try view.setValue(1, &staged);
+
+    const views = try view.getReadonlyByRange(allocator, 0, 4);
+    defer allocator.free(views);
+
+    var value: Checkpoint.Type = undefined;
+    try views[1].toValue(undefined, &value);
+    try std.testing.expectEqual(@as(u64, 99), value.epoch);
+    try views[2].toValue(undefined, &value);
+    try std.testing.expectEqual(@as(u64, 2), value.epoch);
 }


### PR DESCRIPTION
## Motivation

Closes #467. Requested in https://github.com/ChainSafe/lodestar-z/pull/462#discussion_r3529291103: reading a slice of a composite list/vector view currently requires one `getValue`/`getReadonly` call per index, each of which walks the tree from the root.

## Description

- Adds `CompositeChunks.getReadonlyByRange(allocator, start_index, count)`: fetches the committed nodes for the range with a single `getNodesAtDepth` traversal, then materializes element views through the same cache as `getReadonly()`, so borrow rules and visibility of staged (uncommitted) writes are unchanged. The name and shape mirror `getReadonlyByRange` in the TypeScript ssz package.
- Exposes it on `ListCompositeTreeView` (runtime length bounds check) and `ArrayCompositeTreeView` (comptime length bounds check). Out-of-range requests return `error.IndexOutOfBounds` rather than clamping, following existing accessor conventions.
- `getAllReadonly` now delegates to the range variant and gets the same single-traversal speedup.

## Tests

- New unit tests cover range contents, bounds errors, empty ranges, cache identity with `getReadonly`, and visibility of an uncommitted `setValue` inside a fetched range.
- `zig build test:ssz`: 244/244 pass
- `zig build test`: full unit suite passes
- `zig build test:ssz_generic_spec_tests test:ssz_static_spec_tests`: all pass
- `zig fmt --check` clean on touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)