### PR TITLE
feat(logger): runtime log-level filtering over std.log

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -60,6 +60,9 @@ jobs:
       - name: Run hex tests
         run: |
           zig build test:hex
+      - name: Run logger tests
+        run: |
+          zig build test:logger
       - name: Run cpu_count tests
         run: |
           zig build test:cpu_count

--- a/bindings/napi/logger.zig
+++ b/bindings/napi/logger.zig
@@ -1,0 +1,21 @@
+//! JS binding for the `logger` module: runtime log-level control over the
+//! addon's `std.log` output (see src/logger.zig and #413).
+
+const std = @import("std");
+const js = @import("zapi:zapi").js;
+const logger = @import("logger");
+
+/// Set the runtime log level from a Lodestar level string
+/// ("error"/"warn"/"info"/"verbose"/"debug"/"trace").
+/// `verbose` and `trace` map to `std.log`'s `debug`.
+pub fn setLogLevel(level: js.String) !void {
+    var buf: [16]u8 = undefined;
+    const level_str = level.toSlice(&buf) catch return error.InvalidLogLevel;
+    const parsed = logger.levelFromString(level_str) orelse return error.InvalidLogLevel;
+    logger.setLevel(parsed);
+}
+
+/// Current runtime log level as a `std.log` level name.
+pub fn getLogLevel() !js.String {
+    return js.String.from(@tagName(logger.getLevel()));
+}

--- a/bindings/napi/root.zig
+++ b/bindings/napi/root.zig
@@ -10,8 +10,17 @@ pub const BeaconStateView = @import("./BeaconStateView.zig");
 pub const blst = @import("./blst.zig");
 pub const blsVerifier = @import("./bls_verifier.zig");
 pub const pubkeys = @import("./pubkeys.zig");
+pub const logger = @import("./logger.zig");
 
 const options = @import("bls_options");
+const logger_mod = @import("logger");
+
+/// Compile all log levels in; `logger_mod.logFn` gates at runtime
+/// (adjustable from JS via `logger.setLogLevel`).
+pub const std_options: std.Options = .{
+    .log_level = .debug,
+    .logFn = logger_mod.logFn,
+};
 
 var gpa: std.heap.DebugAllocator(.{}) = .init;
 const allocator = if (builtin.mode == .Debug) gpa.allocator() else std.heap.c_allocator;

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -140,6 +140,9 @@
         .time = .{
             .root_source_file = "src/time.zig",
         },
+        .logger = .{
+            .root_source_file = "src/logger.zig",
+        },
         .bounded_array = .{
             .root_source_file = "src/bounded_array.zig",
         },
@@ -368,6 +371,7 @@
                     .fork_types,
                     .state_transition,
                     .hex,
+                    .logger,
                     "zapi:zapi",
                 },
             },
@@ -380,6 +384,7 @@
         // Per-module unit tests (mirror the old auto-generated `test:<module>` steps).
         .constants = .{ .root_module = .constants },
         .hex = .{ .root_module = .hex },
+        .logger = .{ .root_module = .logger },
         .bounded_array = .{ .root_module = .bounded_array },
         .cpu_count = .{ .root_module = .cpu_count },
         .hashing = .{ .root_module = .hashing },

--- a/src/logger.zig
+++ b/src/logger.zig
@@ -1,0 +1,94 @@
+//! Runtime log-level filtering over `std.log`.
+//!
+//! Per the discussion in #446, lodestar-z deliberately does NOT ship a custom
+//! logger: modules log through the standard `std.log` API and the root module
+//! decides formatting and destination. The one gap `std.log` leaves is that
+//! its level is compile-time, while Lodestar configures the level at runtime
+//! (and will pass it in when creating the BeaconEngine, #413).
+//!
+//! This module closes that gap the same way Tigerbeetle does: the root module
+//! compiles all levels in and installs a `logFn` that consults a runtime
+//! level before delegating to `std.log.defaultLog`:
+//!
+//! ```zig
+//! const logger = @import("logger");
+//!
+//! pub const std_options: std.Options = .{
+//!     // Compile every level in; `logger.logFn` gates at runtime.
+//!     .log_level = .debug,
+//!     .logFn = logger.logFn,
+//! };
+//! ```
+//!
+//! Consumers then call `logger.setLevel(...)` (e.g. from the BeaconEngine
+//! constructor with the level configured in the BeaconChain).
+
+const std = @import("std");
+
+/// Runtime log level. Atomic so the JS binding thread can adjust it while
+/// worker threads log. Defaults mirror `std.log.default_level`.
+var runtime_level: std.atomic.Value(u8) = std.atomic.Value(u8).init(
+    @intFromEnum(std.log.default_level),
+);
+
+pub fn setLevel(level: std.log.Level) void {
+    runtime_level.store(@intFromEnum(level), .monotonic);
+}
+
+pub fn getLevel() std.log.Level {
+    return @enumFromInt(runtime_level.load(.monotonic));
+}
+
+/// Parse a Lodestar log-level string into a `std.log.Level`.
+/// Lodestar's `verbose` and `trace` levels are finer than `debug`; `std.log`
+/// has no finer level, so both map to `.debug`.
+pub fn levelFromString(s: []const u8) ?std.log.Level {
+    const map = .{
+        .{ "error", std.log.Level.err },
+        .{ "warn", std.log.Level.warn },
+        .{ "info", std.log.Level.info },
+        .{ "verbose", std.log.Level.debug },
+        .{ "debug", std.log.Level.debug },
+        .{ "trace", std.log.Level.debug },
+    };
+    inline for (map) |entry| {
+        if (std.mem.eql(u8, s, entry[0])) return entry[1];
+    }
+    return null;
+}
+
+/// Drop-in `std.Options.logFn` that gates on the runtime level, then
+/// delegates to `std.log.defaultLog` for formatting and output.
+pub fn logFn(
+    comptime message_level: std.log.Level,
+    comptime scope: @TypeOf(.enum_literal),
+    comptime format: []const u8,
+    args: anytype,
+) void {
+    if (@intFromEnum(message_level) > runtime_level.load(.monotonic)) return;
+    std.log.defaultLog(message_level, scope, format, args);
+}
+
+test "setLevel gates messages" {
+    const initial = getLevel();
+    defer setLevel(initial);
+
+    setLevel(.warn);
+    try std.testing.expectEqual(std.log.Level.warn, getLevel());
+
+    // err (0) and warn (1) pass a .warn threshold; info (2) and debug (3) do not.
+    try std.testing.expect(@intFromEnum(std.log.Level.err) <= @intFromEnum(getLevel()));
+    try std.testing.expect(@intFromEnum(std.log.Level.warn) <= @intFromEnum(getLevel()));
+    try std.testing.expect(@intFromEnum(std.log.Level.info) > @intFromEnum(getLevel()));
+    try std.testing.expect(@intFromEnum(std.log.Level.debug) > @intFromEnum(getLevel()));
+}
+
+test "levelFromString maps Lodestar levels" {
+    try std.testing.expectEqual(std.log.Level.err, levelFromString("error").?);
+    try std.testing.expectEqual(std.log.Level.warn, levelFromString("warn").?);
+    try std.testing.expectEqual(std.log.Level.info, levelFromString("info").?);
+    try std.testing.expectEqual(std.log.Level.debug, levelFromString("verbose").?);
+    try std.testing.expectEqual(std.log.Level.debug, levelFromString("debug").?);
+    try std.testing.expectEqual(std.log.Level.debug, levelFromString("trace").?);
+    try std.testing.expectEqual(@as(?std.log.Level, null), levelFromString("bogus"));
+}


### PR DESCRIPTION
## Motivation

Addresses #413 within the direction settled in #446: the team preferred plain `std.log` over a custom logger, with runtime level configuration (Tigerbeetle-style) as the one acknowledged gap. This PR builds on the groundwork @markolazic01 did in #446 — if you'd rather pick #413 back up yourself, happy to close this in your favor.

Deliberately NOT a logger: no formatting, no module tags, no colors. Modules keep logging through the standard `std.log` API; the root module stays in control of output.

## Description

- `src/logger.zig` (new `logger` module, 2 pub functions + a parser): an atomic runtime level, a `logFn` that gates on it before delegating to `std.log.defaultLog`, and `levelFromString` mapping Lodestar's six level names onto `std.log`'s four (`verbose`/`trace` map to `debug`).
- Bindings install it via `std_options` (`log_level = .debug` so every level compiles into release builds; the logFn gates at runtime) and expose `setLogLevel`/`getLogLevel` to JS, so the level configured in the BeaconChain can be applied when the native BeaconEngine is created (#428).
- Default level mirrors `std.log.default_level`, so existing `std.log.debug` calls in the bindings behave as before.
- `zig build test:logger` added to CI (per the request in #446).

## Tests

- `zig build test:logger`: 2/2 pass
- `zig build build-lib:bindings`: builds clean with the new std_options and exports
- `zig fmt --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)