### PR TITLE
fix(ssz): clean up recursive hasher initialization

### DIFF
--- a/src/ssz/hasher.zig
+++ b/src/ssz/hasher.zig
@@ -54,6 +54,8 @@ pub fn Hasher(comptime ST: type) type {
                         errdefer allocator.free(children);
 
                         children[0] = try Hasher(ST.Element).init(allocator);
+                        // Parent capacity is zero today; keep cleanup paired if that changes.
+                        errdefer children[0].deinit(allocator);
 
                         return try HasherData.initCapacity(allocator, hasher_size, children);
                     }

--- a/src/ssz/hasher.zig
+++ b/src/ssz/hasher.zig
@@ -16,19 +16,31 @@ pub fn Hasher(comptime ST: type) type {
                         return try HasherData.initCapacity(allocator, hasher_size, null);
                     } else {
                         var children = try allocator.alloc(HasherData, 1);
+                        errdefer allocator.free(children);
+
                         children[0] = try Hasher(ST.Element).init(allocator);
+                        errdefer children[0].deinit(allocator);
+
                         return try HasherData.initCapacity(allocator, hasher_size, children);
                     }
                 },
                 .container => {
                     const hasher_size = if (ST.chunk_count % 2 == 1) ST.chunk_count + 1 else ST.chunk_count;
                     var children = try allocator.alloc(HasherData, ST.fields.len);
+                    errdefer allocator.free(children);
+
+                    var initialized_count: usize = 0;
+                    errdefer for (children[0..initialized_count]) |child| {
+                        child.deinit(allocator);
+                    };
+
                     inline for (ST.fields, 0..) |field, i| {
                         if (comptime isBasicType(field.type)) {
                             children[i] = try HasherData.initCapacity(allocator, 0, null);
                         } else {
                             children[i] = try Hasher(field.type).init(allocator);
                         }
+                        initialized_count += 1;
                     }
                     return try HasherData.initCapacity(allocator, hasher_size, children);
                 },
@@ -39,7 +51,11 @@ pub fn Hasher(comptime ST: type) type {
                         return try HasherData.initCapacity(allocator, hasher_size, null);
                     } else {
                         var children = try allocator.alloc(HasherData, 1);
+                        errdefer allocator.free(children);
+
                         children[0] = try Hasher(ST.Element).init(allocator);
+                        errdefer children[0].deinit(allocator);
+
                         return try HasherData.initCapacity(allocator, hasher_size, children);
                     }
                 },

--- a/src/ssz/hasher.zig
+++ b/src/ssz/hasher.zig
@@ -54,7 +54,6 @@ pub fn Hasher(comptime ST: type) type {
                         errdefer allocator.free(children);
 
                         children[0] = try Hasher(ST.Element).init(allocator);
-                        errdefer children[0].deinit(allocator);
 
                         return try HasherData.initCapacity(allocator, hasher_size, children);
                     }

--- a/src/ssz/memory_safety_test.zig
+++ b/src/ssz/memory_safety_test.zig
@@ -4,8 +4,10 @@ const Node = pmt.Node;
 const ChunkedLeafType = pmt.ChunkedLeaf;
 const DoubleFreeDetectAllocator = @import("testing_allocators").DoubleFreeDetectAllocator;
 const ArmOnSizeAllocator = @import("testing_allocators").ArmOnSizeAllocator;
+const Hasher = @import("hasher.zig").Hasher;
 const FixedContainerType = @import("type/container.zig").FixedContainerType;
 const FixedListType = @import("type/list.zig").FixedListType;
+const FixedVectorType = @import("type/vector.zig").FixedVectorType;
 const UintType = @import("type/uint.zig").UintType;
 const ByteVectorType = @import("type/byte_vector.zig").ByteVectorType;
 
@@ -13,6 +15,54 @@ const Checkpoint = FixedContainerType(struct {
     epoch: UintType(64),
     root: ByteVectorType(32),
 });
+
+test "Hasher init container should not leak initialized prefix on later child OOM" {
+    const ChildType = FixedVectorType(UintType(64), 8, .{});
+    const ContainerType = FixedContainerType(struct {
+        first: ChildType,
+        second: ChildType,
+    });
+    var failing = std.testing.FailingAllocator.init(
+        std.testing.allocator,
+        .{ .fail_index = 2 },
+    );
+
+    try std.testing.expectError(
+        error.OutOfMemory,
+        Hasher(ContainerType).init(failing.allocator()),
+    );
+    try std.testing.expectEqual(failing.allocated_bytes, failing.freed_bytes);
+}
+
+test "Hasher init composite vector should not leak initialized child on parent OOM" {
+    const ChildType = FixedVectorType(UintType(64), 8, .{});
+    const VectorType = FixedVectorType(ChildType, 2, .{});
+    var failing = std.testing.FailingAllocator.init(
+        std.testing.allocator,
+        .{ .fail_index = 2 },
+    );
+
+    try std.testing.expectError(
+        error.OutOfMemory,
+        Hasher(VectorType).init(failing.allocator()),
+    );
+    try std.testing.expectEqual(failing.allocated_bytes, failing.freed_bytes);
+}
+
+test "Hasher init composite list should not leak children slice on recursive child OOM" {
+    const ChildType = FixedVectorType(UintType(64), 8, .{});
+    const ListType = FixedListType(ChildType, 4, .{});
+    var failing = std.testing.FailingAllocator.init(
+        std.testing.allocator,
+        .{ .fail_index = 1 },
+    );
+
+    try std.testing.expectError(
+        error.OutOfMemory,
+        Hasher(ListType).init(failing.allocator()),
+    );
+    try std.testing.expectEqual(failing.allocated_bytes, failing.freed_bytes);
+}
 
 // std.testing.allocator can't see pool-slot leaks, so check getNodesInUse() against a baseline.
 test "TreeView composite list sliceTo does not leak pool nodes" {


### PR DESCRIPTION
## Motivation

Recursive `Hasher.init()` builds child scratch state before allocating its parent. If a later child or parent allocation failed, the initialized children and their backing slice were abandoned.

## Description

 - Clean up recursively initialized Hasher children on initialization errors, tracking the initialized prefix for containers.
  - Add deterministic Container, Vector, and List OOM regressions.