### PR TITLE
chore: resolve conflicts on SSZ cleanup branch

### DIFF
--- a/src/ssz/hasher.zig
+++ b/src/ssz/hasher.zig
@@ -16,19 +16,31 @@ pub fn Hasher(comptime ST: type) type {
                         return try HasherData.initCapacity(allocator, hasher_size, null);
                     } else {
                         var children = try allocator.alloc(HasherData, 1);
+                        errdefer allocator.free(children);
+
                         children[0] = try Hasher(ST.Element).init(allocator);
+                        errdefer children[0].deinit(allocator);
+
                         return try HasherData.initCapacity(allocator, hasher_size, children);
                     }
                 },
                 .container => {
                     const hasher_size = if (ST.chunk_count % 2 == 1) ST.chunk_count + 1 else ST.chunk_count;
                     var children = try allocator.alloc(HasherData, ST.fields.len);
+                    errdefer allocator.free(children);
+
+                    var initialized_count: usize = 0;
+                    errdefer for (children[0..initialized_count]) |child| {
+                        child.deinit(allocator);
+                    };
+
                     inline for (ST.fields, 0..) |field, i| {
                         if (comptime isBasicType(field.type)) {
                             children[i] = try HasherData.initCapacity(allocator, 0, null);
                         } else {
                             children[i] = try Hasher(field.type).init(allocator);
                         }
+                        initialized_count += 1;
                     }
                     return try HasherData.initCapacity(allocator, hasher_size, children);
                 },
@@ -39,7 +51,12 @@ pub fn Hasher(comptime ST: type) type {
                         return try HasherData.initCapacity(allocator, hasher_size, null);
                     } else {
                         var children = try allocator.alloc(HasherData, 1);
+                        errdefer allocator.free(children);
+
                         children[0] = try Hasher(ST.Element).init(allocator);
+                        // Parent capacity is zero today; keep cleanup paired if that changes.
+                        errdefer children[0].deinit(allocator);
+
                         return try HasherData.initCapacity(allocator, hasher_size, children);
                     }
                 },

--- a/src/ssz/memory_safety_test.zig
+++ b/src/ssz/memory_safety_test.zig
@@ -5,6 +5,7 @@ const Node = pmt.Node;
 const ChunkedLeafType = pmt.ChunkedLeaf;
 const DoubleFreeDetectAllocator = @import("testing_allocators").DoubleFreeDetectAllocator;
 const ArmOnSizeAllocator = @import("testing_allocators").ArmOnSizeAllocator;
+const Hasher = @import("hasher.zig").Hasher;
 const FixedContainerType = @import("type/container.zig").FixedContainerType;
 const FixedListType = @import("type/list.zig").FixedListType;
 const FixedVectorType = @import("type/vector.zig").FixedVectorType;
@@ -16,6 +17,54 @@ const Checkpoint = FixedContainerType(struct {
     epoch: UintType(64),
     root: ByteVectorType(32),
 });
+
+test "Hasher init container should not leak initialized prefix on later child OOM" {
+    const ChildType = FixedVectorType(UintType(64), 8, .{});
+    const ContainerType = FixedContainerType(struct {
+        first: ChildType,
+        second: ChildType,
+    });
+    var failing = std.testing.FailingAllocator.init(
+        std.testing.allocator,
+        .{ .fail_index = 2 },
+    );
+
+    try std.testing.expectError(
+        error.OutOfMemory,
+        Hasher(ContainerType).init(failing.allocator()),
+    );
+    try std.testing.expectEqual(failing.allocated_bytes, failing.freed_bytes);
+}
+
+test "Hasher init composite vector should not leak initialized child on parent OOM" {
+    const ChildType = FixedVectorType(UintType(64), 8, .{});
+    const VectorType = FixedVectorType(ChildType, 2, .{});
+    var failing = std.testing.FailingAllocator.init(
+        std.testing.allocator,
+        .{ .fail_index = 2 },
+    );
+
+    try std.testing.expectError(
+        error.OutOfMemory,
+        Hasher(VectorType).init(failing.allocator()),
+    );
+    try std.testing.expectEqual(failing.allocated_bytes, failing.freed_bytes);
+}
+
+test "Hasher init composite list should not leak children slice on recursive child OOM" {
+    const ChildType = FixedVectorType(UintType(64), 8, .{});
+    const ListType = FixedListType(ChildType, 4, .{});
+    var failing = std.testing.FailingAllocator.init(
+        std.testing.allocator,
+        .{ .fail_index = 1 },
+    );
+
+    try std.testing.expectError(
+        error.OutOfMemory,
+        Hasher(ListType).init(failing.allocator()),
+    );
+    try std.testing.expectEqual(failing.allocated_bytes, failing.freed_bytes);
+}
 
 // std.testing.allocator can't see pool-slot leaks, so check getNodesInUse() against a baseline.
 test "TreeView composite list sliceTo does not leak pool nodes" {

--- a/src/ssz/memory_safety_test.zig
+++ b/src/ssz/memory_safety_test.zig
@@ -1,12 +1,15 @@
 const std = @import("std");
 const pmt = @import("persistent_merkle_tree");
+const Gindex = pmt.Gindex;
 const Node = pmt.Node;
 const ChunkedLeafType = pmt.ChunkedLeaf;
 const DoubleFreeDetectAllocator = @import("testing_allocators").DoubleFreeDetectAllocator;
 const ArmOnSizeAllocator = @import("testing_allocators").ArmOnSizeAllocator;
 const FixedContainerType = @import("type/container.zig").FixedContainerType;
 const FixedListType = @import("type/list.zig").FixedListType;
+const FixedVectorType = @import("type/vector.zig").FixedVectorType;
 const UintType = @import("type/uint.zig").UintType;
+const BitVectorType = @import("type/bit_vector.zig").BitVectorType;
 const ByteVectorType = @import("type/byte_vector.zig").ByteVectorType;
 
 const Checkpoint = FixedContainerType(struct {
@@ -548,4 +551,132 @@ test "ListBasicTreeView chunked_leaf: set OOM in setChildNode reclaims the CoW c
 
     // The freshly-CoW'd node + its 2KB blob were reclaimed, not leaked.
     try std.testing.expectEqual(baseline, pool.getNodesInUse());
+}
+
+test "ArrayBasicTreeView set should reclaim unpublished node on OOM" {
+    const allocator = std.testing.allocator;
+    var failing = std.testing.FailingAllocator.init(allocator, .{ .resize_fail_index = 0 });
+
+    var pool = try Node.Pool.init(.{
+        .page_allocator = allocator,
+        .allocator = allocator,
+        .pool_size = 128,
+    });
+    defer pool.deinit();
+
+    const VectorType = FixedVectorType(UintType(64), 4, .{});
+    const value: VectorType.Type = .{ 11, 22, 33, 44 };
+    const root = try VectorType.tree.fromValue(&pool, &value);
+    var view = try VectorType.TreeView.init(failing.allocator(), &pool, root);
+    defer view.deinit();
+
+    try std.testing.expectEqual(@as(u64, 11), try view.get(0));
+    const nodes_in_use = pool.getNodesInUse();
+
+    failing.fail_index = failing.alloc_index;
+    try std.testing.expectError(error.OutOfMemory, view.set(0, 99));
+    failing.fail_index = std.math.maxInt(usize);
+
+    // The failed update must not leave an extra in-use pool node.
+    try std.testing.expectEqual(nodes_in_use, pool.getNodesInUse());
+    try std.testing.expectEqual(@as(u64, 11), try view.get(0));
+
+    try view.set(0, 99);
+    try std.testing.expectEqual(@as(u64, 99), try view.get(0));
+}
+
+test "ArrayCompositeTreeView get should leave caches unchanged on OOM" {
+    const allocator = std.testing.allocator;
+    var failing = std.testing.FailingAllocator.init(allocator, .{ .resize_fail_index = 0 });
+
+    var pool = try Node.Pool.init(.{
+        .page_allocator = allocator,
+        .allocator = allocator,
+        .pool_size = 128,
+    });
+    defer pool.deinit();
+
+    const Inner = FixedContainerType(struct { x: UintType(64) });
+    const VectorType = FixedVectorType(Inner, 2, .{});
+    const value: VectorType.Type = .{ .{ .x = 1 }, .{ .x = 2 } };
+    const root = try VectorType.tree.fromValue(&pool, &value);
+    var view = try VectorType.TreeView.init(failing.allocator(), &pool, root);
+    defer view.deinit();
+
+    try view.chunks.state.changed.ensureUnusedCapacity(failing.allocator(), 1);
+
+    failing.fail_index = failing.alloc_index;
+    try std.testing.expectError(error.OutOfMemory, view.get(0));
+    failing.fail_index = std.math.maxInt(usize);
+
+    // A failed mutable get must not publish the index as changed.
+    try std.testing.expectEqual(@as(usize, 0), view.chunks.state.changed.count());
+
+    _ = try view.get(0);
+}
+
+test "ArrayCompositeTreeView getReadonly should reclaim unpublished child view on OOM" {
+    const allocator = std.testing.allocator;
+    var failing = std.testing.FailingAllocator.init(allocator, .{ .resize_fail_index = 0 });
+
+    var pool = try Node.Pool.init(.{
+        .page_allocator = allocator,
+        .allocator = allocator,
+        .pool_size = 128,
+    });
+    defer pool.deinit();
+
+    const Inner = FixedContainerType(struct { x: UintType(64) });
+    const VectorType = FixedVectorType(Inner, 2, .{});
+    const value: VectorType.Type = .{ .{ .x = 1 }, .{ .x = 2 } };
+    const root = try VectorType.tree.fromValue(&pool, &value);
+    var view = try VectorType.TreeView.init(failing.allocator(), &pool, root);
+    defer view.deinit();
+
+    try view.chunks.state.children_nodes.ensureUnusedCapacity(failing.allocator(), 1);
+    const gindex = Gindex.fromDepth(VectorType.chunk_depth, 0);
+    const child_node = try view.chunks.state.getChildNode(gindex);
+    const child_ref_count = child_node.getState(&pool).refCount();
+    const outstanding_bytes = failing.allocated_bytes - failing.freed_bytes;
+
+    failing.fail_index = failing.alloc_index + 1;
+    try std.testing.expectError(error.OutOfMemory, view.getReadonly(0));
+    failing.fail_index = std.math.maxInt(usize);
+
+    // A failed readonly cache insertion must release the child view's node ref and allocation.
+    try std.testing.expectEqual(child_ref_count, child_node.getState(&pool).refCount());
+    try std.testing.expectEqual(outstanding_bytes, failing.allocated_bytes - failing.freed_bytes);
+
+    _ = try view.getReadonly(0);
+}
+
+test "BitVectorTreeView set should reclaim unpublished node on OOM" {
+    const allocator = std.testing.allocator;
+    var failing = std.testing.FailingAllocator.init(allocator, .{ .resize_fail_index = 0 });
+
+    var pool = try Node.Pool.init(.{
+        .page_allocator = allocator,
+        .allocator = allocator,
+        .pool_size = 128,
+    });
+    defer pool.deinit();
+
+    const Bits = BitVectorType(44);
+    const root = try Bits.tree.fromValue(&pool, &Bits.default_value);
+    var view = try Bits.TreeView.init(failing.allocator(), &pool, root);
+    defer view.deinit();
+
+    try std.testing.expect(!try view.get(0));
+    const nodes_in_use = pool.getNodesInUse();
+
+    failing.fail_index = failing.alloc_index;
+    try std.testing.expectError(error.OutOfMemory, view.set(0, true));
+    failing.fail_index = std.math.maxInt(usize);
+
+    // The failed update must not leave an extra in-use pool node.
+    try std.testing.expectEqual(nodes_in_use, pool.getNodesInUse());
+    try std.testing.expect(!try view.get(0));
+
+    try view.set(0, true);
+    try std.testing.expect(try view.get(0));
 }

--- a/src/ssz/tree_view/bit_array.zig
+++ b/src/ssz/tree_view/bit_array.zig
@@ -71,6 +71,8 @@ pub fn BitArray(comptime chunk_depth: Depth) type {
             }
 
             const new_leaf = try self.state.pool.createLeaf(&leaf_bytes);
+            errdefer self.state.pool.unref(new_leaf);
+
             try self.state.setChildNode(gindex, new_leaf);
         }
 

--- a/src/ssz/tree_view/chunks.zig
+++ b/src/ssz/tree_view/chunks.zig
@@ -97,7 +97,10 @@ pub fn BasicPackedChunks(
             }
             const gindex = Gindex.fromDepth(chunk_depth, index / items_per_chunk);
             const child_node = try self.state.getChildNode(gindex);
+
             const new_node = try ST.Element.tree.fromValuePacked(child_node, self.state.pool, index, &value);
+            errdefer self.state.pool.unref(new_node);
+
             try self.state.setChildNode(gindex, new_node);
         }
 
@@ -426,19 +429,23 @@ pub fn CompositeChunks(
         /// clone(transfer_cache) invalidates it — re-get() after either, and don't deinit it.
         pub fn get(self: *Self, index: usize) !ElementPtr {
             const gindex = Gindex.fromDepth(chunk_depth, index);
-            // Always mark as changed - the child may have been previously cached
-            // via getReadonly() without being tracked in changed.
-            try self.state.changed.put(self.state.allocator, gindex, {});
-            const gop = try self.children_data.getOrPut(self.state.allocator, gindex);
-            if (gop.found_existing) {
-                return gop.value_ptr.*;
+            // A successful mutable get always marks the child as changed, including a child cached
+            // by getReadonly(). Reserve first, then publish only after all fallible work succeeds.
+            if (!self.state.changed.contains(gindex)) {
+                try self.state.changed.ensureUnusedCapacity(self.state.allocator, 1);
             }
-            // getOrPut's new slot holds an undefined value until we fill it below; drop it on
-            // failure, or a later deinit would free a garbage pointer.
-            errdefer _ = self.children_data.remove(gindex);
+            if (self.children_data.get(gindex)) |child_ptr| {
+                self.state.changed.putAssumeCapacity(gindex, {});
+                return child_ptr;
+            }
+
+            try self.children_data.ensureUnusedCapacity(self.state.allocator, 1);
+
             const child_node = try self.state.getChildNode(gindex);
             const child_ptr = try Element.init(self.state.allocator, self.state.pool, child_node);
-            gop.value_ptr.* = child_ptr;
+
+            self.state.changed.putAssumeCapacity(gindex, {});
+            self.children_data.putAssumeCapacityNoClobber(gindex, child_ptr);
             return child_ptr;
         }
 
@@ -470,9 +477,12 @@ pub fn CompositeChunks(
                 return child_ptr;
             }
             const child_node = try self.state.getChildNode(gindex);
+
             const child_ptr = try Element.init(self.state.allocator, self.state.pool, child_node);
-            try self.children_data.put(self.state.allocator, gindex, child_ptr);
-            // Do NOT add to self.state.changed (read-only)
+            errdefer child_ptr.deinit();
+
+            // Readonly access publishes the child cache without marking the index as changed.
+            try self.children_data.putNoClobber(self.state.allocator, gindex, child_ptr);
             return child_ptr;
         }
 

--- a/src/ssz/tree_view/utils/tree_view_state.zig
+++ b/src/ssz/tree_view/utils/tree_view_state.zig
@@ -61,12 +61,15 @@ pub const TreeViewState = struct {
     }
 
     pub fn setChildNode(self: *TreeViewState, gindex: Gindex, node: Node.Id) !void {
-        try self.changed.put(self.allocator, gindex, {});
-        const opt_old_node = try self.children_nodes.fetchPut(
-            self.allocator,
-            gindex,
-            node,
-        );
+        if (!self.changed.contains(gindex)) {
+            try self.changed.ensureUnusedCapacity(self.allocator, 1);
+        }
+        if (!self.children_nodes.contains(gindex)) {
+            try self.children_nodes.ensureUnusedCapacity(self.allocator, 1);
+        }
+
+        self.changed.putAssumeCapacity(gindex, {});
+        const opt_old_node = self.children_nodes.fetchPutAssumeCapacity(gindex, node);
         if (opt_old_node) |old_node| {
             if (old_node.value.getState(self.pool).refCount() == 0) {
                 self.pool.unref(old_node.value);


### PR DESCRIPTION
## Summary
- merge current `main` into `fix/ssz-composite-element-cleanup`
- preserve both sets of memory-safety regressions while resolving the only content conflict

## Verification
- `zig fmt --check .`
- `zig build test:ssz`
- `pnpm lint` (passes with existing warnings)