### PR TITLE
fix(ssz): reclaim partial byte and bit vector trees

### DIFF
--- a/src/ssz/memory_safety_test.zig
+++ b/src/ssz/memory_safety_test.zig
@@ -18,6 +18,116 @@ const Checkpoint = FixedContainerType(struct {
     root: ByteVectorType(32),
 });
 
+fn fillPoolLeavingFreeSlots(pool: *Node.Pool, free_slot_count: usize) !void {
+    try pool.preheat(@intCast(pool.nodes.capacity - pool.nodes.len));
+
+    const available_free_count = pool.nodes.len - @intFromEnum(pool.next_free_node);
+    std.debug.assert(free_slot_count <= available_free_count);
+
+    const filler_count = available_free_count - free_slot_count;
+    for (0..filler_count) |_| {
+        _ = try pool.createLeaf(&[_]u8{0} ** 32);
+    }
+}
+
+test "ByteVector tree.deserializeFromBytes should reclaim partial leaves on OOM" {
+    const VectorType = ByteVectorType(64);
+    var failing = std.testing.FailingAllocator.init(
+        std.testing.allocator,
+        .{ .fail_index = 1 },
+    );
+    var pool = try Node.Pool.init(.{
+        .page_allocator = failing.allocator(),
+        .allocator = failing.allocator(),
+        .pool_size = 0,
+    });
+    defer pool.deinit();
+
+    try fillPoolLeavingFreeSlots(&pool, 1);
+
+    const baseline = pool.getNodesInUse();
+    const bytes = [_]u8{0} ** VectorType.fixed_size;
+
+    try std.testing.expectError(
+        error.OutOfMemory,
+        VectorType.tree.deserializeFromBytes(&pool, &bytes),
+    );
+    try std.testing.expectEqual(baseline, pool.getNodesInUse());
+}
+
+test "ByteVector tree.fromValue should reclaim leaves when fill fails with OOM" {
+    const VectorType = ByteVectorType(64);
+    var failing = std.testing.FailingAllocator.init(
+        std.testing.allocator,
+        .{ .fail_index = 1 },
+    );
+    var pool = try Node.Pool.init(.{
+        .page_allocator = failing.allocator(),
+        .allocator = failing.allocator(),
+        .pool_size = 0,
+    });
+    defer pool.deinit();
+
+    try fillPoolLeavingFreeSlots(&pool, 2);
+
+    const baseline = pool.getNodesInUse();
+
+    try std.testing.expectError(
+        error.OutOfMemory,
+        VectorType.tree.fromValue(&pool, &VectorType.default_value),
+    );
+    try std.testing.expectEqual(baseline, pool.getNodesInUse());
+}
+
+test "BitVector tree.deserializeFromBytes should reclaim partial leaves on OOM" {
+    const VectorType = BitVectorType(512);
+    var failing = std.testing.FailingAllocator.init(
+        std.testing.allocator,
+        .{ .fail_index = 1 },
+    );
+    var pool = try Node.Pool.init(.{
+        .page_allocator = failing.allocator(),
+        .allocator = failing.allocator(),
+        .pool_size = 0,
+    });
+    defer pool.deinit();
+
+    try fillPoolLeavingFreeSlots(&pool, 1);
+
+    const baseline = pool.getNodesInUse();
+    const bytes = [_]u8{0} ** VectorType.fixed_size;
+
+    try std.testing.expectError(
+        error.OutOfMemory,
+        VectorType.tree.deserializeFromBytes(&pool, &bytes),
+    );
+    try std.testing.expectEqual(baseline, pool.getNodesInUse());
+}
+
+test "BitVector tree.fromValue should reclaim leaves when fill fails with OOM" {
+    const VectorType = BitVectorType(512);
+    var failing = std.testing.FailingAllocator.init(
+        std.testing.allocator,
+        .{ .fail_index = 1 },
+    );
+    var pool = try Node.Pool.init(.{
+        .page_allocator = failing.allocator(),
+        .allocator = failing.allocator(),
+        .pool_size = 0,
+    });
+    defer pool.deinit();
+
+    try fillPoolLeavingFreeSlots(&pool, 2);
+
+    const baseline = pool.getNodesInUse();
+
+    try std.testing.expectError(
+        error.OutOfMemory,
+        VectorType.tree.fromValue(&pool, &VectorType.default_value),
+    );
+    try std.testing.expectEqual(baseline, pool.getNodesInUse());
+}
+
 test "Hasher init container should not leak initialized prefix on later child OOM" {
     const ChildType = FixedVectorType(UintType(64), 8, .{});
     const ContainerType = FixedContainerType(struct {

--- a/src/ssz/memory_safety_test.zig
+++ b/src/ssz/memory_safety_test.zig
@@ -52,6 +52,7 @@ test "ByteVector tree.deserializeFromBytes should reclaim partial leaves on OOM"
         error.OutOfMemory,
         VectorType.tree.deserializeFromBytes(&pool, &bytes),
     );
+    // The first leaf must not remain in the pool after the second leaf allocation fails.
     try std.testing.expectEqual(baseline, pool.getNodesInUse());
 }
 
@@ -76,6 +77,7 @@ test "ByteVector tree.fromValue should reclaim leaves when fill fails with OOM" 
         error.OutOfMemory,
         VectorType.tree.fromValue(&pool, &VectorType.default_value),
     );
+    // The two leaves must not remain in the pool after parent construction fails.
     try std.testing.expectEqual(baseline, pool.getNodesInUse());
 }
 
@@ -101,6 +103,7 @@ test "BitVector tree.deserializeFromBytes should reclaim partial leaves on OOM" 
         error.OutOfMemory,
         VectorType.tree.deserializeFromBytes(&pool, &bytes),
     );
+    // The first leaf must not remain in the pool after the second leaf allocation fails.
     try std.testing.expectEqual(baseline, pool.getNodesInUse());
 }
 
@@ -125,6 +128,7 @@ test "BitVector tree.fromValue should reclaim leaves when fill fails with OOM" {
         error.OutOfMemory,
         VectorType.tree.fromValue(&pool, &VectorType.default_value),
     );
+    // The two leaves must not remain in the pool after parent construction fails.
     try std.testing.expectEqual(baseline, pool.getNodesInUse());
 }
 

--- a/src/ssz/type/bit_vector.zig
+++ b/src/ssz/type/bit_vector.zig
@@ -232,7 +232,9 @@ pub fn BitVectorType(comptime _length: comptime_int) type {
                 const chunk_bytes: []u8 = @ptrCast(&chunks);
                 @memcpy(chunk_bytes[0..byte_length], data[0..byte_length]);
 
-                var nodes: [chunk_count]Node.Id = undefined;
+                var nodes: [chunk_count]Node.Id = @splat(@as(Node.Id, @enumFromInt(0)));
+                errdefer pool.free(&nodes);
+
                 for (&chunks, 0..) |*chunk, i| {
                     nodes[i] = try pool.createLeaf(chunk);
                 }
@@ -260,7 +262,9 @@ pub fn BitVectorType(comptime _length: comptime_int) type {
             }
 
             pub fn fromValue(pool: *Node.Pool, value: *const Type) !Node.Id {
-                var nodes: [chunk_count]Node.Id = undefined;
+                var nodes: [chunk_count]Node.Id = @splat(@as(Node.Id, @enumFromInt(0)));
+                errdefer pool.free(&nodes);
+
                 for (0..chunk_count) |i| {
                     var leaf_buf = [_]u8{0} ** 32;
                     const start_idx = i * 32;

--- a/src/ssz/type/byte_vector.zig
+++ b/src/ssz/type/byte_vector.zig
@@ -93,7 +93,9 @@ pub fn ByteVectorType(comptime _length: comptime_int) type {
                 const chunk_bytes: []u8 = @ptrCast(&chunks);
                 @memcpy(chunk_bytes[0..length], data[0..length]);
 
-                var nodes: [chunk_count]Node.Id = undefined;
+                var nodes: [chunk_count]Node.Id = @splat(@as(Node.Id, @enumFromInt(0)));
+                errdefer pool.free(&nodes);
+
                 for (&chunks, 0..) |*chunk, i| {
                     nodes[i] = try pool.createLeaf(chunk);
                 }
@@ -119,7 +121,9 @@ pub fn ByteVectorType(comptime _length: comptime_int) type {
             }
 
             pub fn fromValue(pool: *Node.Pool, value: *const Type) !Node.Id {
-                var nodes: [chunk_count]Node.Id = undefined;
+                var nodes: [chunk_count]Node.Id = @splat(@as(Node.Id, @enumFromInt(0)));
+                errdefer pool.free(&nodes);
+
                 for (0..chunk_count) |i| {
                     var leaf_buf = [_]u8{0} ** 32;
                     const start_idx = i * 32;


### PR DESCRIPTION
## Motivation

ByteVector and BitVector tree construction creates leaf nodes before building the parent tree. If a later leaf or parent branch allocation failed, the fresh pool nodes were abandoned.

## Description

- Reclaim fresh ByteVector and BitVector nodes when deserialize or value conversion fails.
- Add four deterministic OOM regressions for second-leaf and final-parent failures.