### PR TITLE
fix(ssz): clean up partially decoded blocks

### DIFF
--- a/src/fork_types/any_beacon_block.zig
+++ b/src/fork_types/any_beacon_block.zig
@@ -788,37 +788,3 @@ fn testBlockSanity(Block: type) !void {
 test "electra - sanity" {
     try testBlockSanity(AnyBeaconBlock);
 }
-
-test "AnySignedBeaconBlock deserialize should deinit partial block on OOM" {
-    const allocator = std.testing.allocator;
-    const SignedBeaconBlock = ct.phase0.SignedBeaconBlock;
-
-    var block = SignedBeaconBlock.default_value;
-    defer SignedBeaconBlock.deinit(allocator, &block);
-
-    try block.message.body.proposer_slashings.append(
-        allocator,
-        ct.phase0.ProposerSlashing.default_value,
-    );
-    try block.message.body.voluntary_exits.append(
-        allocator,
-        ct.phase0.SignedVoluntaryExit.default_value,
-    );
-
-    const bytes = try allocator.alloc(u8, SignedBeaconBlock.serializedSize(&block));
-    defer allocator.free(bytes);
-    _ = SignedBeaconBlock.serializeIntoBytes(&block, bytes);
-
-    const voluntary_exits_fail_index = 2;
-    var failing = std.testing.FailingAllocator.init(
-        allocator,
-        .{ .fail_index = voluntary_exits_fail_index },
-    );
-    try std.testing.expectError(
-        error.OutOfMemory,
-        AnySignedBeaconBlock.deserialize(failing.allocator(), .full, .phase0, bytes),
-    );
-
-    // The decoded proposer slashings list must not leak when voluntary exits allocation fails.
-    try std.testing.expectEqual(failing.allocated_bytes, failing.freed_bytes);
-}

--- a/src/fork_types/any_beacon_block.zig
+++ b/src/fork_types/any_beacon_block.zig
@@ -21,6 +21,21 @@ const AnyAttesterSlashings = @import("./any_attester_slashing.zig").AnyAttesterS
 const BeaconBlock = @import("./beacon_block.zig").BeaconBlock;
 const BeaconBlockBody = @import("./beacon_block.zig").BeaconBlockBody;
 
+fn deserializeSignedBlock(
+    comptime SignedBlock: type,
+    allocator: std.mem.Allocator,
+    bytes: []const u8,
+) !*SignedBlock.Type {
+    const signed_block = try allocator.create(SignedBlock.Type);
+    errdefer allocator.destroy(signed_block);
+
+    signed_block.* = SignedBlock.default_value;
+    errdefer SignedBlock.deinit(allocator, signed_block);
+
+    try SignedBlock.deserializeFromBytes(allocator, bytes, signed_block);
+    return signed_block;
+}
+
 pub const AnySignedBeaconBlock = union(enum) {
     phase0: *ct.phase0.SignedBeaconBlock.Type,
     altair: *ct.altair.SignedBeaconBlock.Type,
@@ -40,101 +55,114 @@ pub const AnySignedBeaconBlock = union(enum) {
         switch (fork_seq) {
             .phase0 => {
                 if (block_type != .full) return error.InvalidBlockTypeForFork;
-                const signed_block = try allocator.create(ct.phase0.SignedBeaconBlock.Type);
-                errdefer allocator.destroy(signed_block);
-                signed_block.* = ct.phase0.SignedBeaconBlock.default_value;
-                try ct.phase0.SignedBeaconBlock.deserializeFromBytes(allocator, bytes, signed_block);
+                const signed_block = try deserializeSignedBlock(
+                    ct.phase0.SignedBeaconBlock,
+                    allocator,
+                    bytes,
+                );
                 return .{ .phase0 = signed_block };
             },
             .altair => {
                 if (block_type != .full) return error.InvalidBlockTypeForFork;
-                const signed_block = try allocator.create(ct.altair.SignedBeaconBlock.Type);
-                errdefer allocator.destroy(signed_block);
-                signed_block.* = ct.altair.SignedBeaconBlock.default_value;
-                try ct.altair.SignedBeaconBlock.deserializeFromBytes(allocator, bytes, signed_block);
+                const signed_block = try deserializeSignedBlock(
+                    ct.altair.SignedBeaconBlock,
+                    allocator,
+                    bytes,
+                );
                 return .{ .altair = signed_block };
             },
             .bellatrix => {
                 if (block_type == .full) {
-                    const signed_block = try allocator.create(ct.bellatrix.SignedBeaconBlock.Type);
-                    errdefer allocator.destroy(signed_block);
-                    signed_block.* = ct.bellatrix.SignedBeaconBlock.default_value;
-                    try ct.bellatrix.SignedBeaconBlock.deserializeFromBytes(allocator, bytes, signed_block);
+                    const signed_block = try deserializeSignedBlock(
+                        ct.bellatrix.SignedBeaconBlock,
+                        allocator,
+                        bytes,
+                    );
                     return .{ .full_bellatrix = signed_block };
                 } else {
-                    const signed_block = try allocator.create(ct.bellatrix.SignedBlindedBeaconBlock.Type);
-                    errdefer allocator.destroy(signed_block);
-                    signed_block.* = ct.bellatrix.SignedBlindedBeaconBlock.default_value;
-                    try ct.bellatrix.SignedBlindedBeaconBlock.deserializeFromBytes(allocator, bytes, signed_block);
+                    const signed_block = try deserializeSignedBlock(
+                        ct.bellatrix.SignedBlindedBeaconBlock,
+                        allocator,
+                        bytes,
+                    );
                     return .{ .blinded_bellatrix = signed_block };
                 }
             },
             .capella => {
                 if (block_type == .full) {
-                    const signed_block = try allocator.create(ct.capella.SignedBeaconBlock.Type);
-                    errdefer allocator.destroy(signed_block);
-                    signed_block.* = ct.capella.SignedBeaconBlock.default_value;
-                    try ct.capella.SignedBeaconBlock.deserializeFromBytes(allocator, bytes, signed_block);
+                    const signed_block = try deserializeSignedBlock(
+                        ct.capella.SignedBeaconBlock,
+                        allocator,
+                        bytes,
+                    );
                     return .{ .full_capella = signed_block };
                 } else {
-                    const signed_block = try allocator.create(ct.capella.SignedBlindedBeaconBlock.Type);
-                    errdefer allocator.destroy(signed_block);
-                    signed_block.* = ct.capella.SignedBlindedBeaconBlock.default_value;
-                    try ct.capella.SignedBlindedBeaconBlock.deserializeFromBytes(allocator, bytes, signed_block);
+                    const signed_block = try deserializeSignedBlock(
+                        ct.capella.SignedBlindedBeaconBlock,
+                        allocator,
+                        bytes,
+                    );
                     return .{ .blinded_capella = signed_block };
                 }
             },
             .deneb => {
                 if (block_type == .full) {
-                    const signed_block = try allocator.create(ct.deneb.SignedBeaconBlock.Type);
-                    errdefer allocator.destroy(signed_block);
-                    signed_block.* = ct.deneb.SignedBeaconBlock.default_value;
-                    try ct.deneb.SignedBeaconBlock.deserializeFromBytes(allocator, bytes, signed_block);
+                    const signed_block = try deserializeSignedBlock(
+                        ct.deneb.SignedBeaconBlock,
+                        allocator,
+                        bytes,
+                    );
                     return .{ .full_deneb = signed_block };
                 } else {
-                    const signed_block = try allocator.create(ct.deneb.SignedBlindedBeaconBlock.Type);
-                    errdefer allocator.destroy(signed_block);
-                    signed_block.* = ct.deneb.SignedBlindedBeaconBlock.default_value;
-                    try ct.deneb.SignedBlindedBeaconBlock.deserializeFromBytes(allocator, bytes, signed_block);
+                    const signed_block = try deserializeSignedBlock(
+                        ct.deneb.SignedBlindedBeaconBlock,
+                        allocator,
+                        bytes,
+                    );
                     return .{ .blinded_deneb = signed_block };
                 }
             },
             .electra => {
                 if (block_type == .full) {
-                    const signed_block = try allocator.create(ct.electra.SignedBeaconBlock.Type);
-                    errdefer allocator.destroy(signed_block);
-                    signed_block.* = ct.electra.SignedBeaconBlock.default_value;
-                    try ct.electra.SignedBeaconBlock.deserializeFromBytes(allocator, bytes, signed_block);
+                    const signed_block = try deserializeSignedBlock(
+                        ct.electra.SignedBeaconBlock,
+                        allocator,
+                        bytes,
+                    );
                     return .{ .full_electra = signed_block };
                 } else {
-                    const signed_block = try allocator.create(ct.electra.SignedBlindedBeaconBlock.Type);
-                    errdefer allocator.destroy(signed_block);
-                    signed_block.* = ct.electra.SignedBlindedBeaconBlock.default_value;
-                    try ct.electra.SignedBlindedBeaconBlock.deserializeFromBytes(allocator, bytes, signed_block);
+                    const signed_block = try deserializeSignedBlock(
+                        ct.electra.SignedBlindedBeaconBlock,
+                        allocator,
+                        bytes,
+                    );
                     return .{ .blinded_electra = signed_block };
                 }
             },
             .fulu => {
                 if (block_type == .full) {
-                    const signed_block = try allocator.create(ct.fulu.SignedBeaconBlock.Type);
-                    errdefer allocator.destroy(signed_block);
-                    signed_block.* = ct.fulu.SignedBeaconBlock.default_value;
-                    try ct.fulu.SignedBeaconBlock.deserializeFromBytes(allocator, bytes, signed_block);
+                    const signed_block = try deserializeSignedBlock(
+                        ct.fulu.SignedBeaconBlock,
+                        allocator,
+                        bytes,
+                    );
                     return .{ .full_fulu = signed_block };
                 } else {
-                    const signed_block = try allocator.create(ct.fulu.SignedBlindedBeaconBlock.Type);
-                    errdefer allocator.destroy(signed_block);
-                    signed_block.* = ct.fulu.SignedBlindedBeaconBlock.default_value;
-                    try ct.fulu.SignedBlindedBeaconBlock.deserializeFromBytes(allocator, bytes, signed_block);
+                    const signed_block = try deserializeSignedBlock(
+                        ct.fulu.SignedBlindedBeaconBlock,
+                        allocator,
+                        bytes,
+                    );
                     return .{ .blinded_fulu = signed_block };
                 }
             },
             .gloas => {
                 if (block_type != .full) return error.InvalidBlockTypeForFork;
-                const signed_block = try allocator.create(ct.gloas.SignedBeaconBlock.Type);
-                errdefer allocator.destroy(signed_block);
-                signed_block.* = ct.gloas.SignedBeaconBlock.default_value;
-                try ct.gloas.SignedBeaconBlock.deserializeFromBytes(allocator, bytes, signed_block);
+                const signed_block = try deserializeSignedBlock(
+                    ct.gloas.SignedBeaconBlock,
+                    allocator,
+                    bytes,
+                );
                 return .{ .full_gloas = signed_block };
             },
         }
@@ -759,4 +787,38 @@ fn testBlockSanity(Block: type) !void {
 
 test "electra - sanity" {
     try testBlockSanity(AnyBeaconBlock);
+}
+
+test "AnySignedBeaconBlock deserialize should deinit partial block on OOM" {
+    const allocator = std.testing.allocator;
+    const SignedBeaconBlock = ct.phase0.SignedBeaconBlock;
+
+    var block = SignedBeaconBlock.default_value;
+    defer SignedBeaconBlock.deinit(allocator, &block);
+
+    try block.message.body.proposer_slashings.append(
+        allocator,
+        ct.phase0.ProposerSlashing.default_value,
+    );
+    try block.message.body.voluntary_exits.append(
+        allocator,
+        ct.phase0.SignedVoluntaryExit.default_value,
+    );
+
+    const bytes = try allocator.alloc(u8, SignedBeaconBlock.serializedSize(&block));
+    defer allocator.free(bytes);
+    _ = SignedBeaconBlock.serializeIntoBytes(&block, bytes);
+
+    const voluntary_exits_fail_index = 2;
+    var failing = std.testing.FailingAllocator.init(
+        allocator,
+        .{ .fail_index = voluntary_exits_fail_index },
+    );
+    try std.testing.expectError(
+        error.OutOfMemory,
+        AnySignedBeaconBlock.deserialize(failing.allocator(), .full, .phase0, bytes),
+    );
+
+    // The decoded proposer slashings list must not leak when voluntary exits allocation fails.
+    try std.testing.expectEqual(failing.allocated_bytes, failing.freed_bytes);
 }

--- a/src/fork_types/memory_safety_test.zig
+++ b/src/fork_types/memory_safety_test.zig
@@ -1,0 +1,37 @@
+const std = @import("std");
+const ct = @import("consensus_types");
+const AnySignedBeaconBlock = @import("./any_beacon_block.zig").AnySignedBeaconBlock;
+
+test "AnySignedBeaconBlock deserialize should deinit partial block on OOM" {
+    const allocator = std.testing.allocator;
+    const SignedBeaconBlock = ct.phase0.SignedBeaconBlock;
+
+    var block = SignedBeaconBlock.default_value;
+    defer SignedBeaconBlock.deinit(allocator, &block);
+
+    try block.message.body.proposer_slashings.append(
+        allocator,
+        ct.phase0.ProposerSlashing.default_value,
+    );
+    try block.message.body.voluntary_exits.append(
+        allocator,
+        ct.phase0.SignedVoluntaryExit.default_value,
+    );
+
+    const bytes = try allocator.alloc(u8, SignedBeaconBlock.serializedSize(&block));
+    defer allocator.free(bytes);
+    _ = SignedBeaconBlock.serializeIntoBytes(&block, bytes);
+
+    const voluntary_exits_fail_index = 2;
+    var failing = std.testing.FailingAllocator.init(
+        allocator,
+        .{ .fail_index = voluntary_exits_fail_index },
+    );
+    try std.testing.expectError(
+        error.OutOfMemory,
+        AnySignedBeaconBlock.deserialize(failing.allocator(), .full, .phase0, bytes),
+    );
+
+    // The decoded proposer slashings list must not leak when voluntary exits allocation fails.
+    try std.testing.expectEqual(failing.allocated_bytes, failing.freed_bytes);
+}

--- a/src/fork_types/root.zig
+++ b/src/fork_types/root.zig
@@ -21,6 +21,8 @@ pub const AnyAttesterSlashing = @import("./any_attester_slashing.zig").AnyAttest
 
 const testing = @import("std").testing;
 test {
+    _ = @import("./memory_safety_test.zig");
+
     testing.refAllDecls(BeaconState(.fulu));
     testing.refAllDecls(SignedBeaconBlock(.full, .fulu));
     testing.refAllDecls(BeaconBlock(.full, .fulu));


### PR DESCRIPTION
## Motivation

Fork-aware signed-block decoding initializes variable SSZ fields in a heap-allocated block. If decoding failed after allocating an early field, the outer block was destroyed without deinitializing the partial value.

## Description

- Centralize fork-specific signed-block allocation, initialization, decoding, and error cleanup.
- Add a deterministic phase0 OOM regression at the public fork-aware decode boundary.