### PR TITLE
fix(state-transition): clean up upgraded payload headers

### DIFF
--- a/src/state_transition/memory_safety_test.zig
+++ b/src/state_transition/memory_safety_test.zig
@@ -17,7 +17,6 @@ const upgradeStateToCapella = @import("slot/upgrade_state_to_capella.zig").upgra
 const upgradeStateToDeneb = @import("slot/upgrade_state_to_deneb.zig").upgradeStateToDeneb;
 
 test "upgradeStateToCapella and upgradeStateToDeneb should release temporary payload headers" {
-    // std.testing.allocator makes the test fail on leaks even without an explicit expect.
     const allocator = std.testing.allocator;
     const chain_config = if (active_preset == .mainnet)
         config.mainnet.chain_config
@@ -65,6 +64,8 @@ test "upgradeStateToCapella and upgradeStateToDeneb should release temporary pay
     );
     defer epoch_cache.deinit();
 
+    // std.testing.allocator makes the test fail without an explicit expect if either upgrade
+    // leaks its temporary payload header.
     const capella_state = try upgradeStateToCapella(
         allocator,
         &beacon_config,

--- a/src/state_transition/memory_safety_test.zig
+++ b/src/state_transition/memory_safety_test.zig
@@ -16,7 +16,8 @@ const processRewardsAndPenalties =
 const upgradeStateToCapella = @import("slot/upgrade_state_to_capella.zig").upgradeStateToCapella;
 const upgradeStateToDeneb = @import("slot/upgrade_state_to_deneb.zig").upgradeStateToDeneb;
 
-fn runPayloadHeaderUpgradeCleanupTest(allocator: std.mem.Allocator) !void {
+test "upgradeStateToCapella and upgradeStateToDeneb should release temporary payload headers" {
+    const allocator = std.testing.allocator;
     const chain_config = if (active_preset == .mainnet)
         config.mainnet.chain_config
     else
@@ -78,15 +79,6 @@ fn runPayloadHeaderUpgradeCleanupTest(allocator: std.mem.Allocator) !void {
         state.castToFork(.capella),
     );
     state = .{ .deneb = deneb_state.inner };
-}
-
-test "upgradeStateToCapella and upgradeStateToDeneb should release temporary payload headers" {
-    var debug_allocator: std.heap.DebugAllocator(.{}) = .init;
-    const run_result = runPayloadHeaderUpgradeCleanupTest(debug_allocator.allocator());
-    const deinit_status = debug_allocator.deinit();
-
-    try std.testing.expectEqual(.ok, deinit_status);
-    try run_result;
 }
 
 test "deserializeContainerOverrideFields... cleans up pool nodes on error" {

--- a/src/state_transition/memory_safety_test.zig
+++ b/src/state_transition/memory_safety_test.zig
@@ -17,6 +17,8 @@ const upgradeStateToCapella = @import("slot/upgrade_state_to_capella.zig").upgra
 const upgradeStateToDeneb = @import("slot/upgrade_state_to_deneb.zig").upgradeStateToDeneb;
 
 test "upgradeStateToCapella and upgradeStateToDeneb should release temporary payload headers" {
+    // The test runner checks this allocator for leaks after all test-scope defers run,
+    // so this test needs no explicit leak assertion.
     const allocator = std.testing.allocator;
     const chain_config = if (active_preset == .mainnet)
         config.mainnet.chain_config

--- a/src/state_transition/memory_safety_test.zig
+++ b/src/state_transition/memory_safety_test.zig
@@ -1,11 +1,93 @@
 const std = @import("std");
+const config = @import("config");
+const ct = @import("consensus_types");
+const AnyBeaconState = @import("fork_types").AnyBeaconState;
+const active_preset = @import("preset").active_preset;
 const ssz = @import("ssz");
 const Node = @import("persistent_merkle_tree").Node;
 const TestCachedBeaconState = @import("test_utils/root.zig").TestCachedBeaconState;
+const getConfig = @import("test_utils/generate_state.zig").getConfig;
+const EpochCache = @import("cache/epoch_cache.zig").EpochCache;
+const PubkeyCache = @import("cache/pubkey_cache.zig").PubkeyCache;
 const deserializeContainerOverrideFieldsWithRanges =
     @import("ssz_container.zig").deserializeContainerOverrideFieldsWithRanges;
 const processRewardsAndPenalties =
     @import("epoch/process_rewards_and_penalties.zig").processRewardsAndPenalties;
+const upgradeStateToCapella = @import("slot/upgrade_state_to_capella.zig").upgradeStateToCapella;
+const upgradeStateToDeneb = @import("slot/upgrade_state_to_deneb.zig").upgradeStateToDeneb;
+
+fn runPayloadHeaderUpgradeCleanupTest(allocator: std.mem.Allocator) !void {
+    const chain_config = if (active_preset == .mainnet)
+        config.mainnet.chain_config
+    else
+        config.minimal.chain_config;
+
+    var pool = try Node.Pool.init(.{
+        .page_allocator = allocator,
+        .allocator = allocator,
+        .pool_size = 10_000,
+    });
+    defer pool.deinit();
+
+    var bellatrix_value = ct.bellatrix.BeaconState.default_value;
+    defer ct.bellatrix.BeaconState.deinit(allocator, &bellatrix_value);
+    bellatrix_value.fork = .{
+        .previous_version = chain_config.ALTAIR_FORK_VERSION,
+        .current_version = chain_config.BELLATRIX_FORK_VERSION,
+        .epoch = 0,
+    };
+    try bellatrix_value.latest_execution_payload_header.extra_data.append(allocator, 0xaa);
+
+    var state = try AnyBeaconState.fromValue(allocator, &pool, .bellatrix, &bellatrix_value);
+    defer state.deinit();
+
+    var pubkey_cache = PubkeyCache.init(allocator, std.testing.io);
+    defer pubkey_cache.deinit();
+
+    const beacon_config = config.BeaconConfig.init(
+        getConfig(chain_config, .bellatrix, 0),
+        (try state.genesisValidatorsRoot()).*,
+    );
+    const epoch_cache = try EpochCache.createFromState(
+        allocator,
+        std.testing.io,
+        &state,
+        .{
+            .config = &beacon_config,
+            .pubkey_cache = &pubkey_cache,
+        },
+        .{
+            .skip_sync_committee_cache = true,
+            .skip_sync_pubkeys = true,
+        },
+    );
+    defer epoch_cache.deinit();
+
+    const capella_state = try upgradeStateToCapella(
+        allocator,
+        &beacon_config,
+        epoch_cache,
+        state.castToFork(.bellatrix),
+    );
+    state = .{ .capella = capella_state.inner };
+
+    const deneb_state = try upgradeStateToDeneb(
+        allocator,
+        &beacon_config,
+        epoch_cache,
+        state.castToFork(.capella),
+    );
+    state = .{ .deneb = deneb_state.inner };
+}
+
+test "upgradeStateToCapella and upgradeStateToDeneb should release temporary payload headers" {
+    var debug_allocator: std.heap.DebugAllocator(.{}) = .init;
+    const run_result = runPayloadHeaderUpgradeCleanupTest(debug_allocator.allocator());
+    const deinit_status = debug_allocator.deinit();
+
+    try std.testing.expectEqual(.ok, deinit_status);
+    try run_result;
+}
 
 test "deserializeContainerOverrideFields... cleans up pool nodes on error" {
     const allocator = std.testing.allocator;

--- a/src/state_transition/memory_safety_test.zig
+++ b/src/state_transition/memory_safety_test.zig
@@ -17,8 +17,7 @@ const upgradeStateToCapella = @import("slot/upgrade_state_to_capella.zig").upgra
 const upgradeStateToDeneb = @import("slot/upgrade_state_to_deneb.zig").upgradeStateToDeneb;
 
 test "upgradeStateToCapella and upgradeStateToDeneb should release temporary payload headers" {
-    // The test runner checks this allocator for leaks after all test-scope defers run,
-    // so this test needs no explicit leak assertion.
+    // std.testing.allocator makes the test fail on leaks even without an explicit expect.
     const allocator = std.testing.allocator;
     const chain_config = if (active_preset == .mainnet)
         config.mainnet.chain_config

--- a/src/state_transition/slot/upgrade_state_to_capella.zig
+++ b/src/state_transition/slot/upgrade_state_to_capella.zig
@@ -59,6 +59,8 @@ pub fn upgradeStateToCapella(
     try state.setFork(&new_fork);
 
     var new_latest_execution_payload_header = ct.capella.ExecutionPayloadHeader.default_value;
+    defer ct.capella.ExecutionPayloadHeader.deinit(allocator, &new_latest_execution_payload_header);
+
     var bellatrix_latest_execution_payload_header = ct.bellatrix.ExecutionPayloadHeader.default_value;
     try bellatrix_state.latestExecutionPayloadHeader(allocator, &bellatrix_latest_execution_payload_header);
     defer ct.bellatrix.ExecutionPayloadHeader.deinit(allocator, &bellatrix_latest_execution_payload_header);

--- a/src/state_transition/slot/upgrade_state_to_deneb.zig
+++ b/src/state_transition/slot/upgrade_state_to_deneb.zig
@@ -21,8 +21,9 @@ pub fn upgradeStateToDeneb(
     };
     try state.setFork(&new_fork);
 
-    // ownership is transferred to BeaconState
     var new_latest_execution_payload_header = ct.deneb.ExecutionPayloadHeader.default_value;
+    defer ct.deneb.ExecutionPayloadHeader.deinit(allocator, &new_latest_execution_payload_header);
+
     var capella_latest_execution_payload_header = ct.capella.ExecutionPayloadHeader.default_value;
     try capella_state.latestExecutionPayloadHeader(allocator, &capella_latest_execution_payload_header);
     defer ct.capella.ExecutionPayloadHeader.deinit(allocator, &capella_latest_execution_payload_header);


### PR DESCRIPTION
## Motivation

Capella and Deneb state upgrades clone `latest_execution_payload_header.extra_data` into a temporary value. `setLatestExecutionPayloadHeader()` copies that value into the persistent Merkle tree, but the temporary header was never deinitialized, leaking non-empty `extra_data` buffers.

## Description

- Deinitialize the temporary upgraded payload header on success and error paths.
- Remove the misleading Deneb ownership-transfer comment.
- Preserve the existing clone and TreeView ownership contracts.
- Add a production-boundary regression covering both fork upgrades.