### PR TITLE
fix(pmt): reclaim grouped intermediate roots

### DIFF
--- a/src/persistent_merkle_tree/Node.zig
+++ b/src/persistent_merkle_tree/Node.zig
@@ -1516,6 +1516,8 @@ pub const Id = enum(u32) {
         }
 
         var node_id = root_node;
+        errdefer if (node_id != root_node) pool.unref(node_id);
+
         var start: usize = 0;
         while (start < gindices.len) {
             const depth = gindices[start].pathLen();

--- a/src/persistent_merkle_tree/memory_safety_test.zig
+++ b/src/persistent_merkle_tree/memory_safety_test.zig
@@ -32,11 +32,13 @@ test "setNodesGrouped should release an intermediate root when a later group run
     const new_data = try pool.createLeafFromUint(101);
     defer pool.unref(new_data);
 
+    // Arm OOM after setup: within-capacity node creation still succeeds, but pool growth fails.
     failing.fail_index = failing.alloc_index;
 
     var filler: std.ArrayList(Node.Id) = .empty;
     defer filler.deinit(std.testing.allocator);
 
+    // Leave one free slot for the depth-1 group, forcing the depth-2 group to grow the pool.
     while (pool.createLeafFromUint(0)) |id| {
         try filler.append(std.testing.allocator, id);
     } else |err| switch (err) {
@@ -45,6 +47,7 @@ test "setNodesGrouped should release an intermediate root when a later group run
     pool.unref(filler.pop().?);
 
     const in_use_before = pool.getNodesInUse();
+    // Model a list commit: gindex 3 stores the length mix-in and gindex 4 stores data.
     const gindices = [_]Gindex{ Gindex.fromUint(3), Gindex.fromUint(4) };
     var nodes = [_]Node.Id{ new_length, new_data };
 

--- a/src/persistent_merkle_tree/memory_safety_test.zig
+++ b/src/persistent_merkle_tree/memory_safety_test.zig
@@ -45,6 +45,7 @@ test "setNodesGrouped should release an intermediate root when a later group run
     // Free exactly one slot for the depth-1 group, leaving none for the depth-2 group.
     pool.unref(capacity_fill_nodes.pop().?);
 
+    // Both replacement nodes are rc=0 caller-owned slots, but they still count as in use.
     const nodes_in_use_before_update = pool.getNodesInUse();
     const replacement_length_gindex = Gindex.fromDepth(1, 1);
     const replacement_data_gindex = Gindex.fromDepth(2, 0);

--- a/src/persistent_merkle_tree/memory_safety_test.zig
+++ b/src/persistent_merkle_tree/memory_safety_test.zig
@@ -22,11 +22,13 @@ test "setNodesGrouped should release an intermediate root when a later group run
     const root = try pool.createBranch(content_root, original_length_node);
     defer pool.unref(root);
 
+    // The first group consumes this node; teardown owns it only if rollback does not free it.
     const replacement_length_node = try pool.createLeafFromUint(100);
     defer if (!replacement_length_node.getState(&pool).isFree()) {
         pool.unref(replacement_length_node);
     };
 
+    // The second group fails before consuming this node, so the test retains ownership.
     const replacement_data_node = try pool.createLeafFromUint(101);
     defer pool.unref(replacement_data_node);
 
@@ -60,10 +62,17 @@ test "setNodesGrouped should release an intermediate root when a later group run
         root.setNodesGrouped(&pool, &replacement_gindices, &replacement_nodes),
     );
 
-    // Creating and freeing the intermediate root cancel out. Rollback also frees the consumed
-    // replacement length node that was already included in nodes_in_use_before_update.
+    // The first group consumed the replacement length, so grouped rollback must free it.
+    try std.testing.expect(replacement_length_node.getState(&pool).isFree());
+
+    // Creating and freeing the intermediate root cancel out. Freeing the replacement length,
+    // which was already included in the baseline, leaves one fewer node in use.
     try std.testing.expectEqual(nodes_in_use_before_update - 1, pool.getNodesInUse());
+
+    // The failed grouped update returns no new root, leaving the original root caller-owned.
     try std.testing.expect(!root.getState(&pool).isFree());
+
+    // The second group failed before consuming the replacement data, which remains caller-owned.
     try std.testing.expect(!replacement_data_node.getState(&pool).isFree());
 
     for (capacity_fill_nodes.items) |id| pool.unref(id);

--- a/src/persistent_merkle_tree/memory_safety_test.zig
+++ b/src/persistent_merkle_tree/memory_safety_test.zig
@@ -62,15 +62,17 @@ test "setNodesGrouped should release an intermediate root when a later group run
         root.setNodesGrouped(&pool, &replacement_gindices, &replacement_nodes),
     );
 
-    // The first update attached the replacement length to the temporary root, so rolling that
-    // root back frees both. The data update failed before attaching its node, leaving it and the
-    // original root for this test to clean up.
+    // The first update put the replacement length under the intermediate root. When the second
+    // update fails, rolling back that root frees the length with it.
     try std.testing.expect(replacement_length_node.getState(&pool).isFree());
 
-    // The temporary root was both created and freed; the net -1 is the released length node.
-    try std.testing.expectEqual(nodes_in_use_before_update - 1, pool.getNodesInUse());
+    // The original root was never consumed, and the failed second update never attached the data.
     try std.testing.expect(!root.getState(&pool).isFree());
     try std.testing.expect(!replacement_data_node.getState(&pool).isFree());
+
+    // The intermediate root adds one node and rollback removes it again. The baseline already
+    // counted the replacement length, so freeing that node is the only net change.
+    try std.testing.expectEqual(nodes_in_use_before_update - 1, pool.getNodesInUse());
 
     for (capacity_fill_nodes.items) |id| pool.unref(id);
 }

--- a/src/persistent_merkle_tree/memory_safety_test.zig
+++ b/src/persistent_merkle_tree/memory_safety_test.zig
@@ -1,0 +1,62 @@
+const std = @import("std");
+
+const Node = @import("Node.zig");
+const Gindex = @import("gindex.zig").Gindex;
+
+test "setNodesGrouped should release an intermediate root when a later group runs out of memory" {
+    var failing = std.testing.FailingAllocator.init(std.testing.allocator, .{ .resize_fail_index = 0 });
+
+    var pool = try Node.Pool.init(.{
+        .page_allocator = failing.allocator(),
+        .allocator = std.testing.allocator,
+        .pool_size = 16,
+    });
+    defer pool.deinit();
+
+    const p = &pool;
+
+    const left = try pool.createBranch(
+        try pool.createLeafFromUint(1),
+        try pool.createLeafFromUint(2),
+    );
+    const right = try pool.createBranch(
+        try pool.createLeafFromUint(3),
+        try pool.createLeafFromUint(4),
+    );
+    const root = try pool.createBranch(left, right);
+    defer pool.unref(root);
+
+    const new_length = try pool.createLeafFromUint(100);
+    defer if (!new_length.getState(p).isFree()) pool.unref(new_length);
+
+    const new_data = try pool.createLeafFromUint(101);
+    defer pool.unref(new_data);
+
+    failing.fail_index = failing.alloc_index;
+
+    var filler: std.ArrayList(Node.Id) = .empty;
+    defer filler.deinit(std.testing.allocator);
+
+    while (pool.createLeafFromUint(0)) |id| {
+        try filler.append(std.testing.allocator, id);
+    } else |err| switch (err) {
+        error.OutOfMemory => {},
+    }
+    pool.unref(filler.pop().?);
+
+    const in_use_before = pool.getNodesInUse();
+    const gindices = [_]Gindex{ Gindex.fromUint(3), Gindex.fromUint(4) };
+    var nodes = [_]Node.Id{ new_length, new_data };
+
+    try std.testing.expectError(error.OutOfMemory, root.setNodesGrouped(p, &gindices, &nodes));
+
+    failing.fail_index = std.math.maxInt(usize);
+
+    // The first group consumes new_length, so its rollback must release that node together with
+    // the intermediate root. The original root and the unprocessed new_data remain caller-owned.
+    try std.testing.expectEqual(in_use_before - 1, pool.getNodesInUse());
+    try std.testing.expect(!root.getState(p).isFree());
+    try std.testing.expect(!new_data.getState(p).isFree());
+
+    for (filler.items) |id| pool.unref(id);
+}

--- a/src/persistent_merkle_tree/memory_safety_test.zig
+++ b/src/persistent_merkle_tree/memory_safety_test.zig
@@ -13,7 +13,7 @@ test "setNodesGrouped should release an intermediate root when a later group run
     });
     defer pool.deinit();
 
-    // This matches a list root: content subtree on the left and length leaf on the right.
+    // A list tree stores its content on the left and its length on the right.
     const content_root = try pool.createBranch(
         try pool.createLeafFromUint(1),
         try pool.createLeafFromUint(2),
@@ -22,32 +22,29 @@ test "setNodesGrouped should release an intermediate root when a later group run
     const root = try pool.createBranch(content_root, original_length_node);
     defer pool.unref(root);
 
-    // The first group consumes this node; teardown owns it only if rollback does not free it.
     const replacement_length_node = try pool.createLeafFromUint(100);
     defer if (!replacement_length_node.getState(&pool).isFree()) {
         pool.unref(replacement_length_node);
     };
 
-    // The second group fails before consuming this node, so the test retains ownership.
     const replacement_data_node = try pool.createLeafFromUint(101);
     defer pool.unref(replacement_data_node);
 
-    // Fail only later pool growth after the fixture is fully allocated.
+    // From here on, the pool can reuse free slots but cannot grow.
     failing.fail_index = failing.alloc_index;
 
     var capacity_fill_nodes: std.ArrayList(Node.Id) = .empty;
     defer capacity_fill_nodes.deinit(std.testing.allocator);
 
-    // Fill every current pool slot; the next allocation reaches the armed growth OOM.
+    // Fill the pool, then free one slot. The length update uses it, forcing the data update to
+    // grow the pool and fail.
     while (pool.createLeafFromUint(0)) |id| {
         try capacity_fill_nodes.append(std.testing.allocator, id);
     } else |err| switch (err) {
         error.OutOfMemory => {},
     }
-    // Free exactly one slot for the depth-1 group, leaving none for the depth-2 group.
     pool.unref(capacity_fill_nodes.pop().?);
 
-    // Both replacement nodes are rc=0 caller-owned slots, but they still count as in use.
     const nodes_in_use_before_update = pool.getNodesInUse();
     const replacement_length_gindex = Gindex.fromDepth(1, 1);
     const replacement_data_gindex = Gindex.fromDepth(2, 0);
@@ -62,17 +59,11 @@ test "setNodesGrouped should release an intermediate root when a later group run
         root.setNodesGrouped(&pool, &replacement_gindices, &replacement_nodes),
     );
 
-    // The first group consumed the replacement length, so grouped rollback must free it.
+    // Rolling back the temporary root also frees the replacement length it owned. The temporary
+    // root itself cancels out of the count, while the original root and replacement data stay ours.
     try std.testing.expect(replacement_length_node.getState(&pool).isFree());
-
-    // Creating and freeing the intermediate root cancel out. Freeing the replacement length,
-    // which was already included in the baseline, leaves one fewer node in use.
     try std.testing.expectEqual(nodes_in_use_before_update - 1, pool.getNodesInUse());
-
-    // The failed grouped update returns no new root, leaving the original root caller-owned.
     try std.testing.expect(!root.getState(&pool).isFree());
-
-    // The second group failed before consuming the replacement data, which remains caller-owned.
     try std.testing.expect(!replacement_data_node.getState(&pool).isFree());
 
     for (capacity_fill_nodes.items) |id| pool.unref(id);

--- a/src/persistent_merkle_tree/memory_safety_test.zig
+++ b/src/persistent_merkle_tree/memory_safety_test.zig
@@ -59,7 +59,8 @@ test "setNodesGrouped should release an intermediate root when a later group run
         root.setNodesGrouped(&pool, &replacement_gindices, &replacement_nodes),
     );
 
-    // Rollback frees the consumed length and intermediate root; the other inputs remain owned.
+    // Creating and freeing the intermediate root cancel out. Rollback also frees the consumed
+    // replacement length node that was already included in nodes_in_use_before_update.
     try std.testing.expectEqual(nodes_in_use_before_update - 1, pool.getNodesInUse());
     try std.testing.expect(!root.getState(&pool).isFree());
     try std.testing.expect(!replacement_data_node.getState(&pool).isFree());

--- a/src/persistent_merkle_tree/memory_safety_test.zig
+++ b/src/persistent_merkle_tree/memory_safety_test.zig
@@ -59,8 +59,6 @@ test "setNodesGrouped should release an intermediate root when a later group run
         root.setNodesGrouped(&pool, &replacement_gindices, &replacement_nodes),
     );
 
-    failing.fail_index = std.math.maxInt(usize);
-
     // Rollback frees the consumed length and intermediate root; the other inputs remain owned.
     try std.testing.expectEqual(nodes_in_use_before_update - 1, pool.getNodesInUse());
     try std.testing.expect(!root.getState(&pool).isFree());

--- a/src/persistent_merkle_tree/memory_safety_test.zig
+++ b/src/persistent_merkle_tree/memory_safety_test.zig
@@ -22,22 +22,24 @@ test "setNodesGrouped should release an intermediate root when a later group run
     const root = try pool.createBranch(content_root, original_length_node);
     defer pool.unref(root);
 
+    // The length update runs first. Once it succeeds, its temporary root owns this node.
     const replacement_length_node = try pool.createLeafFromUint(100);
     defer if (!replacement_length_node.getState(&pool).isFree()) {
         pool.unref(replacement_length_node);
     };
 
+    // The data update runs second, and the test fails before this node is attached.
     const replacement_data_node = try pool.createLeafFromUint(101);
     defer pool.unref(replacement_data_node);
 
-    // From here on, the pool can reuse free slots but cannot grow.
+    // Setup is complete. Existing slots still work, but growing the pool now fails.
     failing.fail_index = failing.alloc_index;
 
     var capacity_fill_nodes: std.ArrayList(Node.Id) = .empty;
     defer capacity_fill_nodes.deinit(std.testing.allocator);
 
-    // Fill the pool, then free one slot. The length update uses it, forcing the data update to
-    // grow the pool and fail.
+    // Fill the pool, then give one slot back. The length update needs that one slot; the data
+    // update needs more space and is where OOM occurs.
     while (pool.createLeafFromUint(0)) |id| {
         try capacity_fill_nodes.append(std.testing.allocator, id);
     } else |err| switch (err) {
@@ -46,6 +48,7 @@ test "setNodesGrouped should release an intermediate root when a later group run
     pool.unref(capacity_fill_nodes.pop().?);
 
     const nodes_in_use_before_update = pool.getNodesInUse();
+    // A list commit updates the length at depth 1 and the first data leaf at depth 2.
     const replacement_length_gindex = Gindex.fromDepth(1, 1);
     const replacement_data_gindex = Gindex.fromDepth(2, 0);
     const replacement_gindices = [_]Gindex{
@@ -59,9 +62,12 @@ test "setNodesGrouped should release an intermediate root when a later group run
         root.setNodesGrouped(&pool, &replacement_gindices, &replacement_nodes),
     );
 
-    // Rolling back the temporary root also frees the replacement length it owned. The temporary
-    // root itself cancels out of the count, while the original root and replacement data stay ours.
+    // The first update attached the replacement length to the temporary root, so rolling that
+    // root back frees both. The data update failed before attaching its node, leaving it and the
+    // original root for this test to clean up.
     try std.testing.expect(replacement_length_node.getState(&pool).isFree());
+
+    // The temporary root was both created and freed; the net -1 is the released length node.
     try std.testing.expectEqual(nodes_in_use_before_update - 1, pool.getNodesInUse());
     try std.testing.expect(!root.getState(&pool).isFree());
     try std.testing.expect(!replacement_data_node.getState(&pool).isFree());

--- a/src/persistent_merkle_tree/memory_safety_test.zig
+++ b/src/persistent_merkle_tree/memory_safety_test.zig
@@ -36,12 +36,13 @@ test "setNodesGrouped should release an intermediate root when a later group run
     var capacity_fill_nodes: std.ArrayList(Node.Id) = .empty;
     defer capacity_fill_nodes.deinit(std.testing.allocator);
 
-    // Leave one slot so the depth-1 length group succeeds and the depth-2 data group must grow.
+    // Fill every current pool slot; the next allocation reaches the armed growth OOM.
     while (pool.createLeafFromUint(0)) |id| {
         try capacity_fill_nodes.append(std.testing.allocator, id);
     } else |err| switch (err) {
         error.OutOfMemory => {},
     }
+    // Free exactly one slot for the depth-1 group, leaving none for the depth-2 group.
     pool.unref(capacity_fill_nodes.pop().?);
 
     const nodes_in_use_before_update = pool.getNodesInUse();

--- a/src/persistent_merkle_tree/memory_safety_test.zig
+++ b/src/persistent_merkle_tree/memory_safety_test.zig
@@ -13,53 +13,57 @@ test "setNodesGrouped should release an intermediate root when a later group run
     });
     defer pool.deinit();
 
-    const p = &pool;
-
-    const left = try pool.createBranch(
+    // This matches a list root: content subtree on the left and length leaf on the right.
+    const content_root = try pool.createBranch(
         try pool.createLeafFromUint(1),
         try pool.createLeafFromUint(2),
     );
-    const right = try pool.createBranch(
-        try pool.createLeafFromUint(3),
-        try pool.createLeafFromUint(4),
-    );
-    const root = try pool.createBranch(left, right);
+    const original_length_node = try pool.createLeafFromUint(2);
+    const root = try pool.createBranch(content_root, original_length_node);
     defer pool.unref(root);
 
-    const new_length = try pool.createLeafFromUint(100);
-    defer if (!new_length.getState(p).isFree()) pool.unref(new_length);
+    const replacement_length_node = try pool.createLeafFromUint(100);
+    defer if (!replacement_length_node.getState(&pool).isFree()) {
+        pool.unref(replacement_length_node);
+    };
 
-    const new_data = try pool.createLeafFromUint(101);
-    defer pool.unref(new_data);
+    const replacement_data_node = try pool.createLeafFromUint(101);
+    defer pool.unref(replacement_data_node);
 
-    // Arm OOM after setup: within-capacity node creation still succeeds, but pool growth fails.
+    // Fail only later pool growth after the fixture is fully allocated.
     failing.fail_index = failing.alloc_index;
 
-    var filler: std.ArrayList(Node.Id) = .empty;
-    defer filler.deinit(std.testing.allocator);
+    var capacity_fill_nodes: std.ArrayList(Node.Id) = .empty;
+    defer capacity_fill_nodes.deinit(std.testing.allocator);
 
-    // Leave one free slot for the depth-1 group, forcing the depth-2 group to grow the pool.
+    // Leave one slot so the depth-1 length group succeeds and the depth-2 data group must grow.
     while (pool.createLeafFromUint(0)) |id| {
-        try filler.append(std.testing.allocator, id);
+        try capacity_fill_nodes.append(std.testing.allocator, id);
     } else |err| switch (err) {
         error.OutOfMemory => {},
     }
-    pool.unref(filler.pop().?);
+    pool.unref(capacity_fill_nodes.pop().?);
 
-    const in_use_before = pool.getNodesInUse();
-    // Model a list commit: gindex 3 stores the length mix-in and gindex 4 stores data.
-    const gindices = [_]Gindex{ Gindex.fromUint(3), Gindex.fromUint(4) };
-    var nodes = [_]Node.Id{ new_length, new_data };
+    const nodes_in_use_before_update = pool.getNodesInUse();
+    const replacement_length_gindex = Gindex.fromDepth(1, 1);
+    const replacement_data_gindex = Gindex.fromDepth(2, 0);
+    const replacement_gindices = [_]Gindex{
+        replacement_length_gindex,
+        replacement_data_gindex,
+    };
+    var replacement_nodes = [_]Node.Id{ replacement_length_node, replacement_data_node };
 
-    try std.testing.expectError(error.OutOfMemory, root.setNodesGrouped(p, &gindices, &nodes));
+    try std.testing.expectError(
+        error.OutOfMemory,
+        root.setNodesGrouped(&pool, &replacement_gindices, &replacement_nodes),
+    );
 
     failing.fail_index = std.math.maxInt(usize);
 
-    // The first group consumes new_length, so its rollback must release that node together with
-    // the intermediate root. The original root and the unprocessed new_data remain caller-owned.
-    try std.testing.expectEqual(in_use_before - 1, pool.getNodesInUse());
-    try std.testing.expect(!root.getState(p).isFree());
-    try std.testing.expect(!new_data.getState(p).isFree());
+    // Rollback frees the consumed length and intermediate root; the other inputs remain owned.
+    try std.testing.expectEqual(nodes_in_use_before_update - 1, pool.getNodesInUse());
+    try std.testing.expect(!root.getState(&pool).isFree());
+    try std.testing.expect(!replacement_data_node.getState(&pool).isFree());
 
-    for (filler.items) |id| pool.unref(id);
+    for (capacity_fill_nodes.items) |id| pool.unref(id);
 }

--- a/src/persistent_merkle_tree/node_test.zig
+++ b/src/persistent_merkle_tree/node_test.zig
@@ -498,6 +498,60 @@ test "setNodes - later-iteration OOM rolls back without panicking on a freed slo
     try std.testing.expectEqual(fresh, try ok_root.getNode(p, Gindex.fromDepth(1, 0)));
 }
 
+test "setNodesGrouped should release an intermediate root when a later group runs out of memory" {
+    var failing = std.testing.FailingAllocator.init(std.testing.allocator, .{ .resize_fail_index = 0 });
+
+    var pool = try Node.Pool.init(.{
+        .page_allocator = failing.allocator(),
+        .allocator = std.testing.allocator,
+        .pool_size = 16,
+    });
+    defer pool.deinit();
+
+    const p = &pool;
+
+    const left = try pool.createBranch(
+        try pool.createLeafFromUint(1),
+        try pool.createLeafFromUint(2),
+    );
+    const right = try pool.createBranch(
+        try pool.createLeafFromUint(3),
+        try pool.createLeafFromUint(4),
+    );
+    const root = try pool.createBranch(left, right);
+    defer pool.unref(root);
+
+    const new_length = try pool.createLeafFromUint(100);
+    defer if (!new_length.getState(p).isFree()) pool.unref(new_length);
+
+    const new_data = try pool.createLeafFromUint(101);
+    defer pool.unref(new_data);
+
+    failing.fail_index = failing.alloc_index;
+
+    var filler: std.ArrayList(Node.Id) = .empty;
+    defer filler.deinit(std.testing.allocator);
+
+    try drainPoolToFull(&pool, &filler);
+    pool.unref(filler.pop().?);
+
+    const in_use_before = pool.getNodesInUse();
+    const gindices = [_]Gindex{ Gindex.fromUint(3), Gindex.fromUint(4) };
+    var nodes = [_]Node.Id{ new_length, new_data };
+
+    try std.testing.expectError(error.OutOfMemory, root.setNodesGrouped(p, &gindices, &nodes));
+
+    failing.fail_index = std.math.maxInt(usize);
+
+    // The first group consumes new_length, so its rollback must release that node together with
+    // the intermediate root. The original root and the unprocessed new_data remain caller-owned.
+    try std.testing.expectEqual(in_use_before - 1, pool.getNodesInUse());
+    try std.testing.expect(!root.getState(p).isFree());
+    try std.testing.expect(!new_data.getState(p).isFree());
+
+    for (filler.items) |id| pool.unref(id);
+}
+
 test "Node.State - refcount overflow saturates at rc_mask without corrupting kind" {
     var at_max = Node.State.initInUse(.leaf, Node.State.rc_mask);
     try std.testing.expectError(Node.Error.RefCountOverflow, at_max.incRefCount());

--- a/src/persistent_merkle_tree/node_test.zig
+++ b/src/persistent_merkle_tree/node_test.zig
@@ -498,60 +498,6 @@ test "setNodes - later-iteration OOM rolls back without panicking on a freed slo
     try std.testing.expectEqual(fresh, try ok_root.getNode(p, Gindex.fromDepth(1, 0)));
 }
 
-test "setNodesGrouped should release an intermediate root when a later group runs out of memory" {
-    var failing = std.testing.FailingAllocator.init(std.testing.allocator, .{ .resize_fail_index = 0 });
-
-    var pool = try Node.Pool.init(.{
-        .page_allocator = failing.allocator(),
-        .allocator = std.testing.allocator,
-        .pool_size = 16,
-    });
-    defer pool.deinit();
-
-    const p = &pool;
-
-    const left = try pool.createBranch(
-        try pool.createLeafFromUint(1),
-        try pool.createLeafFromUint(2),
-    );
-    const right = try pool.createBranch(
-        try pool.createLeafFromUint(3),
-        try pool.createLeafFromUint(4),
-    );
-    const root = try pool.createBranch(left, right);
-    defer pool.unref(root);
-
-    const new_length = try pool.createLeafFromUint(100);
-    defer if (!new_length.getState(p).isFree()) pool.unref(new_length);
-
-    const new_data = try pool.createLeafFromUint(101);
-    defer pool.unref(new_data);
-
-    failing.fail_index = failing.alloc_index;
-
-    var filler: std.ArrayList(Node.Id) = .empty;
-    defer filler.deinit(std.testing.allocator);
-
-    try drainPoolToFull(&pool, &filler);
-    pool.unref(filler.pop().?);
-
-    const in_use_before = pool.getNodesInUse();
-    const gindices = [_]Gindex{ Gindex.fromUint(3), Gindex.fromUint(4) };
-    var nodes = [_]Node.Id{ new_length, new_data };
-
-    try std.testing.expectError(error.OutOfMemory, root.setNodesGrouped(p, &gindices, &nodes));
-
-    failing.fail_index = std.math.maxInt(usize);
-
-    // The first group consumes new_length, so its rollback must release that node together with
-    // the intermediate root. The original root and the unprocessed new_data remain caller-owned.
-    try std.testing.expectEqual(in_use_before - 1, pool.getNodesInUse());
-    try std.testing.expect(!root.getState(p).isFree());
-    try std.testing.expect(!new_data.getState(p).isFree());
-
-    for (filler.items) |id| pool.unref(id);
-}
-
 test "Node.State - refcount overflow saturates at rc_mask without corrupting kind" {
     var at_max = Node.State.initInUse(.leaf, Node.State.rc_mask);
     try std.testing.expectError(Node.Error.RefCountOverflow, at_max.incRefCount());

--- a/src/persistent_merkle_tree/root.zig
+++ b/src/persistent_merkle_tree/root.zig
@@ -13,6 +13,7 @@ pub const ChunkedLeaf = @import("ChunkedLeaf.zig");
 
 test {
     testing.refAllDecls(@This());
+    _ = @import("memory_safety_test.zig");
     testing.refAllDecls(@import("node_test.zig"));
     testing.refAllDecls(@import("proof_test.zig"));
     testing.refAllDecls(@import("view_test.zig"));


### PR DESCRIPTION
## Motivation

`setNodesGrouped()` applies updates one depth group at a time. If a later group failed, the root produced by an earlier group was abandoned together with the child it had consumed.

## Description

- Reclaim intermediate roots when a later grouped update fails.
- Add a deterministic mixed-depth OOM regression.