### PR TITLE
(Don't merge)fix(ssz): validate variable list length offsets

### DIFF
--- a/src/ssz/type/list.zig
+++ b/src/ssz/type/list.zig
@@ -817,7 +817,7 @@ pub fn VariableListType(comptime ST: type, comptime _limit: comptime_int) type {
                     return 0;
                 }
                 var iterator = OffsetIterator(Self).init(data);
-                return try iterator.firstOffset() / 4;
+                return try iterator.next() / 4;
             }
 
             pub fn hashTreeRoot(allocator: std.mem.Allocator, data: []const u8, out: *[32]u8) !void {
@@ -1066,6 +1066,14 @@ test "ListType - sanity" {
 
     _ = BytesBytes.serializeIntoBytes(&bb, bb_buf);
     try BytesBytes.deserializeFromBytes(allocator, bb_buf, &bb);
+}
+
+test "VariableListType serialized.length should reject a first offset beyond the input" {
+    const Element = FixedListType(UintType(16), 2, .{});
+    const List = VariableListType(Element, 4);
+    const data = [_]u8{ 8, 0, 0, 0 };
+
+    try std.testing.expectError(error.offsetOutOfRange, List.serialized.length(&data));
 }
 
 test "clone FixedListType" {

--- a/src/ssz/type/list.zig
+++ b/src/ssz/type/list.zig
@@ -817,7 +817,7 @@ pub fn VariableListType(comptime ST: type, comptime _limit: comptime_int) type {
                     return 0;
                 }
                 var iterator = OffsetIterator(Self).init(data);
-                return try iterator.next() / 4;
+                return try iterator.firstOffset() / 4;
             }
 
             pub fn hashTreeRoot(allocator: std.mem.Allocator, data: []const u8, out: *[32]u8) !void {

--- a/src/ssz/type/offsets.zig
+++ b/src/ssz/type/offsets.zig
@@ -58,6 +58,9 @@ pub fn OffsetIterator(comptime ST: type) type {
                     return error.invalidOffsetCount;
                 }
             }
+            if (first_offset > self.data.len) {
+                return error.offsetOutOfRange;
+            }
 
             return first_offset;
         }

--- a/src/ssz/type/offsets.zig
+++ b/src/ssz/type/offsets.zig
@@ -75,8 +75,10 @@ pub fn OffsetIterator(comptime ST: type) type {
             else
                 self.readOffset(self.pos);
 
-            if (offset > self.data.len) {
-                return error.offsetOutOfRange;
+            if (self.pos > 0) {
+                if (offset > self.data.len) {
+                    return error.offsetOutOfRange;
+                }
             }
             if (offset < self.prev_offset) {
                 return error.offsetNotIncreasing;


### PR DESCRIPTION
## Motivation

`OffsetIterator.firstOffset()` validated the offset table shape and count but not whether the first offset was within the input. `VariableListType.serialized.length()` could therefore expose a false element count and make serialized hashing allocate before rejecting malformed bytes.

## Description

- Validate the first offset range before returning it.
- Add a malformed VariableList length regression.