### PR TITLE
fix(ssz): hash boolean lists as basic lists

### DIFF
--- a/src/ssz/hasher.zig
+++ b/src/ssz/hasher.zig
@@ -94,7 +94,7 @@ pub fn Hasher(comptime ST: type) type {
                             }
                         }
                         try h.merkleize(@ptrCast(scratch.chunks.items), ST.chunk_depth, out);
-                        if (ST.Element.kind == .bool) {
+                        if (comptime isBitListType(ST)) {
                             h.mixInLength(value.bit_len, out);
                         } else {
                             h.mixInLength(value.items.len, out);
@@ -152,3 +152,27 @@ pub const HasherData = struct {
         chunks.deinit(allocator);
     }
 };
+
+test "Hasher should hash ordinary boolean lists as basic lists" {
+    const BooleanList = @import("type/list.zig").FixedListType(
+        @import("type/bool.zig").BoolType(),
+        64,
+        .{},
+    );
+    const allocator = std.testing.allocator;
+
+    var value = BooleanList.default_value;
+    defer BooleanList.deinit(allocator, &value);
+    try value.appendSlice(allocator, &.{ true, false, true });
+
+    var scratch = try Hasher(BooleanList).init(allocator);
+    defer scratch.deinit(allocator);
+
+    var expected: [32]u8 = undefined;
+    try BooleanList.hashTreeRoot(allocator, &value, &expected);
+
+    var actual: [32]u8 = undefined;
+    try Hasher(BooleanList).hash(&scratch, &value, &actual);
+
+    try std.testing.expectEqual(expected, actual);
+}


### PR DESCRIPTION
## Motivation

`Hasher` selected Bitlist length handling for every list with Boolean elements. Instantiating it with an ordinary `List[boolean]` therefore tried to read Bitlist-only storage and failed to compile.

## Description

- Use the exact Bitlist type discriminator when mixing in list length.
- Add a regression comparing incremental hashing with the type's canonical hash-tree root.

The implementation and regression test were primarily AI-authored and independently reviewed with AI assistance.