### PR TITLE
fix(ssz): reject overflowing bit list indexes

### DIFF
--- a/src/ssz/type/bit_list.zig
+++ b/src/ssz/type/bit_list.zig
@@ -645,19 +645,6 @@ test "BitListType - sanity" {
     try std.testing.expect(try b.get(0) == false);
 }
 
-test "BitList set should reject max usize index" {
-    const allocator = std.testing.allocator;
-    const Bits = BitListType(8);
-
-    var value = Bits.default_value;
-    defer Bits.deinit(allocator, &value);
-
-    try std.testing.expectError(
-        error.tooLarge,
-        value.set(allocator, std.math.maxInt(usize), true),
-    );
-}
-
 test "BitListType - sanity with bools" {
     const allocator = std.testing.allocator;
     const Bits = BitListType(16);
@@ -731,7 +718,7 @@ test "clone" {
     try expectEqualSerializedAlloc(Bits, allocator, b, cloned);
 }
 
-test "resize" {
+test "BitList resize and set should enforce length bounds" {
     const allocator = std.testing.allocator;
 
     const Bits = BitListType(16);
@@ -752,6 +739,11 @@ test "resize" {
 
     try std.testing.expect(b.data.items.len == 1);
     try std.testing.expect(b.data.items[0] == 13);
+
+    try std.testing.expectError(
+        error.tooLarge,
+        b.set(allocator, std.math.maxInt(usize), true),
+    );
 }
 
 // Refer to https://github.com/ChainSafe/ssz/blob/f5ed0b457333749b5c3f49fa5eafa096a725f033/packages/ssz/test/unit/byType/bitList/valid.test.ts#L44-L69

--- a/src/ssz/type/bit_list.zig
+++ b/src/ssz/type/bit_list.zig
@@ -130,6 +130,9 @@ pub fn BitList(comptime limit: comptime_int) type {
         }
 
         pub fn set(self: *@This(), allocator: std.mem.Allocator, bit_index: usize, bit: bool) !void {
+            if (bit_index >= limit) {
+                return error.tooLarge;
+            }
             if (bit_index + 1 > self.bit_len) {
                 try self.resize(allocator, bit_index + 1);
             }
@@ -640,6 +643,19 @@ test "BitListType - sanity" {
     try Bits.deserializeFromBytes(allocator, b_buf, &b);
 
     try std.testing.expect(try b.get(0) == false);
+}
+
+test "BitList set should reject max usize index" {
+    const allocator = std.testing.allocator;
+    const Bits = BitListType(8);
+
+    var value = Bits.default_value;
+    defer Bits.deinit(allocator, &value);
+
+    try std.testing.expectError(
+        error.tooLarge,
+        value.set(allocator, std.math.maxInt(usize), true),
+    );
 }
 
 test "BitListType - sanity with bools" {


### PR DESCRIPTION
## Motivation

`BitList.set()` added one to the requested index before validating it against the list limit. Passing `maxInt(usize)` therefore caused an integer-overflow panic instead of returning the existing `error.tooLarge` range error.

## Description

- Reject indexes at or above the BitList limit before calculating the new length.
- Extend the existing resize boundary test with the maximum `usize` index.

The implementation and regression test were primarily AI-authored and independently reviewed with AI assistance.