### PR TITLE
fix(ssz): reject invalid list growth lengths

### DIFF
--- a/src/ssz/tree_view/list_basic.zig
+++ b/src/ssz/tree_view/list_basic.zig
@@ -93,7 +93,7 @@ pub fn ListBasicTreeView(comptime ST: type) type {
         /// Grows the list; new positions read as zero. Shrinking must go through sliceTo —
         /// a bare length cut would leave stale chunk data in the merkleized root.
         pub fn growTo(self: *Self, new_length: usize) !void {
-            std.debug.assert(new_length >= self._len);
+            if (new_length < self._len) return error.InvalidLength;
             if (new_length > ST.limit) return error.LengthOverLimit;
             self._len = new_length;
         }
@@ -686,7 +686,7 @@ test "TreeView list push enforces limit" {
     try std.testing.expectEqual(@as(usize, 2), try view.length());
 }
 
-test "ListBasicTreeView growTo should reject lengths over the limit" {
+test "ListBasicTreeView growTo should reject invalid lengths" {
     const allocator = std.testing.allocator;
     var pool = try Node.Pool.init(.{
         .page_allocator = allocator,
@@ -705,6 +705,7 @@ test "ListBasicTreeView growTo should reject lengths over the limit" {
     var view = try ListType.TreeView.init(allocator, &pool, root);
     defer view.deinit();
 
+    try std.testing.expectError(error.InvalidLength, view.growTo(0));
     try std.testing.expectError(error.LengthOverLimit, view.growTo(ListType.limit + 1));
     try std.testing.expectEqual(@as(usize, 1), try view.length());
 

--- a/src/ssz/tree_view/list_basic.zig
+++ b/src/ssz/tree_view/list_basic.zig
@@ -666,7 +666,7 @@ test "TreeView list push across chunk boundary resets prefetch" {
     try std.testing.expectEqualSlices(u32, expected[0..], filled);
 }
 
-test "TreeView list push enforces limit" {
+test "ListBasicTreeView push and growTo should enforce length bounds" {
     const allocator = std.testing.allocator;
     var pool = try Node.Pool.init(.{ .page_allocator = allocator, .allocator = allocator, .pool_size = 256 });
     defer pool.deinit();
@@ -683,35 +683,9 @@ test "TreeView list push enforces limit" {
     defer view.deinit();
 
     try std.testing.expectError(error.LengthOverLimit, view.push(@as(u32, 3)));
-    try std.testing.expectEqual(@as(usize, 2), try view.length());
-}
-
-test "ListBasicTreeView growTo should reject invalid lengths" {
-    const allocator = std.testing.allocator;
-    var pool = try Node.Pool.init(.{
-        .page_allocator = allocator,
-        .allocator = allocator,
-        .pool_size = 64,
-    });
-    defer pool.deinit();
-
-    const ListType = FixedListType(UintType(32), 2, .{});
-
-    var list: ListType.Type = .empty;
-    defer list.deinit(allocator);
-    try list.append(allocator, 1);
-
-    const root = try ListType.tree.fromValue(&pool, &list);
-    var view = try ListType.TreeView.init(allocator, &pool, root);
-    defer view.deinit();
-
-    try std.testing.expectError(error.InvalidLength, view.growTo(0));
+    try std.testing.expectError(error.InvalidLength, view.growTo(1));
     try std.testing.expectError(error.LengthOverLimit, view.growTo(ListType.limit + 1));
-    try std.testing.expectEqual(@as(usize, 1), try view.length());
-
-    try view.growTo(ListType.limit);
-    try view.commit();
-    try std.testing.expectEqual(ListType.limit, try ListType.tree.length(view.getRoot(), &pool));
+    try std.testing.expectEqual(@as(usize, 2), try view.length());
 }
 
 test "TreeView list basic clone isolates updates" {

--- a/src/ssz/tree_view/list_basic.zig
+++ b/src/ssz/tree_view/list_basic.zig
@@ -94,6 +94,7 @@ pub fn ListBasicTreeView(comptime ST: type) type {
         /// a bare length cut would leave stale chunk data in the merkleized root.
         pub fn growTo(self: *Self, new_length: usize) !void {
             std.debug.assert(new_length >= self._len);
+            if (new_length > ST.limit) return error.LengthOverLimit;
             self._len = new_length;
         }
 
@@ -683,6 +684,33 @@ test "TreeView list push enforces limit" {
 
     try std.testing.expectError(error.LengthOverLimit, view.push(@as(u32, 3)));
     try std.testing.expectEqual(@as(usize, 2), try view.length());
+}
+
+test "ListBasicTreeView growTo should reject lengths over the limit" {
+    const allocator = std.testing.allocator;
+    var pool = try Node.Pool.init(.{
+        .page_allocator = allocator,
+        .allocator = allocator,
+        .pool_size = 64,
+    });
+    defer pool.deinit();
+
+    const ListType = FixedListType(UintType(32), 2, .{});
+
+    var list: ListType.Type = .empty;
+    defer list.deinit(allocator);
+    try list.append(allocator, 1);
+
+    const root = try ListType.tree.fromValue(&pool, &list);
+    var view = try ListType.TreeView.init(allocator, &pool, root);
+    defer view.deinit();
+
+    try std.testing.expectError(error.LengthOverLimit, view.growTo(ListType.limit + 1));
+    try std.testing.expectEqual(@as(usize, 1), try view.length());
+
+    try view.growTo(ListType.limit);
+    try view.commit();
+    try std.testing.expectEqual(ListType.limit, try ListType.tree.length(view.getRoot(), &pool));
 }
 
 test "TreeView list basic clone isolates updates" {

--- a/src/ssz/tree_view/list_composite.zig
+++ b/src/ssz/tree_view/list_composite.zig
@@ -598,7 +598,7 @@ test "TreeView composite list sliceFrom handles boundary conditions" {
     }
 }
 
-test "TreeView composite list push appends element" {
+test "ListCompositeTreeView push and growTo should enforce length bounds" {
     const allocator = std.testing.allocator;
     var pool = try Node.Pool.init(.{ .page_allocator = allocator, .allocator = allocator, .pool_size = 512 });
     defer pool.deinit();
@@ -624,6 +624,8 @@ test "TreeView composite list push appends element" {
     try view.push(element_view);
     transferred = true;
 
+    try std.testing.expectError(error.InvalidLength, view.growTo(1));
+    try std.testing.expectError(error.LengthOverLimit, view.growTo(ListType.limit + 1));
     try std.testing.expectEqual(@as(usize, 2), try view.length());
 
     try view.commit();
@@ -634,34 +636,6 @@ test "TreeView composite list push appends element" {
 
     try std.testing.expectEqual(@as(usize, 2), roundtrip.items.len);
     try std.testing.expectEqual(next_checkpoint.epoch, roundtrip.items[1].epoch);
-}
-
-test "ListCompositeTreeView growTo should reject invalid lengths" {
-    const allocator = std.testing.allocator;
-    var pool = try Node.Pool.init(.{
-        .page_allocator = allocator,
-        .allocator = allocator,
-        .pool_size = 64,
-    });
-    defer pool.deinit();
-
-    const ListType = FixedListType(Checkpoint, 2, .{});
-
-    var list: ListType.Type = .empty;
-    defer list.deinit(allocator);
-    try list.append(allocator, .{ .epoch = 1, .root = [_]u8{1} ** 32 });
-
-    const root = try ListType.tree.fromValue(&pool, &list);
-    var view = try ListType.TreeView.init(allocator, &pool, root);
-    defer view.deinit();
-
-    try std.testing.expectError(error.InvalidLength, view.growTo(0));
-    try std.testing.expectError(error.LengthOverLimit, view.growTo(ListType.limit + 1));
-    try std.testing.expectEqual(@as(usize, 1), try view.length());
-
-    try view.growTo(ListType.limit);
-    try view.commit();
-    try std.testing.expectEqual(ListType.limit, try ListType.tree.length(view.getRoot(), &pool));
 }
 
 test "TreeView composite list clone isolates updates" {

--- a/src/ssz/tree_view/list_composite.zig
+++ b/src/ssz/tree_view/list_composite.zig
@@ -114,6 +114,7 @@ pub fn ListCompositeTreeView(comptime ST: type) type {
         /// a bare length cut would leave stale chunk data in the merkleized root.
         pub fn growTo(self: *Self, new_length: usize) !void {
             std.debug.assert(new_length >= self._len);
+            if (new_length > ST.limit) return error.LengthOverLimit;
             self._len = new_length;
         }
 
@@ -633,6 +634,33 @@ test "TreeView composite list push appends element" {
 
     try std.testing.expectEqual(@as(usize, 2), roundtrip.items.len);
     try std.testing.expectEqual(next_checkpoint.epoch, roundtrip.items[1].epoch);
+}
+
+test "ListCompositeTreeView growTo should reject lengths over the limit" {
+    const allocator = std.testing.allocator;
+    var pool = try Node.Pool.init(.{
+        .page_allocator = allocator,
+        .allocator = allocator,
+        .pool_size = 64,
+    });
+    defer pool.deinit();
+
+    const ListType = FixedListType(Checkpoint, 2, .{});
+
+    var list: ListType.Type = .empty;
+    defer list.deinit(allocator);
+    try list.append(allocator, .{ .epoch = 1, .root = [_]u8{1} ** 32 });
+
+    const root = try ListType.tree.fromValue(&pool, &list);
+    var view = try ListType.TreeView.init(allocator, &pool, root);
+    defer view.deinit();
+
+    try std.testing.expectError(error.LengthOverLimit, view.growTo(ListType.limit + 1));
+    try std.testing.expectEqual(@as(usize, 1), try view.length());
+
+    try view.growTo(ListType.limit);
+    try view.commit();
+    try std.testing.expectEqual(ListType.limit, try ListType.tree.length(view.getRoot(), &pool));
 }
 
 test "TreeView composite list clone isolates updates" {

--- a/src/ssz/tree_view/list_composite.zig
+++ b/src/ssz/tree_view/list_composite.zig
@@ -113,7 +113,7 @@ pub fn ListCompositeTreeView(comptime ST: type) type {
         /// Grows the list; new positions read as zero. Shrinking must go through sliceTo —
         /// a bare length cut would leave stale chunk data in the merkleized root.
         pub fn growTo(self: *Self, new_length: usize) !void {
-            std.debug.assert(new_length >= self._len);
+            if (new_length < self._len) return error.InvalidLength;
             if (new_length > ST.limit) return error.LengthOverLimit;
             self._len = new_length;
         }
@@ -636,7 +636,7 @@ test "TreeView composite list push appends element" {
     try std.testing.expectEqual(next_checkpoint.epoch, roundtrip.items[1].epoch);
 }
 
-test "ListCompositeTreeView growTo should reject lengths over the limit" {
+test "ListCompositeTreeView growTo should reject invalid lengths" {
     const allocator = std.testing.allocator;
     var pool = try Node.Pool.init(.{
         .page_allocator = allocator,
@@ -655,6 +655,7 @@ test "ListCompositeTreeView growTo should reject lengths over the limit" {
     var view = try ListType.TreeView.init(allocator, &pool, root);
     defer view.deinit();
 
+    try std.testing.expectError(error.InvalidLength, view.growTo(0));
     try std.testing.expectError(error.LengthOverLimit, view.growTo(ListType.limit + 1));
     try std.testing.expectEqual(@as(usize, 1), try view.length());
 


### PR DESCRIPTION
## Motivation

Basic and composite list TreeViews did not handle invalid caller-provided lengths consistently. `growTo()` asserted when asked to shrink and accepted lengths above the SSZ type limit, despite exposing an error-returning public API.

## Description

- Return `error.InvalidLength` when the requested length would shrink the list.
- Return `error.LengthOverLimit` before publishing a length above the SSZ limit.
- Extend the existing basic and composite mutation tests with both error cases.

The implementation and regression tests were primarily AI-authored and independently reviewed with AI assistance.