### PR TITLE
fix(bench): stabilize committee benchmark inputs

### DIFF
--- a/bindings/perf/benchmarkSeed.ts
+++ b/bindings/perf/benchmarkSeed.ts
@@ -1,0 +1,5 @@
+import {createHash} from "node:crypto";
+
+export function deterministicBenchmarkSeed(domain: string): Uint8Array {
+  return createHash("sha256").update(domain).digest();
+}

--- a/bindings/perf/shuffle.test.ts
+++ b/bindings/perf/shuffle.test.ts
@@ -1,7 +1,7 @@
 // Mirrors https://github.com/ChainSafe/swap-or-not-shuffle/tree/main/test/perf
-import crypto from "node:crypto";
 import {bench, describe} from "@chainsafe/benchmark";
 import * as shuffleReference from "../test/shuffleReference.ts";
+import {deterministicBenchmarkSeed} from "./benchmarkSeed.js";
 
 const bindings = await import("../src/index.js");
 const shuffle = bindings.default.shuffle;
@@ -34,7 +34,7 @@ for (const listSize of [16_384, 250_000, 1_000_000]) {
 
 describe("committee indices", () => {
   for (const listSize of [16_384, 250_000, 1_000_000]) {
-    const seed = new Uint8Array(crypto.randomBytes(32));
+    const seed = deterministicBenchmarkSeed(`committee-indices:${listSize}`);
     const activeIndices = getInputArray(listSize);
     const effectiveBalanceIncrements = new Uint16Array(listSize);
     for (let i = 0; i < listSize; i++) {

--- a/bindings/test/benchmarkSeed.test.ts
+++ b/bindings/test/benchmarkSeed.test.ts
@@ -1,0 +1,11 @@
+import {describe, expect, it} from "vitest";
+import {deterministicBenchmarkSeed} from "../perf/benchmarkSeed.js";
+
+describe("deterministicBenchmarkSeed", () => {
+  it("returns a stable domain-specific seed", () => {
+    const seed = deterministicBenchmarkSeed("committee-indices:16384");
+
+    expect(Buffer.from(seed).toString("hex")).toBe("613f0807059afde76412455148289789cdd14a3218f1024fb6fd7006d6dd38a7");
+    expect(deterministicBenchmarkSeed("committee-indices:250000")).not.toEqual(seed);
+  });
+});


### PR DESCRIPTION
## Summary

- derive a stable SHA-256 seed for each committee-index benchmark size
- keep benchmark inputs domain-separated while making repeated runs comparable
- cover the deterministic seed contract with a focused regression test

## Motivation

`computeProposerIndex` may evaluate several candidates before finding one whose effective balance passes the selection check. The number of candidates depends on the seed, so generating a fresh random seed for every benchmark process changes the measured workload.

This produced false performance-regression alerts even when the shuffle implementation had not changed. A confirmation run also generated a different seed, so it did not repeat the original workload. Stable per-size seeds make daily, CI, and confirmation results comparable.
