### PR TITLE
fix(ssz): validate bit list length before hashing

### DIFF
--- a/src/ssz/type/bit_list.zig
+++ b/src/ssz/type/bit_list.zig
@@ -389,19 +389,7 @@ pub fn BitListType(comptime _limit: comptime_int) type {
             }
 
             pub fn hashTreeRoot(allocator: std.mem.Allocator, data: []const u8, out: *[32]u8) !void {
-                if (data.len == 0) {
-                    return error.InvalidSize;
-                }
-
-                // ensure padding bit and trailing zeros in last byte
-                const last_byte = data[data.len - 1];
-
-                const last_byte_clz = @clz(last_byte);
-                if (last_byte_clz == 8) {
-                    return error.noPaddingBit;
-                }
-                const last_1_index: u3 = @intCast(7 - last_byte_clz);
-                const bit_len = (data.len - 1) * 8 + last_1_index;
+                const bit_len = try length(data);
                 const chunk_count = (bit_len + 255) / 256;
                 const chunks = try allocator.alloc([32]u8, (chunk_count + 1) / 2 * 2);
                 defer allocator.free(chunks);
@@ -412,7 +400,8 @@ pub fn BitListType(comptime _limit: comptime_int) type {
                 } else {
                     @memcpy(@as([]u8, @ptrCast(chunks))[0..data.len], data);
                     // remove padding bit
-                    @as([]u8, @ptrCast(chunks))[data.len - 1] ^= @as(u8, 1) << last_1_index;
+                    @as([]u8, @ptrCast(chunks))[data.len - 1] ^=
+                        @as(u8, 1) << @intCast(bit_len % 8);
                 }
 
                 try merkleize(@ptrCast(chunks), chunk_depth, out);
@@ -739,7 +728,7 @@ test "resize" {
 }
 
 // Refer to https://github.com/ChainSafe/ssz/blob/f5ed0b457333749b5c3f49fa5eafa096a725f033/packages/ssz/test/unit/byType/bitList/valid.test.ts#L44-L69
-test "BitListType - padding bit test cases" {
+test "BitListType serialized forms should enforce padding and limit" {
     const allocator = std.testing.allocator;
 
     const TestCase = struct {
@@ -777,6 +766,16 @@ test "BitListType - padding bit test cases" {
         try deserialized.toBoolSlice(&deserialized_bools);
         try std.testing.expectEqualSlices(bool, tc.bools, deserialized_bools);
     }
+
+    const over_limit = [_]u8{ 0x00, 0x02 };
+    try std.testing.expectError(error.tooLarge, Bits.serialized.validate(&over_limit));
+    try std.testing.expectError(error.tooLarge, Bits.serialized.length(&over_limit));
+
+    var root: [32]u8 = undefined;
+    try std.testing.expectError(
+        error.tooLarge,
+        Bits.serialized.hashTreeRoot(allocator, &over_limit, &root),
+    );
 }
 
 // Refer to https://github.com/ChainSafe/ssz/blob/f5ed0b457333749b5c3f49fa5eafa096a725f033/packages/ssz/test/unit/byType/bitList/valid.test.ts#L5-L41

--- a/src/ssz/type/bit_list.zig
+++ b/src/ssz/type/bit_list.zig
@@ -389,7 +389,22 @@ pub fn BitListType(comptime _limit: comptime_int) type {
             }
 
             pub fn hashTreeRoot(allocator: std.mem.Allocator, data: []const u8, out: *[32]u8) !void {
-                const bit_len = try length(data);
+                if (data.len == 0) {
+                    return error.InvalidSize;
+                }
+
+                // ensure padding bit and trailing zeros in last byte
+                const last_byte = data[data.len - 1];
+
+                const last_byte_clz = @clz(last_byte);
+                if (last_byte_clz == 8) {
+                    return error.noPaddingBit;
+                }
+                const last_1_index: u3 = @intCast(7 - last_byte_clz);
+                const bit_len = (data.len - 1) * 8 + last_1_index;
+                if (bit_len > limit) {
+                    return error.tooLarge;
+                }
                 const chunk_count = (bit_len + 255) / 256;
                 const chunks = try allocator.alloc([32]u8, (chunk_count + 1) / 2 * 2);
                 defer allocator.free(chunks);
@@ -400,8 +415,7 @@ pub fn BitListType(comptime _limit: comptime_int) type {
                 } else {
                     @memcpy(@as([]u8, @ptrCast(chunks))[0..data.len], data);
                     // remove padding bit
-                    @as([]u8, @ptrCast(chunks))[data.len - 1] ^=
-                        @as(u8, 1) << @intCast(bit_len % 8);
+                    @as([]u8, @ptrCast(chunks))[data.len - 1] ^= @as(u8, 1) << last_1_index;
                 }
 
                 try merkleize(@ptrCast(chunks), chunk_depth, out);

--- a/src/ssz/type/bit_list.zig
+++ b/src/ssz/type/bit_list.zig
@@ -349,7 +349,12 @@ pub fn BitListType(comptime _limit: comptime_int) type {
         }
 
         pub const serialized = struct {
-            pub fn validate(data: []const u8) !void {
+            const Parsed = struct {
+                bit_len: usize,
+                padding_bit_index: u3,
+            };
+
+            inline fn parse(data: []const u8) !Parsed {
                 if (data.len == 0) {
                     return error.InvalidSize;
                 }
@@ -366,60 +371,38 @@ pub fn BitListType(comptime _limit: comptime_int) type {
                 if (bit_len > limit) {
                     return error.tooLarge;
                 }
+                return .{
+                    .bit_len = bit_len,
+                    .padding_bit_index = last_1_index,
+                };
+            }
+
+            pub fn validate(data: []const u8) !void {
+                _ = try parse(data);
             }
 
             pub fn length(data: []const u8) !usize {
-                if (data.len == 0) {
-                    return error.InvalidSize;
-                }
-
-                // ensure padding bit and trailing zeros in last byte
-                const last_byte = data[data.len - 1];
-
-                const last_byte_clz = @clz(last_byte);
-                if (last_byte_clz == 8) {
-                    return error.noPaddingBit;
-                }
-                const last_1_index: u3 = @intCast(7 - last_byte_clz);
-                const bit_len = (data.len - 1) * 8 + last_1_index;
-                if (bit_len > limit) {
-                    return error.tooLarge;
-                }
-                return bit_len;
+                return (try parse(data)).bit_len;
             }
 
             pub fn hashTreeRoot(allocator: std.mem.Allocator, data: []const u8, out: *[32]u8) !void {
-                if (data.len == 0) {
-                    return error.InvalidSize;
-                }
-
-                // ensure padding bit and trailing zeros in last byte
-                const last_byte = data[data.len - 1];
-
-                const last_byte_clz = @clz(last_byte);
-                if (last_byte_clz == 8) {
-                    return error.noPaddingBit;
-                }
-                const last_1_index: u3 = @intCast(7 - last_byte_clz);
-                const bit_len = (data.len - 1) * 8 + last_1_index;
-                if (bit_len > limit) {
-                    return error.tooLarge;
-                }
-                const chunk_count = (bit_len + 255) / 256;
+                const parsed = try parse(data);
+                const chunk_count = (parsed.bit_len + 255) / 256;
                 const chunks = try allocator.alloc([32]u8, (chunk_count + 1) / 2 * 2);
                 defer allocator.free(chunks);
 
                 @memset(chunks, [_]u8{0} ** 32);
-                if (bit_len % 8 == 0) {
+                if (parsed.bit_len % 8 == 0) {
                     @memcpy(@as([]u8, @ptrCast(chunks))[0 .. data.len - 1], data[0 .. data.len - 1]);
                 } else {
                     @memcpy(@as([]u8, @ptrCast(chunks))[0..data.len], data);
                     // remove padding bit
-                    @as([]u8, @ptrCast(chunks))[data.len - 1] ^= @as(u8, 1) << last_1_index;
+                    @as([]u8, @ptrCast(chunks))[data.len - 1] ^=
+                        @as(u8, 1) << parsed.padding_bit_index;
                 }
 
                 try merkleize(@ptrCast(chunks), chunk_depth, out);
-                mixInLength(bit_len, out);
+                mixInLength(parsed.bit_len, out);
             }
         };
 


### PR DESCRIPTION
## Motivation

BitList serialized validation, length lookup, and hashing duplicated the same padding-bit parsing. The hashing copy omitted the list-limit check, so over-limit data could be hashed even though validation and deserialization rejected it.

## Description

- Centralize serialized padding and limit validation in a private inline parser.
- Reuse the parsed bit length and padding-bit index across validation, length lookup, and hashing.
- Extend the existing padding and limit test with an over-limit serialized value.

The implementation and regression test were primarily AI-authored and independently reviewed with AI assistance.