### PR TITLE
fix(pmt): reclaim partial compact proof nodes

### DIFF
--- a/src/persistent_merkle_tree/memory_safety_test.zig
+++ b/src/persistent_merkle_tree/memory_safety_test.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 
 const Node = @import("Node.zig");
 const Gindex = @import("gindex.zig").Gindex;
+const proof = @import("proof.zig");
 
 test "setNodesGrouped should release an intermediate root when a later group runs out of memory" {
     var failing = std.testing.FailingAllocator.init(std.testing.allocator, .{ .resize_fail_index = 0 });
@@ -75,4 +76,52 @@ test "setNodesGrouped should release an intermediate root when a later group run
     try std.testing.expectEqual(nodes_in_use_before_update - 1, pool.getNodesInUse());
 
     for (capacity_fill_nodes.items) |id| pool.unref(id);
+}
+
+test "compact multiproof reconstruction should reclaim partial nodes on OOM" {
+    var leaves = [_][32]u8{
+        [_]u8{1} ** 32,
+        [_]u8{2} ** 32,
+    };
+    // The descriptor is a branch with two leaf children.
+    const descriptor = [_]u8{0b0110_0000};
+
+    // One free slot fails on the right leaf; two fail on the parent branch.
+    for ([_]usize{ 1, 2 }) |available_slots| {
+        var failing = std.testing.FailingAllocator.init(
+            std.testing.allocator,
+            .{ .resize_fail_index = 0 },
+        );
+
+        var pool = try Node.Pool.init(.{
+            .page_allocator = failing.allocator(),
+            .allocator = std.testing.allocator,
+            .pool_size = 8,
+        });
+        defer pool.deinit();
+
+        failing.fail_index = failing.alloc_index;
+
+        var capacity_fill_nodes: std.ArrayList(Node.Id) = .empty;
+        defer capacity_fill_nodes.deinit(std.testing.allocator);
+
+        while (pool.createLeafFromUint(0)) |id| {
+            try capacity_fill_nodes.append(std.testing.allocator, id);
+        } else |err| switch (err) {
+            error.OutOfMemory => {},
+        }
+        for (0..available_slots) |_| {
+            pool.unref(capacity_fill_nodes.pop().?);
+        }
+
+        const baseline = pool.getNodesInUse();
+        try std.testing.expectError(
+            error.OutOfMemory,
+            proof.createNodeFromCompactMultiProof(&pool, &leaves, &descriptor),
+        );
+
+        try std.testing.expectEqual(baseline, pool.getNodesInUse());
+
+        for (capacity_fill_nodes.items) |id| pool.unref(id);
+    }
 }

--- a/src/persistent_merkle_tree/proof.zig
+++ b/src/persistent_merkle_tree/proof.zig
@@ -554,7 +554,11 @@ fn compactMultiProofToNode(
 
     pointer.bit_index += 1;
     const left = try compactMultiProofToNode(pool, bitlist, leaves, pointer);
+    errdefer pool.unref(left);
+
     const right = try compactMultiProofToNode(pool, bitlist, leaves, pointer);
+    errdefer pool.unref(right);
+
     return pool.createBranch(left, right);
 }
 
@@ -576,6 +580,7 @@ pub fn createNodeFromCompactMultiProof(
 
     var pointer = MultiProofPointer{ .bit_index = 0, .leaf_index = 0 };
     const node = try compactMultiProofToNode(pool, bitlist, leaves, &pointer);
+    errdefer pool.unref(node);
 
     try pool.ref(node);
     return node;


### PR DESCRIPTION
## Motivation

Compact multiproof reconstruction creates fresh pool nodes recursively. If a later child or parent allocation failed, earlier rc=0 nodes had no owner to reclaim them and remained in the pool.

## Description

- Reclaim reconstructed children until a parent branch takes ownership.
- Reclaim the reconstructed root until its caller reference succeeds.
- Add deterministic right-child and parent-branch OOM regressions.

The implementation and regression test were primarily AI-authored and independently reviewed with AI assistance.