### PR TITLE
fix(pmt): reject empty compact proof leaves

### DIFF
--- a/src/persistent_merkle_tree/proof.zig
+++ b/src/persistent_merkle_tree/proof.zig
@@ -570,6 +570,9 @@ pub fn createNodeFromCompactMultiProof(
 
     const bitlist = try descriptorToBitlist(temp_allocator, descriptor);
 
+    if (leaves.len == 0) {
+        return error.InvalidWitnessLength;
+    }
     if (bitlist.len != leaves.len * 2 - 1) {
         return error.InvalidWitnessLength;
     }

--- a/src/persistent_merkle_tree/proof_test.zig
+++ b/src/persistent_merkle_tree/proof_test.zig
@@ -217,6 +217,23 @@ test "compact multiproof - should roundtrip node -> proof -> node" {
     }
 }
 
+test "compact multiproof reconstruction should reject empty leaves" {
+    var pool = try Node.Pool.init(.{
+        .page_allocator = testing.allocator,
+        .allocator = testing.allocator,
+        .pool_size = 0,
+    });
+    defer pool.deinit();
+
+    var leaves = [_][32]u8{};
+    const descriptor = [_]u8{0b1000_0000};
+
+    try testing.expectError(
+        proof.Error.InvalidWitnessLength,
+        proof.createNodeFromCompactMultiProof(&pool, &leaves, &descriptor),
+    );
+}
+
 // Prove individual chunks inside a `.chunked_leaf` node: createSingleProof
 // must materialize the packed leaf to collect intermediate witnesses.
 test "single proof through chunked_leaf" {


### PR DESCRIPTION
## Motivation

Compact multiproof reconstruction computed `leaves.len * 2 - 1` before rejecting empty leaves. Empty input therefore panicked on integer underflow instead of returning `InvalidWitnessLength`.

## Description

- Reject empty compact multiproof leaves before validating the descriptor length.
- Add a regression for the existing error contract.

The implementation and regression test were primarily AI-authored and independently reviewed with AI assistance.