### PR TITLE
refactor(ssz): simplify progressive bit list type

### DIFF
--- a/src/ssz/root.zig
+++ b/src/ssz/root.zig
@@ -65,12 +65,6 @@ pub const ListBasicTreeView = tree_view.ListBasicTreeView;
 pub const ListCompositeTreeView = tree_view.ListCompositeTreeView;
 pub const CloneOpts = @import("tree_view/utils/clone_opts.zig").CloneOpts;
 
-test "redundant SSZ helper APIs are not exposed" {
-    try testing.expect(!@hasDecl(types, "isProgressiveListType"));
-    try testing.expect(!@hasDecl(types, "isCompatibleUnionType"));
-    try testing.expect(!@hasDecl(HasherData, "getAllocator"));
-}
-
 test {
     _ = @import("memory_safety_test.zig");
     testing.refAllDecls(@This());

--- a/src/ssz/type/progressive_bit_list.zig
+++ b/src/ssz/type/progressive_bit_list.zig
@@ -11,102 +11,100 @@ const mixInLength = @import("hashing").mixInLength;
 const Node = @import("persistent_merkle_tree").Node;
 const progressive = @import("progressive.zig");
 
-pub fn ProgressiveBitList() type {
-    return struct {
-        data: std.ArrayListUnmanaged(u8),
-        bit_len: usize,
+pub const ProgressiveBitList = struct {
+    data: std.ArrayListUnmanaged(u8),
+    bit_len: usize,
 
-        pub const empty: @This() = .{
-            .data = std.ArrayListUnmanaged(u8).empty,
-            .bit_len = 0,
+    pub const empty: @This() = .{
+        .data = std.ArrayListUnmanaged(u8).empty,
+        .bit_len = 0,
+    };
+
+    pub fn equals(self: *const @This(), other: *const @This()) bool {
+        return self.bit_len == other.bit_len and std.mem.eql(u8, self.data.items, other.data.items);
+    }
+
+    pub fn fromBitLen(allocator: std.mem.Allocator, bit_len: usize) !@This() {
+        const byte_len = std.math.divCeil(usize, bit_len, 8) catch unreachable;
+
+        var data = try std.ArrayListUnmanaged(u8).initCapacity(allocator, byte_len);
+        data.expandToCapacity();
+        @memset(data.items, 0);
+        return @This(){
+            .data = data,
+            .bit_len = bit_len,
         };
+    }
 
-        pub fn equals(self: *const @This(), other: *const @This()) bool {
-            return self.bit_len == other.bit_len and std.mem.eql(u8, self.data.items, other.data.items);
+    pub fn deinit(self: *@This(), allocator: std.mem.Allocator) void {
+        self.data.deinit(allocator);
+    }
+
+    pub fn get(self: *const @This(), bit_index: usize) !bool {
+        if (bit_index >= self.bit_len) {
+            return error.OutOfRange;
         }
 
-        pub fn fromBitLen(allocator: std.mem.Allocator, bit_len: usize) !@This() {
-            const byte_len = std.math.divCeil(usize, bit_len, 8) catch unreachable;
+        const byte_idx = bit_index / 8;
+        const offset_in_byte: u3 = @intCast(bit_index % 8);
+        const mask = @as(u8, 1) << offset_in_byte;
+        return (self.data.items[byte_idx] & mask) == mask;
+    }
 
-            var data = try std.ArrayListUnmanaged(u8).initCapacity(allocator, byte_len);
-            data.expandToCapacity();
-            @memset(data.items, 0);
-            return @This(){
-                .data = data,
-                .bit_len = bit_len,
-            };
+    pub fn set(self: *@This(), allocator: std.mem.Allocator, bit_index: usize, bit: bool) !void {
+        if (bit_index + 1 > self.bit_len) {
+            try self.resize(allocator, bit_index + 1);
+        }
+        try self.setAssumeCapacity(bit_index, bit);
+    }
+
+    pub fn resize(self: *@This(), allocator: std.mem.Allocator, bit_len: usize) !void {
+        const old_bit_len = self.bit_len;
+        const old_byte_len = std.math.divCeil(usize, old_bit_len, 8) catch unreachable;
+        const byte_len = std.math.divCeil(usize, bit_len, 8) catch unreachable;
+        try self.data.resize(allocator, byte_len);
+        self.bit_len = bit_len;
+        // zero out additionally allocated bytes
+        if (old_byte_len < byte_len) {
+            @memset(self.data.items[old_byte_len..], 0);
+        } else if (bit_len < old_bit_len and bit_len % 8 != 0) {
+            const retained_bits: u3 = @intCast(bit_len % 8);
+            const retained_mask = (@as(u8, 1) << retained_bits) - 1;
+            self.data.items[byte_len - 1] &= retained_mask;
+        }
+    }
+
+    /// Set bit value at index `bit_index`
+    pub fn setAssumeCapacity(self: *@This(), bit_index: usize, bit: bool) !void {
+        if (bit_index >= self.bit_len) {
+            return error.OutOfRange;
         }
 
-        pub fn deinit(self: *@This(), allocator: std.mem.Allocator) void {
-            self.data.deinit(allocator);
-        }
-
-        pub fn get(self: *const @This(), bit_index: usize) !bool {
-            if (bit_index >= self.bit_len) {
-                return error.OutOfRange;
-            }
-
-            const byte_idx = bit_index / 8;
-            const offset_in_byte: u3 = @intCast(bit_index % 8);
-            const mask = @as(u8, 1) << offset_in_byte;
-            return (self.data.items[byte_idx] & mask) == mask;
-        }
-
-        pub fn set(self: *@This(), allocator: std.mem.Allocator, bit_index: usize, bit: bool) !void {
-            if (bit_index + 1 > self.bit_len) {
-                try self.resize(allocator, bit_index + 1);
-            }
-            try self.setAssumeCapacity(bit_index, bit);
-        }
-
-        pub fn resize(self: *@This(), allocator: std.mem.Allocator, bit_len: usize) !void {
-            const old_bit_len = self.bit_len;
-            const old_byte_len = std.math.divCeil(usize, old_bit_len, 8) catch unreachable;
-            const byte_len = std.math.divCeil(usize, bit_len, 8) catch unreachable;
-            try self.data.resize(allocator, byte_len);
-            self.bit_len = bit_len;
-            // zero out additionally allocated bytes
-            if (old_byte_len < byte_len) {
-                @memset(self.data.items[old_byte_len..], 0);
-            } else if (bit_len < old_bit_len and bit_len % 8 != 0) {
-                const retained_bits: u3 = @intCast(bit_len % 8);
-                const retained_mask = (@as(u8, 1) << retained_bits) - 1;
-                self.data.items[byte_len - 1] &= retained_mask;
-            }
-        }
-
-        /// Set bit value at index `bit_index`
-        pub fn setAssumeCapacity(self: *@This(), bit_index: usize, bit: bool) !void {
-            if (bit_index >= self.bit_len) {
-                return error.OutOfRange;
-            }
-
-            const byte_index = bit_index / 8;
-            const offset_in_byte: u3 = @intCast(bit_index % 8);
-            const mask = @as(u8, 1) << offset_in_byte;
-            var byte = self.data.items[byte_index];
-            if (bit) {
-                // For bit in byte, 1,0 OR 1 = 1
-                // byte 100110
+        const byte_index = bit_index / 8;
+        const offset_in_byte: u3 = @intCast(bit_index % 8);
+        const mask = @as(u8, 1) << offset_in_byte;
+        var byte = self.data.items[byte_index];
+        if (bit) {
+            // For bit in byte, 1,0 OR 1 = 1
+            // byte 100110
+            // mask 010000
+            // res  110110
+            byte |= mask;
+            self.data.items[byte_index] = byte;
+        } else {
+            // For bit in byte, 1,0 OR 1 = 0
+            if ((byte & mask) == mask) {
+                // byte 110110
                 // mask 010000
-                // res  110110
-                byte |= mask;
+                // res  100110
+                byte ^= mask;
                 self.data.items[byte_index] = byte;
             } else {
-                // For bit in byte, 1,0 OR 1 = 0
-                if ((byte & mask) == mask) {
-                    // byte 110110
-                    // mask 010000
-                    // res  100110
-                    byte ^= mask;
-                    self.data.items[byte_index] = byte;
-                } else {
-                    // Ok, bit is already 0
-                }
+                // Ok, bit is already 0
             }
         }
-    };
-}
+    }
+};
 
 pub fn isProgressiveBitListType(ST: type) bool {
     return ST.kind == .progressive_bit_list;
@@ -117,7 +115,7 @@ pub fn ProgressiveBitListType() type {
         const Self = @This();
         pub const kind = TypeKind.progressive_bit_list;
         pub const Element: type = BoolType();
-        pub const Type: type = ProgressiveBitList();
+        pub const Type: type = ProgressiveBitList;
         pub const min_size: usize = 1;
         pub const max_size: usize = std.math.maxInt(usize);
 
@@ -406,6 +404,11 @@ pub fn ProgressiveBitListType() type {
             try deserializeFromBytes(allocator, bytes, out);
         }
     };
+}
+
+test "ProgressiveBitList is a directly usable value type" {
+    const bits: ProgressiveBitList = .empty;
+    try std.testing.expectEqual(@as(usize, 0), bits.bit_len);
 }
 
 test "ProgressiveBitListType - sanity" {


### PR DESCRIPTION
## Summary
- expose `ProgressiveBitList` directly as a value type instead of a zero-argument type factory
- remove the redundant negative API-presence test requested in ChainSafe/lodestar-z#99
- add focused coverage for direct value-type use

## Verification
- `zig build test:ssz`
- `zig fmt --check src/ssz/root.zig src/ssz/type/progressive_bit_list.zig`
- `pnpm lint` (passes with 10 existing warnings)

Addresses https://github.com/ChainSafe/lodestar-z/pull/99#discussion_r3897161271 and https://github.com/ChainSafe/lodestar-z/pull/99#discussion_r3897162738
This pr from lodekeeper-z was left behind during merging https://github.com/ChainSafe/lodestar-z/pull/99 into main.