### PR TITLE
fix: reject withdrawal count mismatches

### DIFF
--- a/src/state_transition/block/process_block.zig
+++ b/src/state_transition/block/process_block.zig
@@ -80,6 +80,10 @@ pub fn processBlock(
                     .full => blk: {
                         const actual_withdrawals = block.body().executionPayload().inner.withdrawals;
                         if (withdrawals_result.withdrawals.items.len != actual_withdrawals.items.len) {
+                            std.log.err("withdrawal count mismatch: expected {d}, actual {d}", .{
+                                withdrawals_result.withdrawals.items.len,
+                                actual_withdrawals.items.len,
+                            });
                             return error.WithdrawalsLengthMismatch;
                         }
                         var root: Root = undefined;

--- a/src/state_transition/block/process_block.zig
+++ b/src/state_transition/block/process_block.zig
@@ -79,7 +79,9 @@ pub fn processBlock(
                 const payload_withdrawals_root = switch (block_type) {
                     .full => blk: {
                         const actual_withdrawals = block.body().executionPayload().inner.withdrawals;
-                        std.debug.assert(withdrawals_result.withdrawals.items.len == actual_withdrawals.items.len);
+                        if (withdrawals_result.withdrawals.items.len != actual_withdrawals.items.len) {
+                            return error.WithdrawalsLengthMismatch;
+                        }
                         var root: Root = undefined;
                         try types.capella.Withdrawals.hashTreeRoot(allocator, &actual_withdrawals, &root);
                         break :blk root;

--- a/src/state_transition/state_transition.zig
+++ b/src/state_transition/state_transition.zig
@@ -322,44 +322,6 @@ test "state transition - electra block" {
     deinitReusedEpochTransitionCache(std.testing.io);
 }
 
-test "state transition - rejects a full block with an extra withdrawal" {
-    const allocator = std.testing.allocator;
-    var pool = try Node.Pool.init(.{
-        .page_allocator = allocator,
-        .allocator = allocator,
-        .pool_size = 256 * 5,
-    });
-    defer pool.deinit();
-
-    var test_state = try TestCachedBeaconState.init(allocator, &pool, 256);
-    defer test_state.deinit();
-
-    var electra_block = types.electra.SignedBeaconBlock.default_value;
-    try generateElectraBlock(allocator, test_state.cached_state, &electra_block);
-    defer types.electra.SignedBeaconBlock.deinit(allocator, &electra_block);
-
-    try electra_block.message.body.execution_payload.withdrawals.append(
-        allocator,
-        types.capella.Withdrawal.default_value,
-    );
-
-    const signed_beacon_block = AnySignedBeaconBlock{ .full_electra = &electra_block };
-    try testing.expectError(
-        error.WithdrawalsLengthMismatch,
-        stateTransition(
-            allocator,
-            std.testing.io,
-            test_state.cached_state,
-            signed_beacon_block,
-            .{
-                .verify_state_root = false,
-                .verify_proposer = false,
-                .verify_signatures = false,
-            },
-        ),
-    );
-}
-
 test "state transition - a rejected block leaves the pre-state unchanged" {
     const allocator = std.testing.allocator;
     var pool = try Node.Pool.init(.{ .page_allocator = allocator, .allocator = allocator, .pool_size = 256 * 5 });

--- a/src/state_transition/state_transition.zig
+++ b/src/state_transition/state_transition.zig
@@ -322,6 +322,44 @@ test "state transition - electra block" {
     deinitReusedEpochTransitionCache(std.testing.io);
 }
 
+test "state transition - rejects a full block with an extra withdrawal" {
+    const allocator = std.testing.allocator;
+    var pool = try Node.Pool.init(.{
+        .page_allocator = allocator,
+        .allocator = allocator,
+        .pool_size = 256 * 5,
+    });
+    defer pool.deinit();
+
+    var test_state = try TestCachedBeaconState.init(allocator, &pool, 256);
+    defer test_state.deinit();
+
+    var electra_block = types.electra.SignedBeaconBlock.default_value;
+    try generateElectraBlock(allocator, test_state.cached_state, &electra_block);
+    defer types.electra.SignedBeaconBlock.deinit(allocator, &electra_block);
+
+    try electra_block.message.body.execution_payload.withdrawals.append(
+        allocator,
+        types.capella.Withdrawal.default_value,
+    );
+
+    const signed_beacon_block = AnySignedBeaconBlock{ .full_electra = &electra_block };
+    try testing.expectError(
+        error.WithdrawalsLengthMismatch,
+        stateTransition(
+            allocator,
+            std.testing.io,
+            test_state.cached_state,
+            signed_beacon_block,
+            .{
+                .verify_state_root = false,
+                .verify_proposer = false,
+                .verify_signatures = false,
+            },
+        ),
+    );
+}
+
 test "state transition - a rejected block leaves the pre-state unchanged" {
     const allocator = std.testing.allocator;
     var pool = try Node.Pool.init(.{ .page_allocator = allocator, .allocator = allocator, .pool_size = 256 * 5 });


### PR DESCRIPTION
## Motivation

I thought it could be from the malicious block, `assert` may be not suitable