### PR TITLE
fix(stf): keep expected withdrawals query read-only

### DIFF
--- a/src/state_transition/block/process_withdrawals.zig
+++ b/src/state_transition/block/process_withdrawals.zig
@@ -213,8 +213,6 @@ pub fn getExpectedWithdrawals(
         }
     }
 
-    try state.setNextWithdrawalIndex(withdrawal_index);
-
     withdrawals_result.sampled_validators = n;
     withdrawals_result.processed_partial_withdrawals_count = processed_partial_withdrawals_count;
 }


### PR DESCRIPTION
## Motivation

`getExpectedWithdrawals()` is a public query, but it writes the locally advanced withdrawal index back to the beacon state. It should be a wrong invocation.

## Description

- Keep the withdrawal index local while computing expected withdrawals.
- Leave the state update in `processWithdrawals()`, matching Lodestar and the pinned consensus specification: [`get_expected_withdrawals`](https://github.com/ethereum/consensus-specs/blob/v1.7.0-alpha.11/specs/capella/beacon-chain.md#new-get_expected_withdrawals) only computes the result, while [`process_withdrawals`](https://github.com/ethereum/consensus-specs/blob/v1.7.0-alpha.11/specs/capella/beacon-chain.md#new-process_withdrawals) updates `next_withdrawal_index`.