### PR TITLE
fix(stf): cleanup sync-committee init OOM path

### DIFF
--- a/src/state_transition/cache/sync_committee_cache.zig
+++ b/src/state_transition/cache/sync_committee_cache.zig
@@ -45,6 +45,8 @@ pub const SyncCommitteeCache = union(enum) {
 
     pub fn initValidatorIndices(allocator: Allocator, indices: []const ValidatorIndex) !SyncCommitteeCache {
         const cloned_indices = try allocator.alloc(ValidatorIndex, indices.len);
+        errdefer allocator.free(cloned_indices);
+
         std.mem.copyForwards(ValidatorIndex, cloned_indices, indices);
         const cache = try SyncCommitteeCacheAltair.initValidatorIndices(allocator, cloned_indices);
         return SyncCommitteeCache{ .altair = cache };

--- a/src/state_transition/memory_safety_test.zig
+++ b/src/state_transition/memory_safety_test.zig
@@ -15,6 +15,8 @@ const processRewardsAndPenalties =
     @import("epoch/process_rewards_and_penalties.zig").processRewardsAndPenalties;
 const upgradeStateToCapella = @import("slot/upgrade_state_to_capella.zig").upgradeStateToCapella;
 const upgradeStateToDeneb = @import("slot/upgrade_state_to_deneb.zig").upgradeStateToDeneb;
+const SyncCommitteeCache = @import("cache/sync_committee_cache.zig").SyncCommitteeCache;
+const ValidatorIndex = ct.primitive.ValidatorIndex.Type;
 
 test "upgradeStateToCapella and upgradeStateToDeneb should release temporary payload headers" {
     const allocator = std.testing.allocator;
@@ -147,4 +149,15 @@ test "processRewardsAndPenalties - sanity" {
         test_state.epoch_transition_cache,
         null,
     );
+}
+
+test "initValidatorIndices - cleans up cloned indices on init failure" {
+    const indices = [_]ValidatorIndex{ 0, 1, 2 };
+    var failing = std.testing.FailingAllocator.init(std.testing.allocator, .{ .fail_index = 1 });
+
+    try std.testing.expectError(
+        error.OutOfMemory,
+        SyncCommitteeCache.initValidatorIndices(failing.allocator(), &indices),
+    );
+    try std.testing.expectEqual(failing.allocated_bytes, failing.freed_bytes);
 }

--- a/src/state_transition/utils/execution.zig
+++ b/src/state_transition/utils/execution.zig
@@ -27,7 +27,8 @@ pub fn isMergeTransitionComplete(comptime fork: ForkSeq, state: *BeaconState(for
     if (comptime fork.lt(.bellatrix)) {
         return false;
     }
-    if (comptime fork.gte(.capella)) {
+    // Gloas (ePBS): merge is always complete, no latestExecutionPayloadHeader in state
+    if (comptime fork.gte(.gloas)) {
         return true;
     }
     const block_hash = state.latestExecutionPayloadHeaderBlockHash() catch return false;

--- a/src/state_transition/utils/execution.zig
+++ b/src/state_transition/utils/execution.zig
@@ -1,16 +1,18 @@
 const std = @import("std");
+const types = @import("consensus_types");
 const ForkSeq = @import("config").ForkSeq;
 const ForkTypes = @import("fork_types").ForkTypes;
+const AnyBeaconState = @import("fork_types").AnyBeaconState;
 const BeaconState = @import("fork_types").BeaconState;
 const BeaconBlock = @import("fork_types").BeaconBlock;
 const BeaconBlockBody = @import("fork_types").BeaconBlockBody;
 const BlockType = @import("fork_types").BlockType;
+const Node = @import("persistent_merkle_tree").Node;
 const ZERO_HASH = @import("constants").ZERO_HASH;
 
 pub fn isExecutionEnabled(comptime fork: ForkSeq, state: *BeaconState(fork), comptime block_type: BlockType, block: *const BeaconBlock(block_type, fork)) bool {
     if (comptime fork.lt(.bellatrix)) return false;
-    // Gloas (ePBS): execution is always enabled, payload is decoupled from the block
-    if (comptime fork.gte(.gloas)) return true;
+    if (comptime fork.gte(.capella)) return true;
     if (isMergeTransitionComplete(fork, state)) return true;
 
     switch (block_type) {
@@ -27,10 +29,40 @@ pub fn isMergeTransitionComplete(comptime fork: ForkSeq, state: *BeaconState(for
     if (comptime fork.lt(.bellatrix)) {
         return false;
     }
-    // Gloas (ePBS): merge is always complete, no latestExecutionPayloadHeader in state
-    if (comptime fork.gte(.gloas)) {
+    if (comptime fork.gte(.capella)) {
         return true;
     }
     const block_hash = state.latestExecutionPayloadHeaderBlockHash() catch return false;
     return !std.mem.eql(u8, block_hash[0..], ZERO_HASH[0..]);
+}
+
+test "Capella enables execution for default full and blinded blocks" {
+    const allocator = std.testing.allocator;
+    const pool_size = 256 * 5;
+    var pool = try Node.Pool.init(.{
+        .page_allocator = allocator,
+        .allocator = allocator,
+        .pool_size = pool_size,
+    });
+    defer pool.deinit();
+
+    var any_state = try AnyBeaconState.fromValue(
+        allocator,
+        &pool,
+        .capella,
+        &types.capella.BeaconState.default_value,
+    );
+    defer any_state.deinit();
+    const state = any_state.castToFork(.capella);
+
+    const full_block = BeaconBlock(.full, .capella){
+        .inner = types.capella.BeaconBlock.default_value,
+    };
+    const blinded_block = BeaconBlock(.blinded, .capella){
+        .inner = types.capella.BlindedBeaconBlock.default_value,
+    };
+
+    try std.testing.expect(isMergeTransitionComplete(.capella, state));
+    try std.testing.expect(isExecutionEnabled(.capella, state, .full, &full_block));
+    try std.testing.expect(isExecutionEnabled(.capella, state, .blinded, &blinded_block));
 }

--- a/src/state_transition/utils/execution.zig
+++ b/src/state_transition/utils/execution.zig
@@ -1,13 +1,10 @@
 const std = @import("std");
-const types = @import("consensus_types");
 const ForkSeq = @import("config").ForkSeq;
 const ForkTypes = @import("fork_types").ForkTypes;
-const AnyBeaconState = @import("fork_types").AnyBeaconState;
 const BeaconState = @import("fork_types").BeaconState;
 const BeaconBlock = @import("fork_types").BeaconBlock;
 const BeaconBlockBody = @import("fork_types").BeaconBlockBody;
 const BlockType = @import("fork_types").BlockType;
-const Node = @import("persistent_merkle_tree").Node;
 const ZERO_HASH = @import("constants").ZERO_HASH;
 
 pub fn isExecutionEnabled(comptime fork: ForkSeq, state: *BeaconState(fork), comptime block_type: BlockType, block: *const BeaconBlock(block_type, fork)) bool {
@@ -34,35 +31,4 @@ pub fn isMergeTransitionComplete(comptime fork: ForkSeq, state: *BeaconState(for
     }
     const block_hash = state.latestExecutionPayloadHeaderBlockHash() catch return false;
     return !std.mem.eql(u8, block_hash[0..], ZERO_HASH[0..]);
-}
-
-test "Capella enables execution for default full and blinded blocks" {
-    const allocator = std.testing.allocator;
-    const pool_size = 256 * 5;
-    var pool = try Node.Pool.init(.{
-        .page_allocator = allocator,
-        .allocator = allocator,
-        .pool_size = pool_size,
-    });
-    defer pool.deinit();
-
-    var any_state = try AnyBeaconState.fromValue(
-        allocator,
-        &pool,
-        .capella,
-        &types.capella.BeaconState.default_value,
-    );
-    defer any_state.deinit();
-    const state = any_state.castToFork(.capella);
-
-    const full_block = BeaconBlock(.full, .capella){
-        .inner = types.capella.BeaconBlock.default_value,
-    };
-    const blinded_block = BeaconBlock(.blinded, .capella){
-        .inner = types.capella.BlindedBeaconBlock.default_value,
-    };
-
-    try std.testing.expect(isMergeTransitionComplete(.capella, state));
-    try std.testing.expect(isExecutionEnabled(.capella, state, .full, &full_block));
-    try std.testing.expect(isExecutionEnabled(.capella, state, .blinded, &blinded_block));
 }

--- a/src/state_transition/utils/execution.zig
+++ b/src/state_transition/utils/execution.zig
@@ -27,8 +27,7 @@ pub fn isMergeTransitionComplete(comptime fork: ForkSeq, state: *BeaconState(for
     if (comptime fork.lt(.bellatrix)) {
         return false;
     }
-    // Gloas (ePBS): merge is always complete, no latestExecutionPayloadHeader in state
-    if (comptime fork.gte(.gloas)) {
+    if (comptime fork.gte(.capella)) {
         return true;
     }
     const block_hash = state.latestExecutionPayloadHeaderBlockHash() catch return false;

--- a/src/state_transition/utils/execution.zig
+++ b/src/state_transition/utils/execution.zig
@@ -9,7 +9,8 @@ const ZERO_HASH = @import("constants").ZERO_HASH;
 
 pub fn isExecutionEnabled(comptime fork: ForkSeq, state: *BeaconState(fork), comptime block_type: BlockType, block: *const BeaconBlock(block_type, fork)) bool {
     if (comptime fork.lt(.bellatrix)) return false;
-    if (comptime fork.gte(.capella)) return true;
+    // Gloas (ePBS): execution is always enabled, payload is decoupled from the block
+    if (comptime fork.gte(.gloas)) return true;
     if (isMergeTransitionComplete(fork, state)) return true;
 
     switch (block_type) {


### PR DESCRIPTION
## Motivation

Part of #621.

Completes issue checklist item **17** in [#621](https://github.com/ChainSafe/lodestar-z/issues/621): free cloned sync-committee indices on initialization failure.

## Description

- Free `cloned_indices` on initialization failure before ownership transfer in sync-committee cache setup.
- Move the OOM regression test to `state_transition/memory_safety_test.zig` to keep memory-safety coverage localized.

## AI assistance

The implementation was primarily AI-authored and independently reviewed with targeted ownership and regression checks.
