### PR TITLE
fix(stf): fix pending partial withdrawals state and sync-committee OOM cleanup

### DIFF
--- a/src/state_transition/block/process_withdrawals.zig
+++ b/src/state_transition/block/process_withdrawals.zig
@@ -123,9 +123,7 @@ pub fn getExpectedWithdrawals(
             var validator: types.phase0.Validator.Type = undefined;
             try validators.getValue(undefined, withdrawal.validator_index, &validator);
 
-            const total_withdrawn_gop = try withdrawal_balances.getOrPut(withdrawal.validator_index);
-
-            const total_withdrawn: u64 = if (total_withdrawn_gop.found_existing) total_withdrawn_gop.value_ptr.* else 0;
+            const total_withdrawn: u64 = @intCast(withdrawal_balances.get(withdrawal.validator_index) orelse 0);
             const balance = try balances.get(withdrawal.validator_index) - total_withdrawn;
 
             if (validator.exit_epoch == c.FAR_FUTURE_EPOCH and
@@ -158,8 +156,7 @@ pub fn getExpectedWithdrawals(
         // Get next validator in turn
         const validator_index = (next_withdrawal_validator_index + n) % validators_count;
         var validator = try validators.get(validator_index);
-        const withdraw_balance_gop = try withdrawal_balances.getOrPut(validator_index);
-        const withdraw_balance: u64 = if (withdraw_balance_gop.found_existing) withdraw_balance_gop.value_ptr.* else 0;
+        const withdraw_balance: u64 = @intCast(withdrawal_balances.get(validator_index) orelse 0);
         const val_balance = try balances.get(validator_index);
         const balance = if (comptime fork.gte(.electra))
             // Deduct partially withdrawn balance already queued above

--- a/src/state_transition/cache/sync_committee_cache.zig
+++ b/src/state_transition/cache/sync_committee_cache.zig
@@ -45,6 +45,8 @@ pub const SyncCommitteeCache = union(enum) {
 
     pub fn initValidatorIndices(allocator: Allocator, indices: []const ValidatorIndex) !SyncCommitteeCache {
         const cloned_indices = try allocator.alloc(ValidatorIndex, indices.len);
+        errdefer allocator.free(cloned_indices);
+
         std.mem.copyForwards(ValidatorIndex, cloned_indices, indices);
         const cache = try SyncCommitteeCacheAltair.initValidatorIndices(allocator, cloned_indices);
         return SyncCommitteeCache{ .altair = cache };

--- a/src/state_transition/memory_safety_test.zig
+++ b/src/state_transition/memory_safety_test.zig
@@ -15,6 +15,8 @@ const processRewardsAndPenalties =
     @import("epoch/process_rewards_and_penalties.zig").processRewardsAndPenalties;
 const upgradeStateToCapella = @import("slot/upgrade_state_to_capella.zig").upgradeStateToCapella;
 const upgradeStateToDeneb = @import("slot/upgrade_state_to_deneb.zig").upgradeStateToDeneb;
+const SyncCommitteeCache = @import("cache/sync_committee_cache.zig").SyncCommitteeCache;
+const ValidatorIndex = ct.primitive.ValidatorIndex.Type;
 
 test "upgradeStateToCapella and upgradeStateToDeneb should release temporary payload headers" {
     const allocator = std.testing.allocator;
@@ -143,4 +145,15 @@ test "processRewardsAndPenalties - sanity" {
         test_state.epoch_transition_cache,
         null,
     );
+}
+
+test "initValidatorIndices - cleans up cloned indices on init failure" {
+    const indices = [_]ValidatorIndex{ 0, 1, 2 };
+    var failing = std.testing.FailingAllocator.init(std.testing.allocator, .{ .fail_index = 1 });
+
+    try std.testing.expectError(
+        error.OutOfMemory,
+        SyncCommitteeCache.initValidatorIndices(failing.allocator(), &indices),
+    );
+    try std.testing.expectEqual(failing.allocated_bytes, failing.freed_bytes);
 }


### PR DESCRIPTION
## Motivation

- Ensure pending partial withdrawals cannot read an undefined balance from a partially initialized map entry.
- Keep sync committee cache init OOM cleanup safe on partial construction failure.

## Description

- Replace `getOrPut`-then-read patterns in
  `src/state_transition/block/process_withdrawals.zig` with `get(...) orelse 0` so
a missing validator entry is treated as 0 without inserting uninitialized map state.
- Keep `withdrawal_balances` updates explicit with `put` when and only when a withdrawal
is actually applied.
- Preserve existing map ownership and error propagation in withdrawal processing.
- Ensure cleanup and failure handling in
  `src/state_transition/cache/sync_committee_cache.zig` remains unchanged from
  previous safety pass.
- Add/update regression coverage in `src/state_transition/memory_safety_test.zig` to cover
  the OOM/partial-init path for sync committee cache construction.
