### PR TITLE
fix(state-transition): prevent next-shuffling corruption on decision-root failure

### DIFF
--- a/src/state_transition/cache/epoch_cache.zig
+++ b/src/state_transition/cache/epoch_cache.zig
@@ -564,15 +564,15 @@ pub const EpochCache = struct {
         const next_shuffling_active_indices = try self.allocator.alloc(ValidatorIndex, epoch_transition_cache.next_shuffling_active_indices.len);
         std.mem.copyForwards(ValidatorIndex, next_shuffling_active_indices, epoch_transition_cache.next_shuffling_active_indices);
 
-        const next_shuffling = try computeEpochShuffling(
+        const next_shuffling_rc = try initEpochShufflingRc(
             self.allocator,
             state,
             next_shuffling_active_indices,
             epoch_after_upcoming,
         );
-        errdefer next_shuffling.deinit();
+        errdefer next_shuffling_rc.unref();
 
-        const next_shuffling_rc = try EpochShufflingRc.init(self.allocator, next_shuffling);
+        const next_decision_root = try calculateShufflingDecisionRoot(state, epoch_after_upcoming);
 
         self.previous_shuffling.unref();
         self.previous_shuffling = self.current_shuffling;
@@ -582,7 +582,7 @@ pub const EpochCache = struct {
         self.current_decision_root = self.next_decision_root;
 
         self.next_shuffling = next_shuffling_rc;
-        self.next_decision_root = try calculateShufflingDecisionRoot(state, epoch_after_upcoming);
+        self.next_decision_root = next_decision_root;
 
         self.churn_limit = getChurnLimit(self.config, self.current_shuffling.get().active_indices.len);
         self.activation_churn_limit = getActivationChurnLimit(self.config, self.config.forkSeq(slot), self.current_shuffling.get().active_indices.len);

--- a/src/state_transition/cache/sync_committee_cache.zig
+++ b/src/state_transition/cache/sync_committee_cache.zig
@@ -45,6 +45,8 @@ pub const SyncCommitteeCache = union(enum) {
 
     pub fn initValidatorIndices(allocator: Allocator, indices: []const ValidatorIndex) !SyncCommitteeCache {
         const cloned_indices = try allocator.alloc(ValidatorIndex, indices.len);
+        errdefer allocator.free(cloned_indices);
+
         std.mem.copyForwards(ValidatorIndex, cloned_indices, indices);
         const cache = try SyncCommitteeCacheAltair.initValidatorIndices(allocator, cloned_indices);
         return SyncCommitteeCache{ .altair = cache };

--- a/src/state_transition/memory_safety_test.zig
+++ b/src/state_transition/memory_safety_test.zig
@@ -157,3 +157,20 @@ test "initValidatorIndices - cleans up cloned indices on init failure" {
     );
     try std.testing.expectEqual(failing.allocated_bytes, failing.freed_bytes);
 }
+
+test "afterProcessEpoch should not leak when decision-root calculation fails" {
+    const allocator = std.testing.allocator;
+    var pool = try Node.Pool.init(.{ .page_allocator = allocator, .allocator = allocator, .pool_size = 500_000 });
+    defer pool.deinit();
+
+    var test_state = try TestCachedBeaconState.init(allocator, &pool, 256);
+    defer test_state.deinit();
+
+    try std.testing.expectError(
+        error.SlotTooBig,
+        test_state.cached_state.epoch_cache.afterProcessEpoch(
+            test_state.cached_state.state,
+            test_state.epoch_transition_cache,
+        ),
+    );
+}

--- a/src/state_transition/memory_safety_test.zig
+++ b/src/state_transition/memory_safety_test.zig
@@ -15,6 +15,8 @@ const processRewardsAndPenalties =
     @import("epoch/process_rewards_and_penalties.zig").processRewardsAndPenalties;
 const upgradeStateToCapella = @import("slot/upgrade_state_to_capella.zig").upgradeStateToCapella;
 const upgradeStateToDeneb = @import("slot/upgrade_state_to_deneb.zig").upgradeStateToDeneb;
+const SyncCommitteeCache = @import("cache/sync_committee_cache.zig").SyncCommitteeCache;
+const ValidatorIndex = ct.primitive.ValidatorIndex.Type;
 
 test "upgradeStateToCapella and upgradeStateToDeneb should release temporary payload headers" {
     const allocator = std.testing.allocator;
@@ -143,4 +145,15 @@ test "processRewardsAndPenalties - sanity" {
         test_state.epoch_transition_cache,
         null,
     );
+}
+
+test "initValidatorIndices - cleans up cloned indices on init failure" {
+    const indices = [_]ValidatorIndex{ 0, 1, 2 };
+    var failing = std.testing.FailingAllocator.init(std.testing.allocator, .{ .fail_index = 1 });
+
+    try std.testing.expectError(
+        error.OutOfMemory,
+        SyncCommitteeCache.initValidatorIndices(failing.allocator(), &indices),
+    );
+    try std.testing.expectEqual(failing.allocated_bytes, failing.freed_bytes);
 }


### PR DESCRIPTION
### Motivation
- `afterProcessEpoch` can corrupt ownership when `calculateShufflingDecisionRoot` fails after the new next shuffle is assigned.
- The old order can create a deallocation/use-after-free window because the cache field is updated before the fallible decision-root step completes.

### Description
- Keep next-shuffling construction and commit boundary safe by committing it only after decision-root calculation succeeds.
- Add a regression test in `memory_safety_test.zig` to ensure `afterProcessEpoch` does not leak on decision-root failure.

### Validation
- `zig fmt --check src/state_transition/cache/epoch_cache.zig src/state_transition/memory_safety_test.zig`
- `zig build test:state_transition -- --test-filter "afterProcessEpoch should not leak when decision-root calculation fails"`

### AI assistance
- Changes were prepared with AI-assisted implementation and review.
