### PR TITLE
feat(napi): expose forkSeq on BeaconStateView binding

### DIFF
--- a/bindings/napi/BeaconStateView.zig
+++ b/bindings/napi/BeaconStateView.zig
@@ -25,6 +25,7 @@ pub const js_meta = js.class(.{ .properties = .{
     .slot = js.prop(.{ .get = true, .set = false }),
     .fork = js.prop(.{ .get = true, .set = false }),
     .forkName = js.prop(.{ .get = true, .set = false }),
+    .forkSeq = js.prop(.{ .get = true, .set = false }),
     .epoch = js.prop(.{ .get = true, .set = false }),
     .genesisTime = js.prop(.{ .get = true, .set = false }),
     .genesisValidatorsRoot = js.prop(.{ .get = true, .set = false }),
@@ -153,6 +154,11 @@ pub fn fork(self: *const BeaconStateView) !js_types.Fork {
 pub fn forkName(self: *const BeaconStateView) !js.String {
     const cached_state = try self.requireState();
     return js.String.from(cached_state.state.forkSeq().name());
+}
+
+pub fn forkSeq(self: *const BeaconStateView) !js.Number {
+    const cached_state = try self.requireState();
+    return js.Number.from(@intFromEnum(cached_state.state.forkSeq()));
 }
 
 pub fn epoch(self: *const BeaconStateView) !js.Number {

--- a/bindings/src/index.d.ts
+++ b/bindings/src/index.d.ts
@@ -93,6 +93,17 @@ export enum ForkName {
   gloas = "gloas",
 }
 
+export enum ForkSeq {
+  phase0 = 0,
+  altair = 1,
+  bellatrix = 2,
+  capella = 3,
+  deneb = 4,
+  electra = 5,
+  fulu = 6,
+  gloas = 7,
+}
+
 interface SyncCommittee {
   pubkeys: Uint8Array[];
   aggregatePubkey: Uint8Array;
@@ -190,6 +201,7 @@ export declare class BeaconStateView {
   slot: number;
   fork: Fork;
   forkName: ForkName;
+  forkSeq: ForkSeq;
   epoch: number;
   genesisTime: number;
   genesisValidatorsRoot: Uint8Array;


### PR DESCRIPTION
Adds a `forkSeq` getter to the native `BeaconStateView` binding, requested for ChainSafe/lodestar#9927 (cc @nflaig).

**Why:** On the Lodestar TS side, `NativeBeaconStateView.forkSeq` now reads `binding.forkSeq` directly (rather than deriving it from `forkName` via `ForkSeq[forkName]`), and `IBeaconStateViewNative` no longer omits `forkSeq` — so the compiled `.node` binding needs to expose it.

**Change:**
- `bindings/napi/BeaconStateView.zig`: register the `forkSeq` property + a getter returning `@intFromEnum(state.forkSeq())` — the same `state.forkSeq()` the existing `forkName` getter already uses (`.forkSeq().name()`), just returned as the ordinal instead of the name.
- `bindings/src/index.d.ts`: add `forkSeq: ForkSeq` to the `BeaconStateView` interface + a local `ForkSeq` enum mirroring the existing `ForkName` enum.

The `ForkSeq` enum ordinals (`phase0=0 … gloas=7`) match both `src/config/fork_seq.zig`'s `ForkSeq` and `@lodestar/params`' `ForkSeq`, so `binding.forkSeq` equals the old `ForkSeq[forkName]` value.

Heads up: I don't have a Zig toolchain in this environment so I couldn't build locally — leaving CI to verify the addon build/tests. The change mirrors the existing `forkName` prop/getter exactly.

🤖 Generated with AI assistance
