### PR TITLE
fix(stf): allocate epoch cache clone before refs

### DIFF
--- a/src/state_transition/cache/epoch_cache.zig
+++ b/src/state_transition/cache/epoch_cache.zig
@@ -488,7 +488,9 @@ pub const EpochCache = struct {
     }
 
     pub fn clone(self: *const EpochCache, allocator: Allocator) !*EpochCache {
-        const epoch_cache = EpochCache{
+        const epoch_cache_ptr = try allocator.create(EpochCache);
+
+        epoch_cache_ptr.* = .{
             .allocator = allocator,
             .config = self.config,
             // Common append-only structures shared with all states, no need to clone
@@ -525,10 +527,6 @@ pub const EpochCache = struct {
             .epoch = self.epoch,
         };
 
-        const epoch_cache_ptr = try allocator.create(EpochCache);
-        errdefer allocator.destroy(epoch_cache_ptr);
-
-        epoch_cache_ptr.* = epoch_cache;
         return epoch_cache_ptr;
     }
 

--- a/src/state_transition/memory_safety_test.zig
+++ b/src/state_transition/memory_safety_test.zig
@@ -144,3 +144,28 @@ test "processRewardsAndPenalties - sanity" {
         null,
     );
 }
+
+test "EpochCache.clone does not retain shared references when allocation fails" {
+    const allocator = std.testing.allocator;
+
+    var pool = try Node.Pool.init(.{
+        .page_allocator = allocator,
+        .allocator = allocator,
+        .pool_size = 200_000,
+    });
+    defer pool.deinit();
+
+    var test_state = try TestCachedBeaconState.init(allocator, &pool, 256);
+    defer test_state.deinit();
+
+    var failing_allocator = std.testing.FailingAllocator.init(
+        allocator,
+        .{ .fail_index = 0 },
+    );
+
+    // Leaked refs prevent test_state teardown from releasing the last shared owners.
+    try std.testing.expectError(
+        error.OutOfMemory,
+        test_state.cached_state.epoch_cache.clone(failing_allocator.allocator()),
+    );
+}


### PR DESCRIPTION
## Motivation

`EpochCache.clone()` increments six shared references before allocating the destination cache. If that allocation fails, the references remain retained after the source cache is released.

## Description

- Allocate the destination `EpochCache` before acquiring shared references.
- Initialize the allocated cache directly once allocation can no longer fail.
- Cover destination allocation failure with a deterministic memory-safety regression.

Part of #621.