### PR TITLE
fix: split tests in variable element iterator

### DIFF
--- a/src/ssz/type/variable_element_iterator.zig
+++ b/src/ssz/type/variable_element_iterator.zig
@@ -40,7 +40,6 @@
 //! The iterator reads each offset once and yields borrowed element slices without allocation.
 
 const std = @import("std");
-const TypeKind = @import("type_kind.zig").TypeKind;
 const isFixedType = @import("type_kind.zig").isFixedType;
 
 /// Returns an iterator over serialized elements of a variable-element SSZ list, vector, or progressive list.
@@ -139,101 +138,3 @@ pub fn VariableElementIterator(comptime ST: type) type {
     };
 }
 
-/// A dummy ssz variable element used for tests.
-const VariableElement = struct {
-    pub const kind = TypeKind.list;
-};
-
-/// A dummy ssz variable list used for tests.
-const VariableList = struct {
-    pub const kind = TypeKind.list;
-    pub const Element = VariableElement;
-    pub const limit = 2;
-};
-
-/// A dummy ssz variable vector used for tests.
-const VariableVector = struct {
-    pub const kind = TypeKind.vector;
-    pub const Element = VariableElement;
-    pub const length = 2;
-};
-
-const VariableProgressiveList = struct {
-    pub const kind = TypeKind.progressive_list;
-    pub const Element = VariableElement;
-};
-
-test "iterates validated variable elements" {
-    const data = [_]u8{
-        8,  0, 0, 0,
-        10, 0, 0, 0,
-        1,  2, 3, 4,
-        5,
-    };
-
-    var elements = try VariableElementIterator(VariableList).init(&data);
-    try std.testing.expectEqual(@as(usize, 2), elements.len);
-    try std.testing.expectEqualSlices(u8, &.{ 1, 2 }, (try elements.next()).?);
-    try std.testing.expectEqualSlices(u8, &.{ 3, 4, 5 }, (try elements.next()).?);
-    try std.testing.expectEqual(null, try elements.next());
-}
-
-test "iterates progressive list elements" {
-    const data = [_]u8{
-        8,  0, 0, 0,
-        10, 0, 0, 0,
-        1,  2, 3, 4,
-        5,
-    };
-
-    var elements = try VariableElementIterator(VariableProgressiveList).init(&data);
-    try std.testing.expectEqual(@as(usize, 2), elements.len);
-    try std.testing.expectEqualSlices(u8, &.{ 1, 2 }, (try elements.next()).?);
-    try std.testing.expectEqualSlices(u8, &.{ 3, 4, 5 }, (try elements.next()).?);
-    try std.testing.expectEqual(null, try elements.next());
-}
-
-test "accepts empty list and empty elements" {
-    var empty_list = try VariableElementIterator(VariableList).init(&.{});
-    try std.testing.expectEqual(@as(usize, 0), empty_list.len);
-    try std.testing.expectEqual(null, try empty_list.next());
-
-    const data = [_]u8{
-        8, 0, 0, 0,
-        8, 0, 0, 0,
-    };
-    var empty_elements = try VariableElementIterator(VariableList).init(&data);
-    try std.testing.expectEqualSlices(u8, &.{}, (try empty_elements.next()).?);
-    try std.testing.expectEqualSlices(u8, &.{}, (try empty_elements.next()).?);
-    try std.testing.expectEqual(null, try empty_elements.next());
-}
-
-test "rejects malformed offsets during iteration or initialization" {
-    var decreasing = try VariableElementIterator(VariableList).init(&.{
-        8, 0, 0, 0,
-        7, 0, 0, 0,
-    });
-    try std.testing.expectError(error.offsetNotIncreasing, decreasing.next());
-
-    var out_of_range = try VariableElementIterator(VariableList).init(&.{
-        8, 0, 0, 0,
-        9, 0, 0, 0,
-    });
-    try std.testing.expectError(error.offsetOutOfRange, out_of_range.next());
-    try std.testing.expectError(
-        error.offsetNotDivisibleBy4,
-        VariableElementIterator(VariableList).init(&.{ 5, 0, 0, 0, 0 }),
-    );
-    try std.testing.expectError(
-        error.invalidOffsetCount,
-        VariableElementIterator(VariableVector).init(&.{ 4, 0, 0, 0 }),
-    );
-    try std.testing.expectError(
-        error.invalidOffsetCount,
-        VariableElementIterator(VariableList).init(&.{ 12, 0, 0, 0 }),
-    );
-    try std.testing.expectError(
-        error.offsetOutOfRange,
-        VariableElementIterator(VariableVector).init(&.{}),
-    );
-}

--- a/src/ssz/type/variable_element_iterator.zig
+++ b/src/ssz/type/variable_element_iterator.zig
@@ -137,3 +137,7 @@ pub fn VariableElementIterator(comptime ST: type) type {
         }
     };
 }
+
+test {
+    _ = @import("variable_element_iterator_test.zig");
+}

--- a/src/ssz/type/variable_element_iterator.zig
+++ b/src/ssz/type/variable_element_iterator.zig
@@ -137,4 +137,3 @@ pub fn VariableElementIterator(comptime ST: type) type {
         }
     };
 }
-

--- a/src/ssz/type/variable_element_iterator_test.zig
+++ b/src/ssz/type/variable_element_iterator_test.zig
@@ -27,7 +27,6 @@ const VariableProgressiveList = struct {
     pub const Element = VariableElement;
 };
 
-
 test "iterates validated variable elements" {
     const data = [_]u8{
         8,  0, 0, 0,

--- a/src/ssz/type/variable_element_iterator_test.zig
+++ b/src/ssz/type/variable_element_iterator_test.zig
@@ -1,0 +1,104 @@
+const std = @import("std");
+const VariableElementIterator = @import("variable_element_iterator.zig").VariableElementIterator;
+const TypeKind = @import("type_kind.zig").TypeKind;
+const ssz = @import("ssz");
+
+/// A dummy ssz variable element used for tests.
+const VariableElement = struct {
+    pub const kind = TypeKind.list;
+};
+
+/// A dummy ssz variable list used for tests.
+const VariableList = struct {
+    pub const kind = TypeKind.list;
+    pub const Element = VariableElement;
+    pub const limit = 2;
+};
+
+/// A dummy ssz variable vector used for tests.
+const VariableVector = struct {
+    pub const kind = TypeKind.vector;
+    pub const Element = VariableElement;
+    pub const length = 2;
+};
+
+const VariableProgressiveList = struct {
+    pub const kind = TypeKind.progressive_list;
+    pub const Element = VariableElement;
+};
+
+
+test "iterates validated variable elements" {
+    const data = [_]u8{
+        8,  0, 0, 0,
+        10, 0, 0, 0,
+        1,  2, 3, 4,
+        5,
+    };
+
+    var elements = try VariableElementIterator(VariableList).init(&data);
+    try std.testing.expectEqual(@as(usize, 2), elements.len);
+    try std.testing.expectEqualSlices(u8, &.{ 1, 2 }, (try elements.next()).?);
+    try std.testing.expectEqualSlices(u8, &.{ 3, 4, 5 }, (try elements.next()).?);
+    try std.testing.expectEqual(null, try elements.next());
+}
+
+test "iterates progressive list elements" {
+    const data = [_]u8{
+        8,  0, 0, 0,
+        10, 0, 0, 0,
+        1,  2, 3, 4,
+        5,
+    };
+
+    var elements = try VariableElementIterator(VariableProgressiveList).init(&data);
+    try std.testing.expectEqual(@as(usize, 2), elements.len);
+    try std.testing.expectEqualSlices(u8, &.{ 1, 2 }, (try elements.next()).?);
+    try std.testing.expectEqualSlices(u8, &.{ 3, 4, 5 }, (try elements.next()).?);
+    try std.testing.expectEqual(null, try elements.next());
+}
+
+test "accepts empty list and empty elements" {
+    var empty_list = try VariableElementIterator(VariableList).init(&.{});
+    try std.testing.expectEqual(@as(usize, 0), empty_list.len);
+    try std.testing.expectEqual(null, try empty_list.next());
+
+    const data = [_]u8{
+        8, 0, 0, 0,
+        8, 0, 0, 0,
+    };
+    var empty_elements = try VariableElementIterator(VariableList).init(&data);
+    try std.testing.expectEqualSlices(u8, &.{}, (try empty_elements.next()).?);
+    try std.testing.expectEqualSlices(u8, &.{}, (try empty_elements.next()).?);
+    try std.testing.expectEqual(null, try empty_elements.next());
+}
+
+test "rejects malformed offsets during iteration or initialization" {
+    var decreasing = try VariableElementIterator(VariableList).init(&.{
+        8, 0, 0, 0,
+        7, 0, 0, 0,
+    });
+    try std.testing.expectError(error.offsetNotIncreasing, decreasing.next());
+
+    var out_of_range = try VariableElementIterator(VariableList).init(&.{
+        8, 0, 0, 0,
+        9, 0, 0, 0,
+    });
+    try std.testing.expectError(error.offsetOutOfRange, out_of_range.next());
+    try std.testing.expectError(
+        error.offsetNotDivisibleBy4,
+        VariableElementIterator(VariableList).init(&.{ 5, 0, 0, 0, 0 }),
+    );
+    try std.testing.expectError(
+        error.invalidOffsetCount,
+        VariableElementIterator(VariableVector).init(&.{ 4, 0, 0, 0 }),
+    );
+    try std.testing.expectError(
+        error.invalidOffsetCount,
+        VariableElementIterator(VariableList).init(&.{ 12, 0, 0, 0 }),
+    );
+    try std.testing.expectError(
+        error.offsetOutOfRange,
+        VariableElementIterator(VariableVector).init(&.{}),
+    );
+}


### PR DESCRIPTION
unblocks https://github.com/ChainSafe/lodestar-z/pull/649