### PR TITLE
fix: hash block body when converting to header

### DIFF
--- a/src/state_transition/block/process_block_header.zig
+++ b/src/state_transition/block/process_block_header.zig
@@ -81,38 +81,6 @@ pub fn blockToHeader(allocator: Allocator, signed_block: AnySignedBeaconBlock, o
 const TestCachedBeaconState = @import("../test_utils/root.zig").TestCachedBeaconState;
 const preset = @import("preset").preset;
 
-test "blockToHeader should preserve the block root and header fields" {
-    const allocator = std.testing.allocator;
-
-    inline for (.{
-        .{ types.phase0.SignedBeaconBlock, "phase0" },
-        .{ types.electra.SignedBeaconBlock, "full_electra" },
-        .{ types.electra.SignedBlindedBeaconBlock, "blinded_electra" },
-    }) |case| {
-        var signed_block = case[0].default_value;
-        signed_block.message.slot = 123;
-        signed_block.message.proposer_index = 456;
-        signed_block.message.parent_root = [_]u8{1} ** 32;
-        signed_block.message.state_root = [_]u8{2} ** 32;
-        signed_block.message.body.graffiti = [_]u8{3} ** 32;
-
-        const block = @unionInit(AnySignedBeaconBlock, case[1], &signed_block);
-        var header: BeaconBlockHeader = undefined;
-        try blockToHeader(allocator, block, &header);
-
-        try std.testing.expectEqual(signed_block.message.slot, header.slot);
-        try std.testing.expectEqual(signed_block.message.proposer_index, header.proposer_index);
-        try std.testing.expectEqualSlices(u8, &signed_block.message.parent_root, &header.parent_root);
-        try std.testing.expectEqualSlices(u8, &signed_block.message.state_root, &header.state_root);
-
-        var block_root: [32]u8 = undefined;
-        try block.beaconBlock().hashTreeRoot(allocator, &block_root);
-        var header_root: [32]u8 = undefined;
-        try types.phase0.BeaconBlockHeader.hashTreeRoot(&header, &header_root);
-        try std.testing.expectEqualSlices(u8, &block_root, &header_root);
-    }
-}
-
 test "process block header - sanity" {
     const allocator = std.testing.allocator;
     const pool_size = 180_000;

--- a/src/state_transition/block/process_block_header.zig
+++ b/src/state_transition/block/process_block_header.zig
@@ -75,11 +75,43 @@ pub fn blockToHeader(allocator: Allocator, signed_block: AnySignedBeaconBlock, o
     out.proposer_index = block.proposerIndex();
     out.parent_root = block.parentRoot().*;
     out.state_root = block.stateRoot().*;
-    try block.hashTreeRoot(allocator, &out.body_root);
+    try block.beaconBlockBody().hashTreeRoot(allocator, &out.body_root);
 }
 
 const TestCachedBeaconState = @import("../test_utils/root.zig").TestCachedBeaconState;
 const preset = @import("preset").preset;
+
+test "blockToHeader should preserve the block root and header fields" {
+    const allocator = std.testing.allocator;
+
+    inline for (.{
+        .{ types.phase0.SignedBeaconBlock, "phase0" },
+        .{ types.electra.SignedBeaconBlock, "full_electra" },
+        .{ types.electra.SignedBlindedBeaconBlock, "blinded_electra" },
+    }) |case| {
+        var signed_block = case[0].default_value;
+        signed_block.message.slot = 123;
+        signed_block.message.proposer_index = 456;
+        signed_block.message.parent_root = [_]u8{1} ** 32;
+        signed_block.message.state_root = [_]u8{2} ** 32;
+        signed_block.message.body.graffiti = [_]u8{3} ** 32;
+
+        const block = @unionInit(AnySignedBeaconBlock, case[1], &signed_block);
+        var header: BeaconBlockHeader = undefined;
+        try blockToHeader(allocator, block, &header);
+
+        try std.testing.expectEqual(signed_block.message.slot, header.slot);
+        try std.testing.expectEqual(signed_block.message.proposer_index, header.proposer_index);
+        try std.testing.expectEqualSlices(u8, &signed_block.message.parent_root, &header.parent_root);
+        try std.testing.expectEqualSlices(u8, &signed_block.message.state_root, &header.state_root);
+
+        var block_root: [32]u8 = undefined;
+        try block.beaconBlock().hashTreeRoot(allocator, &block_root);
+        var header_root: [32]u8 = undefined;
+        try types.phase0.BeaconBlockHeader.hashTreeRoot(&header, &header_root);
+        try std.testing.expectEqualSlices(u8, &block_root, &header_root);
+    }
+}
 
 test "process block header - sanity" {
     const allocator = std.testing.allocator;


### PR DESCRIPTION
## Motivation

`blockToHeader` puts the full beacon block root in `body_root`, so the resulting header does not preserve the block root. The helper currently has no in-repository callers.