### PR TITLE
fix: avoid duplicate phase0 pending-attestation participants

### DIFF
--- a/src/state_transition/epoch/process_pending_attestations.zig
+++ b/src/state_transition/epoch/process_pending_attestations.zig
@@ -53,11 +53,6 @@ pub fn processPendingAttestations(
         const committee = @as([]const u64, try epoch_cache.getBeaconCommittee(att_slot, att_data.index));
         var participants = try att.aggregation_bits.intersectValues(ValidatorIndex, allocator, committee);
         defer participants.deinit(allocator);
-        for (committee, 0..) |validator_index, bit_index| {
-            if (try att.aggregation_bits.get(bit_index)) {
-                try participants.append(allocator, validator_index);
-            }
-        }
 
         if (epoch == prev_epoch) {
             for (participants.items) |p| {


### PR DESCRIPTION
## Motivation

Phase0 pending-attestation processing appends each set-bit participant twice, duplicating flag and inclusion-delay work and potentially triggering an unnecessary growth allocation.

## Description

Remove the second collection loop because `intersectValues` already returns the participants. 

AI assistance: this implementation was primarily AI-authored.
