### PR TITLE
feat(metrics): record external hash tree root timings

### DIFF
--- a/bindings/napi/metrics.zig
+++ b/bindings/napi/metrics.zig
@@ -18,6 +18,27 @@ pub fn init() !void {
     initialized = true;
 }
 
+/// JS: metrics.observeStateHashTreeRoot(source, seconds) → void
+pub fn observeStateHashTreeRoot(source: js.String, seconds: js.Number) !void {
+    if (!initialized) return error.MetricsNotInitialized;
+
+    var source_buffer: [32]u8 = undefined;
+    const source_name = try source.toSlice(&source_buffer);
+    const source_value = std.meta.stringToEnum(
+        state_transition.metrics.StateHashTreeRootSource,
+        source_name,
+    ) orelse return error.InvalidStateHashTreeRootSource;
+    const seconds_value = try seconds.toF64();
+    if (!std.math.isFinite(seconds_value) or
+        seconds_value < 0 or
+        seconds_value > state_transition.metrics.state_hash_tree_root_duration_seconds_max)
+    {
+        return error.InvalidMetricDuration;
+    }
+
+    try state_transition.metrics.observeStateHashTreeRoot(source_value, seconds_value);
+}
+
 /// JS: metrics.scrapeMetrics() → string
 pub fn scrapeMetrics() !js.String {
     var aw: std.Io.Writer.Allocating = .init(allocator);

--- a/bindings/src/index.d.ts
+++ b/bindings/src/index.d.ts
@@ -1,5 +1,13 @@
 // biome-ignore-all lint/style/useNamingConvention: spec-canonical fork names in `ForkName`
 
+export type StateHashTreeRootSource =
+  | "state_transition"
+  | "block_transition"
+  | "prepare_next_slot"
+  | "prepare_next_epoch"
+  | "regen_state"
+  | "compute_new_state_root";
+
 interface BeaconBlockHeader {
   slot: number;
   proposerIndex: number;
@@ -391,6 +399,7 @@ declare const bindings: {
   };
   metrics: {
     init: () => void;
+    observeStateHashTreeRoot: (source: StateHashTreeRootSource, seconds: number) => void;
     scrapeMetrics: () => string;
   };
   BeaconStateView: typeof BeaconStateView;

--- a/bindings/src/metrics.d.ts
+++ b/bindings/src/metrics.d.ts
@@ -1,5 +1,16 @@
+export type StateHashTreeRootSource =
+  | "state_transition"
+  | "block_transition"
+  | "prepare_next_slot"
+  | "prepare_next_epoch"
+  | "regen_state"
+  | "compute_new_state_root";
+
 /** Initialize native state-transition metrics. */
 export declare function init(): void;
+
+/** Record an externally timed state hash-tree-root operation. */
+export declare function observeStateHashTreeRoot(source: StateHashTreeRootSource, seconds: number): void;
 
 /** Scrape native state-transition metrics in Prometheus text format. */
 export declare function scrapeMetrics(): string;

--- a/bindings/src/metrics.js
+++ b/bindings/src/metrics.js
@@ -3,4 +3,5 @@ import bindings from "./bindings.js";
 const native = bindings.metrics;
 
 export const init = native.init;
+export const observeStateHashTreeRoot = native.observeStateHashTreeRoot;
 export const scrapeMetrics = native.scrapeMetrics;

--- a/bindings/test/metrics.test.ts
+++ b/bindings/test/metrics.test.ts
@@ -1,0 +1,45 @@
+import {beforeAll, describe, expect, it} from "vitest";
+import bindings, {type StateHashTreeRootSource} from "../src/index.js";
+
+const sources = [
+  "state_transition",
+  "block_transition",
+  "prepare_next_slot",
+  "prepare_next_epoch",
+  "regen_state",
+  "compute_new_state_root",
+] as const satisfies StateHashTreeRootSource[];
+
+describe("metrics", () => {
+  beforeAll(() => {
+    bindings.metrics.init();
+  });
+
+  it.each(sources)("records an external %s hash tree root duration", (source) => {
+    const seconds = source === "block_transition" ? 0.125 : 0.001;
+    bindings.metrics.observeStateHashTreeRoot(source, seconds);
+
+    const output = bindings.metrics.scrapeMetrics();
+    expect(output).toContain(`lodestar_stfn_hash_tree_root_seconds_count{source="${source}"} 1`);
+    expect(output).toContain(`lodestar_stfn_hash_tree_root_seconds_sum{source="${source}"} ${seconds}`);
+  });
+
+  it("accepts the maximum duration", () => {
+    expect(() => bindings.metrics.observeStateHashTreeRoot("block_transition", 60 * 60)).not.toThrow();
+  });
+
+  it.each([
+    {error: "InvalidStateHashTreeRootSource", seconds: 0, source: "invalid"},
+    {error: "InvalidMetricDuration", seconds: -1, source: "block_transition"},
+    {error: "InvalidMetricDuration", seconds: Number.NaN, source: "block_transition"},
+    {error: "InvalidMetricDuration", seconds: Number.POSITIVE_INFINITY, source: "block_transition"},
+    {error: "InvalidMetricDuration", seconds: 60 * 60 + 1, source: "block_transition"},
+  ])("rejects invalid observation $error", ({source, seconds, error}) => {
+    const observeStateHashTreeRoot = bindings.metrics.observeStateHashTreeRoot as unknown as (
+      source: string,
+      seconds: number
+    ) => void;
+
+    expect(() => observeStateHashTreeRoot(source, seconds)).toThrow(error);
+  });
+});

--- a/docs/security/IMPLEMENTATION_MAP.md
+++ b/docs/security/IMPLEMENTATION_MAP.md
@@ -4,7 +4,7 @@ This is the volatile companion to the stable [threat model](../../THREAT_MODEL.m
 implementation facts needed to establish a trust boundary or precondition.
 
 - **Owner:** `@ChainSafe/lodestar`
-- **Last reviewed:** 2026-08-21
+- **Last reviewed:** 2026-09-06
 
 ## Integration status
 
@@ -25,6 +25,7 @@ supported caller supplies a current hostile path.
 | Boundary or invariant | Current implementation evidence |
 | --- | --- |
 | N-API exports and shared addon lifecycle | [`build.zig`](../../build.zig) and [`bindings/napi/root.zig`](../../bindings/napi/root.zig) give zapi class exports a Zig package and addon-specific identity. The identity's version component comes from `build.zig.zon`, which intentionally remains `0.0.0` independently of the npm bindings version. The root module registers exports and initializes or tears down process-wide configuration, pools, metrics, and the pubkey cache on first or last environment. |
+| Native metrics bridge | [`metrics.observeStateHashTreeRoot`](../../bindings/napi/metrics.zig) requires prior metrics initialization, validates the caller-provided source name, and accepts durations from zero through one hour before recording them in the process-wide native registry. |
 | Beacon-state construction | [`BeaconStateView.createFromBytes`](../../bindings/napi/BeaconStateView.zig) reads the slot and SSZ-deserializes bytes without authenticating a root. Its contract therefore requires trusted state bytes. |
 | State-transition candidate isolation | [`stateTransition`](../../src/state_transition/state_transition.zig) clones the cached state and destroys the clone on error before returning a post-state. Verification options are caller policy. |
 | Serialized block boundary | [`BeaconStateView.stateTransition`](../../bindings/napi/BeaconStateView.zig) accepts serialized signed-block bytes and a caller-selected full or blinded block type, then passes the decoded block to the transition. The fork-aware decoder rejects unsupported blinded forks. This is a hostile-input boundary for integrated callers. |

--- a/src/state_transition/metrics.zig
+++ b/src/state_transition/metrics.zig
@@ -12,6 +12,8 @@ pub const StateCloneSource = enum {
     process_slots,
 };
 
+pub const state_hash_tree_root_duration_seconds_max: f64 = 60 * 60;
+
 pub const StateHashTreeRootSource = enum {
     state_transition,
     block_transition,
@@ -263,6 +265,14 @@ pub fn observeEpochTransitionStep(
         labels,
         @as(f64, @floatFromInt(ns)) / std.time.ns_per_s,
     );
+}
+
+pub fn observeStateHashTreeRoot(source: StateHashTreeRootSource, seconds: f64) !void {
+    std.debug.assert(std.math.isFinite(seconds));
+    std.debug.assert(seconds >= 0);
+    std.debug.assert(seconds <= state_hash_tree_root_duration_seconds_max);
+
+    try state_transition.state_hash_tree_root.observe(.{ .source = source }, seconds);
 }
 
 /// Writes all metrics to `writer`.


### PR DESCRIPTION
Zig stf only observes hash tree root timings within its own stf module. The `beacon-node` package in lodestar-ts is another user of this metric, and this is dropped if we switch to native (ctrl+F `stateHashTreeRootTime`)

So we expose this observation and use it on the beacon-node side.

Used in https://github.com/ChainSafe/lodestar/pull/9632/changes/c74f70aa2337b7e6076167236790bf7d6f63b9f6