### PR TITLE
refactor(stf): remove unused epoch transition cache options

### DIFF
--- a/bench/state_transition/process_block.zig
+++ b/bench/state_transition/process_block.zig
@@ -541,7 +541,6 @@ fn runBenchmark(
         io,
         cached_state,
         block_slot,
-        .{},
     );
     try cached_state.state.commit();
     try state_transition.buildSlashingsCacheFromStateIfNeeded(allocator, cached_state.state, &cached_state.slashings_cache);

--- a/bindings/napi/BeaconStateView.zig
+++ b/bindings/napi/BeaconStateView.zig
@@ -1302,7 +1302,7 @@ pub fn processSlots(self: *const BeaconStateView, slot_arg: js.Number, options: 
         allocator.destroy(post_state);
     }
 
-    try st.processSlots(allocator, js.io(), post_state, slot_value, .{});
+    try st.processSlots(allocator, js.io(), post_state, slot_value);
     return .{
         .cached_state = post_state,
         .pool_rc = pool.state.poolRc().ref(),

--- a/src/state_transition/cache/epoch_transition_cache.zig
+++ b/src/state_transition/cache/epoch_transition_cache.zig
@@ -153,13 +153,6 @@ pub fn deinitReusedEpochTransitionCache(io: std.Io) void {
     }
 }
 
-pub const EpochTransitionCacheOpts = struct {
-    /// Assert progressive balances the same in the cache.
-    assert_correct_progressive_balances: bool = false,
-    ///  Do not queue shuffling calculation async. Forces sync JIT calculation in afterProcessEpoch
-    async_shuffling_calculation: bool = false,
-};
-
 pub const EpochTransitionCache = struct {
     prev_epoch: Epoch,
     current_epoch: Epoch,
@@ -463,7 +456,6 @@ pub const EpochTransitionCache = struct {
             }
         }
 
-        // assertCorrectProgressiveBalances = true by default
         if (fork_seq.gte(.altair)) {
             if (epoch_cache.current_target_unslashed_balance_increments != curr_target_unsl_stake) {
                 return error.InCorrectCurrentTargetUnslashedBalance;

--- a/src/state_transition/state_transition.zig
+++ b/src/state_transition/state_transition.zig
@@ -17,7 +17,6 @@ const AnySignedBeaconBlock = @import("fork_types").AnySignedBeaconBlock;
 const EpochCache = @import("./cache/epoch_cache.zig").EpochCache;
 const verifyProposerSignature = @import("./signature_sets/proposer.zig").verifyProposerSignature;
 pub const processBlock = @import("./block/process_block.zig").processBlock;
-const EpochTransitionCacheOpts = @import("cache/epoch_transition_cache.zig").EpochTransitionCacheOpts;
 const EpochTransitionCache = @import("cache/epoch_transition_cache.zig").EpochTransitionCache;
 const processEpoch = @import("epoch/process_epoch.zig").processEpoch;
 const computeEpochAtSlot = @import("utils/epoch.zig").computeEpochAtSlot;
@@ -52,7 +51,6 @@ pub fn processSlots(
     io: std.Io,
     cached_state: *CachedBeaconState,
     slot: Slot,
-    _: EpochTransitionCacheOpts,
 ) !void {
     const config = cached_state.config;
     const epoch_cache = cached_state.epoch_cache;
@@ -188,7 +186,6 @@ pub fn stateTransition(
         io,
         post_cached_state,
         block_slot,
-        .{},
     );
 
     const config = post_cached_state.config;

--- a/test/spec/runner/sanity.zig
+++ b/test/spec/runner/sanity.zig
@@ -81,7 +81,6 @@ pub fn SlotsTestCase(comptime fork: ForkSeq) type {
                 std.testing.io,
                 self.pre.cached_state,
                 try self.pre.cached_state.state.slot() + self.slots,
-                .{},
             );
         }
 


### PR DESCRIPTION
**Motivation**

`EpochTransitionCacheOpts` exposes two ignored options. Progressive balance checks already run unconditionally for Altair and later forks. Remove the obsolete options, matching the direction of ChainSafe/lodestar#10046.

**Description**

Delete `EpochTransitionCacheOpts` and the unused `processSlots` parameter, updating its callers. 

AI assistance: implementation and PR description were primarily authored by Codex, with an independent AI code review.
