### PR TITLE
perf(ssz): stream list tree reads into output values

### DIFF
--- a/src/ssz/type/list.zig
+++ b/src/ssz/type/list.zig
@@ -408,24 +408,23 @@ pub fn FixedListType(comptime ST: type, comptime _limit: comptime_int, comptime 
                 @memset(out.items, Element.default_value);
 
                 return if (comptime use_chunked_leaf)
-                    toValueChunkedLeaf(allocator, node, pool, out, len, chunk_count)
+                    toValueChunkedLeaf(node, pool, out, len, chunk_count)
                 else
-                    toValuePlain(allocator, node, pool, out, len, chunk_count);
+                    toValuePlain(node, pool, out, len, chunk_count);
             }
 
             /// `toValue` for chunked_leaf layouts. `out.items` is pre-resized
             /// to `len` and zero-initialised by the caller.
-            fn toValueChunkedLeaf(allocator: std.mem.Allocator, node: Node.Id, pool: *Node.Pool, out: *Type, len: usize, chunk_count: usize) !void {
+            fn toValueChunkedLeaf(node: Node.Id, pool: *Node.Pool, out: *Type, len: usize, chunk_count: usize) !void {
                 const content_root = try node.getLeft(pool);
                 const items_per_chunk = 32 / Element.fixed_size;
                 const chunked_leaf_count = (chunk_count + ChunkedLeaf.K - 1) / ChunkedLeaf.K;
-                const chunked_leaf_ids = try allocator.alloc(Node.Id, chunked_leaf_count);
-                defer allocator.free(chunked_leaf_ids);
-                try content_root.getNodesAtDepth(pool, chunked_leaf_depth, 0, chunked_leaf_ids);
+                var it = Node.DepthIterator.init(pool, content_root, chunked_leaf_depth, 0);
 
                 const state_col = pool.nodes.items(.state);
                 var item_idx: usize = 0;
-                outer: for (chunked_leaf_ids) |sid| {
+                outer: for (0..chunked_leaf_count) |_| {
+                    const sid = try it.next();
                     // A zero subtree at chunked_leaf boundary is semantically an
                     // all-zero chunked_leaf — out.items already initialised to
                     // Element.default_value via the @memset above, so
@@ -450,29 +449,24 @@ pub fn FixedListType(comptime ST: type, comptime _limit: comptime_int, comptime 
 
             /// `toValue` for non-chunked_leaf layouts. `out.items` is
             /// pre-resized to `len` by the caller.
-            fn toValuePlain(allocator: std.mem.Allocator, node: Node.Id, pool: *Node.Pool, out: *Type, len: usize, chunk_count: usize) !void {
-                const nodes = try allocator.alloc(Node.Id, chunk_count);
-                defer allocator.free(nodes);
-
-                try node.getNodesAtDepth(pool, chunk_depth + 1, 0, nodes);
+            fn toValuePlain(node: Node.Id, pool: *Node.Pool, out: *Type, len: usize, chunk_count: usize) !void {
+                var it = Node.DepthIterator.init(pool, node, chunk_depth + 1, 0);
 
                 if (comptime isBasicType(Element)) {
-                    // tightly packed list
-                    for (0..len) |i| {
-                        try Element.tree.toValuePacked(
-                            nodes[i * Element.fixed_size / 32],
-                            pool,
-                            i,
-                            &out.items[i],
-                        );
+                    const items_per_chunk = 32 / Element.fixed_size;
+                    var next_item: usize = 0;
+                    for (0..chunk_count) |_| {
+                        const chunk = try it.next();
+                        const end_item = next_item + @min(items_per_chunk, len - next_item);
+                        for (next_item..end_item) |i| {
+                            try Element.tree.toValuePacked(chunk, pool, i, &out.items[i]);
+                        }
+                        next_item = end_item;
                     }
+                    std.debug.assert(next_item == len);
                 } else {
-                    for (0..len) |i| {
-                        try Element.tree.toValue(
-                            nodes[i],
-                            pool,
-                            &out.items[i],
-                        );
+                    for (out.items) |*item| {
+                        try Element.tree.toValue(try it.next(), pool, item);
                     }
                 }
             }
@@ -905,20 +899,12 @@ pub fn VariableListType(comptime ST: type, comptime _limit: comptime_int) type {
                     return;
                 }
 
-                const nodes = try allocator.alloc(Node.Id, chunk_count);
-                defer allocator.free(nodes);
-
-                try node.getNodesAtDepth(pool, chunk_depth + 1, 0, nodes);
+                var it = Node.DepthIterator.init(pool, node, chunk_depth + 1, 0);
 
                 try out.resize(allocator, len);
                 @memset(out.items, Element.default_value);
-                for (0..len) |i| {
-                    try Element.tree.toValue(
-                        allocator,
-                        nodes[i],
-                        pool,
-                        &out.items[i],
-                    );
+                for (out.items) |*item| {
+                    try Element.tree.toValue(allocator, try it.next(), pool, item);
                 }
             }
 

--- a/src/ssz/type/list_test.zig
+++ b/src/ssz/type/list_test.zig
@@ -114,6 +114,119 @@ test "ListType - sanity" {
     try BytesBytes.deserializeFromBytes(allocator, bb_buf, &bb);
 }
 
+test "memory_safety: fixed list tree reads reuse output capacity without traversal allocations" {
+    const allocator = std.testing.allocator;
+    inline for (.{ UintType(64), BoolType(), PoolExhaustionCheckpoint }) |Element| {
+        inline for (.{ false, true }) |chunked| {
+            if (!chunked or Element.kind != .container) {
+                const List = FixedListType(Element, pmt.ChunkedLeaf.K * 64, .{ .chunked_leaf = chunked });
+                var failing = std.testing.FailingAllocator.init(allocator, .{});
+                var pool = try Node.Pool.init(.{
+                    .page_allocator = allocator,
+                    .allocator = failing.allocator(),
+                    .pool_size = 16384,
+                });
+                defer pool.deinit();
+
+                inline for (.{ 0, 1, 31, 32, 33, pmt.ChunkedLeaf.K * 32 + 1 }) |len| {
+                    var value = List.default_value;
+                    defer List.deinit(allocator, &value);
+                    try value.resize(allocator, len);
+                    for (value.items, 0..) |*item, i| {
+                        item.* = switch (Element.kind) {
+                            .uint => @intCast(i + 1),
+                            .bool => i % 2 == 0,
+                            .container => .{ .epoch = @intCast(i + 1), .root = @splat(@intCast(i % 256)) },
+                            else => unreachable,
+                        };
+                    }
+                    const node = try List.tree.fromValue(&pool, &value);
+                    defer pool.unref(node);
+                    const before = node.getRoot(&pool).*;
+                    const zero = try List.tree.zeros(&pool, len);
+                    defer pool.unref(zero);
+
+                    var out = List.default_value;
+                    defer List.deinit(failing.allocator(), &out);
+                    try out.ensureTotalCapacity(failing.allocator(), len);
+                    failing.fail_index = failing.alloc_index;
+                    failing.resize_fail_index = failing.resize_index;
+                    defer {
+                        failing.fail_index = std.math.maxInt(usize);
+                        failing.resize_fail_index = std.math.maxInt(usize);
+                    }
+
+                    try List.tree.toValue(failing.allocator(), node, &pool, &out);
+                    try std.testing.expect(List.equals(&value, &out));
+                    try std.testing.expectEqualSlices(u8, &before, node.getRoot(&pool));
+                    try List.tree.toValue(failing.allocator(), zero, &pool, &out);
+                    for (out.items) |item| {
+                        try std.testing.expect(Element.equals(&Element.default_value, &item));
+                    }
+                    try std.testing.expect(!failing.has_induced_failure);
+                }
+            }
+        }
+    }
+}
+
+test "memory_safety: variable list tree reads allocate only materialized values" {
+    const allocator = std.testing.allocator;
+    const Element = ByteListType(8);
+    const List = VariableListType(Element, 8);
+    var pool = try Node.Pool.init(.{
+        .page_allocator = allocator,
+        .allocator = allocator,
+        .pool_size = 64,
+    });
+    defer pool.deinit();
+    var value = List.default_value;
+    defer List.deinit(allocator, &value);
+    try value.appendNTimes(allocator, Element.default_value, 3);
+    const node = try List.tree.fromValue(&pool, &value);
+    defer pool.unref(node);
+
+    var failing = std.testing.FailingAllocator.init(allocator, .{});
+    var out = List.default_value;
+    defer List.deinit(failing.allocator(), &out);
+    try out.ensureTotalCapacity(failing.allocator(), value.items.len);
+    failing.fail_index = failing.alloc_index;
+    failing.resize_fail_index = failing.resize_index;
+
+    try List.tree.toValue(failing.allocator(), node, &pool, &out);
+    try std.testing.expect(List.equals(&value, &out));
+    try std.testing.expect(!failing.has_induced_failure);
+}
+
+test "memory_safety: variable list tree reads leave partial values deinit-safe" {
+    const allocator = std.testing.allocator;
+    const Element = ByteListType(8);
+    const List = VariableListType(Element, 8);
+    var pool = try Node.Pool.init(.{
+        .page_allocator = allocator,
+        .allocator = allocator,
+        .pool_size = 64,
+    });
+    defer pool.deinit();
+    var value = List.default_value;
+    defer List.deinit(allocator, &value);
+    try value.appendNTimes(allocator, Element.default_value, 3);
+    for (value.items, 0..) |*item, i| try item.append(allocator, @intCast(i + 1));
+    const node = try List.tree.fromValue(&pool, &value);
+    defer pool.unref(node);
+    const before = node.getRoot(&pool).*;
+
+    try std.testing.checkAllAllocationFailures(allocator, struct {
+        fn run(failing: std.mem.Allocator, source: Node.Id, source_pool: *Node.Pool, expected: *const List.Type) !void {
+            var out = List.default_value;
+            defer List.deinit(failing, &out);
+            try List.tree.toValue(failing, source, source_pool, &out);
+            try std.testing.expect(List.equals(expected, &out));
+        }
+    }.run, .{ node, &pool, &value });
+    try std.testing.expectEqualSlices(u8, &before, node.getRoot(&pool));
+}
+
 test "clone FixedListType" {
     const allocator = std.testing.allocator;
     const Checkpoint = FixedContainerType(struct {


### PR DESCRIPTION
Reading an SSZ list tree into a value allocates a temporary node-ID array even when the destination already has sufficient capacity. Use the existing bounded depth iterator for plain, chunked, and variable-element lists so allocations are limited to the output value and its children. Packed decoding, zero-subtree handling, and partial-value cleanup retain their existing behavior.

Follow-up to #158. This PR is independent of the open proof and hashing work.

This implementation was primarily authored by Codex.
