### PR TITLE
fix: stabilize ptc benchmark seeds

### DIFF
--- a/bindings/perf/shuffle.test.ts
+++ b/bindings/perf/shuffle.test.ts
@@ -84,7 +84,7 @@ describe("committee indices", () => {
 describe("computePtcIndices - per slot", () => {
   const {EFFECTIVE_BALANCE_INCREMENT, MAX_EFFECTIVE_BALANCE_ELECTRA, PTC_SIZE} = shuffleReference;
   for (const vc of [16_384, 250_000, 1_000_000]) {
-    const seed = new Uint8Array(crypto.randomBytes(32));
+    const seed = deterministicBenchmarkSeed(`ptc-indices:${vc}`);
     const indices = getInputArray(vc);
     const effectiveBalanceIncrements = new Uint16Array(vc).fill(32);
 
@@ -119,7 +119,7 @@ describe("computePtcIndicesForEpoch - full epoch (32 slots)", () => {
     const slotOffsets = new Uint32Array(SLOTS_PER_EPOCH + 1);
     for (let i = 0; i <= SLOTS_PER_EPOCH; i++) slotOffsets[i] = i * indicesPerSlot;
     const effectiveBalanceIncrements = new Uint16Array(vc).fill(32);
-    const epochSeed = new Uint8Array(crypto.randomBytes(32));
+    const epochSeed = deterministicBenchmarkSeed(`ptc-epoch:${vc}`);
     const startSlot = 0;
 
     const committees: Uint32Array[][] = new Array(SLOTS_PER_EPOCH);


### PR DESCRIPTION
**Motivation**

The PTC performance fixtures call `crypto.randomBytes` without importing Node's crypto module. On Node 22, `crypto` is the Web Crypto global, so benchmark collection fails:

```text
TypeError: crypto.randomBytes is not a function
```

`@chainsafe/benchmark` 2.0.1 still exits successfully and persists only 24 results, silently dropping the shuffle suite.

**Description**

Use `deterministicBenchmarkSeed` for the per-slot and full-epoch PTC fixtures, with labels separated by operation and validator count. Two complete benchmark executions now each produce all 49 results, including the 25 shuffle cases. The measured implementations are unchanged.

**AI Assistance Disclosure**

The implementation and verification were primarily AI-authored.
