### PR TITLE
perf: stream bitlist tree reads

### DIFF
--- a/src/ssz/type/bit_list.zig
+++ b/src/ssz/type/bit_list.zig
@@ -486,31 +486,15 @@ pub fn BitListType(comptime _limit: comptime_int) type {
 
             pub fn toValue(allocator: std.mem.Allocator, node: Node.Id, pool: *Node.Pool, out: *Type) !void {
                 const bit_len = try length(node, pool);
-                const chunk_count = (bit_len + 255) / 256;
-                if (chunk_count == 0) {
-                    try out.resize(allocator, 0);
-                    return;
-                }
-
-                const byte_length = (bit_len + 7) / 8;
-
-                const nodes = try allocator.alloc(Node.Id, chunk_count);
-                defer allocator.free(nodes);
-
-                try node.getNodesAtDepth(pool, chunk_depth + 1, 0, nodes);
-
                 try out.resize(allocator, bit_len);
+                const chunk_count = (bit_len + 255) / 256;
+                const byte_length = out.data.items.len;
+                var it = Node.DepthIterator.init(pool, node, chunk_depth + 1, 0);
                 for (0..chunk_count) |i| {
-                    const start_idx = i * 32;
-                    const remaining_bytes = byte_length - start_idx;
-
-                    // Determine how many bytes to copy for this chunk
-                    const bytes_to_copy = @min(remaining_bytes, 32);
-
-                    // Copy data if there are bytes to copy
-                    if (bytes_to_copy > 0) {
-                        @memcpy(out.data.items[start_idx..][0..bytes_to_copy], nodes[i].getRoot(pool)[0..bytes_to_copy]);
-                    }
+                    const start = i * 32;
+                    const len = @min(32, byte_length - start);
+                    const chunk = try it.next();
+                    @memcpy(out.data.items[start..][0..len], chunk.getRoot(pool)[0..len]);
                 }
             }
 

--- a/src/ssz/type/bit_list_test.zig
+++ b/src/ssz/type/bit_list_test.zig
@@ -407,3 +407,34 @@ test "BitListType - tree.zeros" {
         try std.testing.expectEqualSlices(u8, &expected_root, tree_node.getRoot(&pool));
     }
 }
+
+test "memory_safety: BitListType tree reads need only output capacity" {
+    const allocator = std.testing.allocator;
+    const List = BitListType(1025);
+    var pool = try Node.Pool.init(.{ .page_allocator = allocator, .allocator = allocator, .pool_size = 1024 });
+    defer pool.deinit();
+    for ([_]usize{ 0, 1, 7, 8, 31, 32, 33, 255, 256, 257, List.limit }) |len| {
+        var value = List.default_value;
+        defer List.deinit(allocator, &value);
+        try value.resize(allocator, len);
+        for (0..len) |i| try value.setAssumeCapacity(i, i % 3 == 0);
+        const node = try List.tree.fromValue(&pool, &value);
+        defer pool.unref(node);
+        const before = node.getRoot(&pool).*;
+        var failing = std.testing.FailingAllocator.init(allocator, .{});
+        var out = List.default_value;
+        defer List.deinit(failing.allocator(), &out);
+        try out.resize(failing.allocator(), List.limit);
+        failing.fail_index = failing.alloc_index;
+        failing.resize_fail_index = failing.resize_index;
+        try List.tree.toValue(failing.allocator(), node, &pool, &out);
+        try std.testing.expect(List.equals(&value, &out));
+        try std.testing.expectEqualSlices(u8, &before, node.getRoot(&pool));
+        const zero = try List.tree.zeros(&pool, len);
+        defer pool.unref(zero);
+        try List.tree.toValue(failing.allocator(), zero, &pool, &out);
+        var root: [32]u8 = undefined;
+        try List.hashTreeRoot(allocator, &out, &root);
+        try std.testing.expectEqualSlices(u8, zero.getRoot(&pool), &root);
+    }
+}


### PR DESCRIPTION
**Motivation**

BitList tree-to-value conversion allocates a node-ID array even when the destination already has enough capacity. Ordinary list conversion was addressed in #671.

Related to #158.

**Description**

Read chunks with `Node.DepthIterator` directly into the resized BitList output. Boundary and implicit-zero tests disable allocations after reserving output capacity and verify that source roots remain unchanged.

**AI Assistance Disclosure**

The changes were primarily AI-authored.
