### PR TITLE
refactor: share bytelist tree conversion

### DIFF
--- a/src/ssz/tree_view/list_composite_test.zig
+++ b/src/ssz/tree_view/list_composite_test.zig
@@ -867,18 +867,22 @@ test "memory_safety: getAllReadonlyValues should deinit completed prefix and cur
     var view = try ListType.TreeView.init(allocator, &pool, root);
     defer view.deinit();
 
-    // Fail the second element's second field after its first field and the prefix own memory.
-    var failing = std.testing.FailingAllocator.init(allocator, .{
-        .fail_index = 8,
-        .resize_fail_index = 0,
-    });
-
-    try std.testing.expectError(
-        error.OutOfMemory,
-        view.getAllReadonlyValues(failing.allocator()),
-    );
-    // The completed prefix and current partially converted value must not leak.
-    try std.testing.expectEqual(failing.allocated_bytes, failing.freed_bytes);
+    var backing = std.testing.FailingAllocator.init(allocator, .{ .resize_fail_index = 0 });
+    var saw_operation_oom = false;
+    try std.testing.checkAllAllocationFailures(backing.allocator(), struct {
+        fn run(
+            output_allocator: std.mem.Allocator,
+            input: *ListType.TreeView,
+            saw_oom: *bool,
+        ) !void {
+            errdefer saw_oom.* = true;
+            const values = try input.getAllReadonlyValues(output_allocator);
+            defer output_allocator.free(values);
+            defer for (values) |*value| Element.deinit(output_allocator, value);
+            try std.testing.expectEqual(@as(usize, 2), values.len);
+        }
+    }.run, .{ view, &saw_operation_oom });
+    try std.testing.expect(saw_operation_oom);
 }
 
 test "memory_safety: iterator nextValue should deinit current value on conversion OOM" {
@@ -908,16 +912,23 @@ test "memory_safety: iterator nextValue should deinit current value on conversio
     var view = try ListType.TreeView.init(allocator, &pool, root);
     defer view.deinit();
 
-    var iterator = view.iteratorReadonly(0);
-    // Fail the second field after the first field owns an allocation.
-    var failing = std.testing.FailingAllocator.init(allocator, .{
-        .fail_index = 2,
-        .resize_fail_index = 0,
-    });
-
-    try std.testing.expectError(error.OutOfMemory, iterator.nextValue(failing.allocator()));
-    // The current partially converted value must not leak.
-    try std.testing.expectEqual(failing.allocated_bytes, failing.freed_bytes);
+    var backing = std.testing.FailingAllocator.init(allocator, .{ .resize_fail_index = 0 });
+    var saw_operation_oom = false;
+    try std.testing.checkAllAllocationFailures(backing.allocator(), struct {
+        fn run(
+            output_allocator: std.mem.Allocator,
+            input: *ListType.TreeView,
+            saw_oom: *bool,
+        ) !void {
+            var iterator = input.iteratorReadonly(0);
+            errdefer saw_oom.* = true;
+            var value = try iterator.nextValue(output_allocator);
+            defer Element.deinit(output_allocator, &value);
+            try std.testing.expectEqualSlices(u8, &.{1}, value.first.items);
+            try std.testing.expectEqualSlices(u8, &.{2}, value.second.items);
+        }
+    }.run, .{ view, &saw_operation_oom });
+    try std.testing.expect(saw_operation_oom);
 }
 
 // std.testing.allocator can't see pool-slot leaks, so check getNodesInUse() against a baseline.

--- a/src/ssz/type/byte_list.zig
+++ b/src/ssz/type/byte_list.zig
@@ -165,32 +165,7 @@ pub fn ByteListType(comptime _limit: comptime_int) type {
                 return std.mem.readInt(usize, hash[0..8], .little);
             }
 
-            pub fn toValue(allocator: std.mem.Allocator, node: Node.Id, pool: *Node.Pool, out: *Type) !void {
-                const len = try length(node, pool);
-                const chunk_count = (len + 31) / 32;
-                if (chunk_count == 0) {
-                    try out.resize(allocator, 0);
-                    return;
-                }
-
-                const nodes = try allocator.alloc(Node.Id, chunk_count);
-                defer allocator.free(nodes);
-                try node.getNodesAtDepth(pool, chunk_depth + 1, 0, nodes);
-
-                try out.resize(allocator, len);
-                for (0..chunk_count) |i| {
-                    const start_idx = i * 32;
-                    const remaining_bytes = len - start_idx;
-
-                    // Determine how many bytes to copy for this chunk
-                    const bytes_to_copy = @min(remaining_bytes, 32);
-
-                    // Copy data if there are bytes to copy
-                    if (bytes_to_copy > 0) {
-                        @memcpy(out.items[start_idx..][0..bytes_to_copy], nodes[i].getRoot(pool)[0..bytes_to_copy]);
-                    }
-                }
-            }
+            pub const toValue = GenericList.tree.toValue;
 
             pub fn fromValue(pool: *Node.Pool, value: *const Type) !Node.Id {
                 const chunk_count = chunkCount(value);

--- a/src/ssz/type/byte_list_test.zig
+++ b/src/ssz/type/byte_list_test.zig
@@ -351,3 +351,34 @@ test "ByteListType - tree.zeros" {
         try std.testing.expectEqualSlices(u8, &expected_root, tree_node.getRoot(&pool));
     }
 }
+
+test "memory_safety: ByteListType tree reads need only output capacity" {
+    const allocator = std.testing.allocator;
+    const List = ByteListType(1025);
+    var pool = try Node.Pool.init(.{ .page_allocator = allocator, .allocator = allocator, .pool_size = 1024 });
+    defer pool.deinit();
+    for ([_]usize{ 0, 1, 7, 8, 31, 32, 33, 255, 256, 257, List.limit }) |len| {
+        var value = List.default_value;
+        defer List.deinit(allocator, &value);
+        try value.resize(allocator, len);
+        for (value.items, 0..) |*byte, i| byte.* = @truncate(i);
+        const node = try List.tree.fromValue(&pool, &value);
+        defer pool.unref(node);
+        const before = node.getRoot(&pool).*;
+        var failing = std.testing.FailingAllocator.init(allocator, .{});
+        var out = List.default_value;
+        defer List.deinit(failing.allocator(), &out);
+        try out.ensureTotalCapacity(failing.allocator(), List.limit);
+        failing.fail_index = failing.alloc_index;
+        failing.resize_fail_index = failing.resize_index;
+        try List.tree.toValue(failing.allocator(), node, &pool, &out);
+        try std.testing.expect(List.equals(&value, &out));
+        try std.testing.expectEqualSlices(u8, &before, node.getRoot(&pool));
+        const zero = try List.tree.zeros(&pool, len);
+        defer pool.unref(zero);
+        try List.tree.toValue(failing.allocator(), zero, &pool, &out);
+        var root: [32]u8 = undefined;
+        try List.hashTreeRoot(allocator, &out, &root);
+        try std.testing.expectEqualSlices(u8, zero.getRoot(&pool), &root);
+    }
+}

--- a/src/ssz/type/list.zig
+++ b/src/ssz/type/list.zig
@@ -474,8 +474,13 @@ pub fn FixedListType(comptime ST: type, comptime _limit: comptime_int, comptime 
                     for (0..chunk_count) |_| {
                         const chunk = try it.next();
                         const end_item = next_item + @min(items_per_chunk, len - next_item);
-                        for (next_item..end_item) |i| {
-                            try Element.tree.toValuePacked(chunk, pool, i, &out.items[i]);
+                        if (comptime canMemcpySsz(Element)) {
+                            const bytes = std.mem.sliceAsBytes(out.items[next_item..end_item]);
+                            @memcpy(bytes, chunk.getRoot(pool)[0..bytes.len]);
+                        } else {
+                            for (next_item..end_item) |i| {
+                                try Element.tree.toValuePacked(chunk, pool, i, &out.items[i]);
+                            }
                         }
                         next_item = end_item;
                     }


### PR DESCRIPTION
**Motivation**

ByteList retains a separate tree-to-value implementation with temporary traversal allocation, while the generic uint8-list implementation already streams its reads.

Related to #158.

**Description**

Alias `ByteListType.tree.toValue` to `GenericList.tree.toValue`. Add the existing `canMemcpySsz` fast path to plain packed-list reads so byte-compatible types copy each chunk once.

**AI Assistance Disclosure**

The changes were primarily AI-authored.
