### PR TITLE
perf: bound progressive builder scratch

### DIFF
--- a/src/ssz/type/progressive.zig
+++ b/src/ssz/type/progressive.zig
@@ -206,23 +206,26 @@ pub fn fillWithContentsComptime(comptime node_count: usize, pool: *Node.Pool, no
     return n;
 }
 
-pub fn fillWithContents(allocator: std.mem.Allocator, pool: *Node.Pool, nodes: []Node.Id) !Node.Id {
-    const subtree_count = subtreeIndex(nodes.len);
+pub fn fillWithContents(_: std.mem.Allocator, pool: *Node.Pool, nodes: []Node.Id) !Node.Id {
+    const max_subtrees = @min((@import("hashing").max_depth - 1) / 3, (@bitSizeOf(usize) - 1) / 2) + 1;
+    var subtree_starts: [max_subtrees]usize = undefined;
+    var subtree_count: usize = 0;
+    var pos: usize = 0;
+    for (0..max_subtrees) |i| {
+        if (pos == nodes.len) break;
+        subtree_starts[i] = pos;
+        pos += @min(@as(usize, 1) << @intCast(2 * i), nodes.len - pos);
+        subtree_count += 1;
+    }
+    if (pos != nodes.len) return error.InputTooLong;
+
     var n: Node.Id = @enumFromInt(0);
     errdefer pool.unref(n);
-
-    var subtree_starts = std.ArrayList(usize).empty;
-    defer subtree_starts.deinit(allocator);
-    var pos: usize = 0;
-    for (0..subtree_count) |subtree_i| {
-        try subtree_starts.append(allocator, pos);
-        pos += @min(subtreeLength(subtree_i), nodes.len - pos);
-    }
 
     for (0..subtree_count) |i| {
         const subtree_i = subtree_count - 1 - i;
         const subtree_depth = subtreeDepth(subtree_i);
-        const l = subtree_starts.items[subtree_i];
+        const l = subtree_starts[subtree_i];
         const subtree_length = @min(subtreeLength(subtree_i), nodes.len - l);
 
         const subtree_root = try Node.fillWithContents(pool, nodes[l .. l + subtree_length], subtree_depth);
@@ -230,4 +233,8 @@ pub fn fillWithContents(allocator: std.mem.Allocator, pool: *Node.Pool, nodes: [
     }
 
     return n;
+}
+
+test {
+    _ = @import("progressive_test.zig");
 }

--- a/src/ssz/type/progressive_test.zig
+++ b/src/ssz/type/progressive_test.zig
@@ -1,0 +1,26 @@
+const std = @import("std");
+const progressive = @import("progressive.zig");
+const Node = @import("persistent_merkle_tree").Node;
+
+test "progressive builder needs no subtree offset allocation" {
+    const allocator = std.testing.allocator;
+    inline for (.{ 0, 1, 2, 5, 6, 21, 22, 85, 86, 341, 342 }) |count| {
+        var failing = std.testing.FailingAllocator.init(allocator, .{ .fail_index = 0 });
+        var pool = try Node.Pool.init(.{ .page_allocator = allocator, .allocator = failing.allocator(), .pool_size = 2048 });
+        defer pool.deinit();
+        const baseline = pool.getNodesInUse();
+        var nodes: [count]Node.Id = undefined;
+        var chunks: [count][32]u8 = undefined;
+        for (&chunks, &nodes, 0..) |*chunk, *node, i| {
+            chunk.* = @splat(@truncate(i));
+            node.* = try pool.createLeaf(chunk);
+        }
+        const tree = try progressive.fillWithContents(failing.allocator(), &pool, &nodes);
+        var expected: [32]u8 = undefined;
+        try progressive.merkleizeChunks(allocator, &chunks, &expected);
+        try std.testing.expectEqualSlices(u8, &expected, tree.getRoot(&pool));
+        pool.unref(tree);
+        try std.testing.expectEqual(baseline, pool.getNodesInUse());
+        try std.testing.expect(!failing.has_induced_failure);
+    }
+}


### PR DESCRIPTION
**Motivation**

The runtime progressive builder allocates an ArrayList just to remember subtree starting offsets.

Related to #158.

**Description**

Use a bounded offset array sized from supported tree depth. Reject lengths that exceed the representable progressive path before creating nodes. Preserve the existing tree construction and ownership behavior. Tests compare roots and reclaim all nodes across subtree boundaries with allocator scratch disabled.

**AI Assistance Disclosure**

The changes were primarily AI-authored.
