### PR TITLE
feat(metrics): report proposer rewards per type

### DIFF
--- a/src/state_transition/metrics.zig
+++ b/src/state_transition/metrics.zig
@@ -41,7 +41,7 @@ pub const ProposerRewardKind = enum {
 
 const HashTreeRootLabel = struct { source: StateHashTreeRootSource };
 const EpochTransitionStepLabel = struct { step: EpochTransitionStepKind };
-const ProposerRewardLabel = struct { kind: ProposerRewardKind };
+const ProposerRewardLabel = struct { type: ProposerRewardKind };
 
 const Metrics = struct {
     epoch_transition: EpochTransition,

--- a/src/state_transition/state_transition.zig
+++ b/src/state_transition/state_transition.zig
@@ -240,6 +240,11 @@ pub fn stateTransition(
     }
     metrics.state_transition.process_block.observe(time.durationSeconds(time.since(io, timer)));
 
+    const proposer_rewards = post_cached_state.proposer_rewards;
+    try metrics.state_transition.proposer_rewards.set(.{ .type = .attestation }, proposer_rewards.attestations);
+    try metrics.state_transition.proposer_rewards.set(.{ .type = .sync_aggregate }, proposer_rewards.sync_aggregate);
+    try metrics.state_transition.proposer_rewards.set(.{ .type = .slashing }, proposer_rewards.slashing);
+
     timer = time.start(io);
     try post_state.commit();
     metrics.state_transition.process_block_commit.observe(time.durationSeconds(time.since(io, timer)));

--- a/src/state_transition/state_transition_test.zig
+++ b/src/state_transition/state_transition_test.zig
@@ -192,6 +192,19 @@ test "state transition - records per-block and per-epoch metrics" {
     try testing.expectEqual(@as(?u64, attestation_count), metricValue(out, "lodestar_stfn_attestations_per_block_total"));
     try testing.expect(metricValue(out, "lodestar_stfn_new_seen_attesters_per_block_total").? > 0);
     try testing.expect(metricValue(out, "lodestar_stfn_new_seen_attesters_effective_balance_per_block_total").? > 0);
+    const proposer_rewards = post_state.getProposerRewards();
+    try testing.expectEqual(
+        @as(?u64, proposer_rewards.attestations),
+        metricValue(out, "lodestar_stfn_proposer_rewards_total{type=\"attestation\"}"),
+    );
+    try testing.expectEqual(
+        @as(?u64, proposer_rewards.sync_aggregate),
+        metricValue(out, "lodestar_stfn_proposer_rewards_total{type=\"sync_aggregate\"}"),
+    );
+    try testing.expectEqual(
+        @as(?u64, proposer_rewards.slashing),
+        metricValue(out, "lodestar_stfn_proposer_rewards_total{type=\"slashing\"}"),
+    );
 }
 
 test "proposer rewards should report only new attestation participation and reset on clone" {


### PR DESCRIPTION
**Motivation**

Missing proposer rewards metrics, as reported by lodekeeper in this discord [message](https://discord.com/channels/593655374469660673/1508869388223250722/1547627396310769806)

**Description**

- populates rewards according to types.
- changes `kind` to `type` to align with lodestar-ts

**AI Assistance Disclosure**
codex assisted
