### PR TITLE
fix(bindings): return sync committee index maps

### DIFF
--- a/bindings/napi/BeaconStateView.zig
+++ b/bindings/napi/BeaconStateView.zig
@@ -587,47 +587,10 @@ pub fn nextSyncCommittee(self: *const BeaconStateView) !js_types.SyncCommittee {
     return js_types.wrap(js_types.SyncCommittee, try sszValueToNapiValue(env, ct.altair.SyncCommittee, &result));
 }
 
-pub fn currentSyncCommitteeIndexed(self: *const BeaconStateView) !js_types.IndexedSyncCommitteeWithMap {
-    const env = js.env();
+pub fn currentSyncCommitteeIndexed(self: *const BeaconStateView) !js_types.IndexedSyncCommittee {
     const cached_state = try self.requireState();
     const sync_committee_cache = cached_state.epoch_cache.current_sync_committee_indexed.get();
-    const validator_indices = sync_committee_cache.getValidatorIndices();
-    const validator_index_map = sync_committee_cache.getValidatorIndexMap();
-
-    const obj = try env.createObject();
-    try obj.setNamedProperty(
-        "validatorIndices",
-        try numberSliceToNapiValue(
-            env,
-            u64,
-            validator_indices,
-            .{ .typed_array = .uint32 },
-        ),
-    );
-
-    const global = try env.getGlobal();
-    const map_ctor = try global.getNamedProperty("Map");
-    const map = try env.newInstance(map_ctor, .{});
-    const set_fn = try map.getNamedProperty("set");
-
-    var iterator = validator_index_map.iterator();
-    while (iterator.next()) |entry| {
-        const idx = entry.key_ptr.*;
-        const positions = entry.value_ptr;
-
-        const key_value_napi = try env.createInt64(@intCast(idx));
-        const positions_napi = try numberSliceToNapiValue(
-            env,
-            u32,
-            positions.items,
-            .{ .typed_array = .uint32 },
-        );
-
-        _ = try env.callFunction(set_fn, map, .{ key_value_napi, positions_napi });
-    }
-
-    try obj.setNamedProperty("validatorIndexMap", map);
-    return .{ .val = obj };
+    return indexedSyncCommitteeToNapi(sync_committee_cache);
 }
 
 pub fn syncProposerReward(self: *const BeaconStateView) !js.Number {
@@ -637,39 +600,58 @@ pub fn syncProposerReward(self: *const BeaconStateView) !js.Number {
 }
 
 /// Get the indexed sync committee at a given epoch.
-/// Returns: object with validatorIndices (Uint32Array)
 pub fn getIndexedSyncCommitteeAtEpoch(self: *const BeaconStateView, epoch_arg: js.Number) !js_types.IndexedSyncCommittee {
-    const env = js.env();
     const cached_state = try self.requireState();
     const epoch_value: u64 = @intCast(try epoch_arg.toI64());
 
     const sync_committee = cached_state.epoch_cache.getIndexedSyncCommitteeAtEpoch(epoch_value) catch {
         return throwNullAs(js_types.IndexedSyncCommittee, "NO_SYNC_COMMITTEE", "Sync committee not available for requested epoch");
     };
-
-    const obj = try env.createObject();
-    try obj.setNamedProperty(
-        "validatorIndices",
-        try numberSliceToNapiValue(env, u64, sync_committee.getValidatorIndices(), .{ .typed_array = .uint32 }),
-    );
-    return .{ .val = obj };
+    return indexedSyncCommitteeToNapi(&sync_committee);
 }
 
 /// Get the indexed sync committee for a given slot (uses slot+1 offset for duty lookups).
 pub fn getIndexedSyncCommittee(self: *const BeaconStateView, slot_arg: js.Number) !js_types.IndexedSyncCommittee {
-    const env = js.env();
     const cached_state = try self.requireState();
     const slot_value: u64 = @intCast(try slot_arg.toI64());
 
     const sync_committee = cached_state.epoch_cache.getIndexedSyncCommittee(slot_value) catch {
         return throwNullAs(js_types.IndexedSyncCommittee, "NO_SYNC_COMMITTEE", "Sync committee not available for requested slot");
     };
+    return indexedSyncCommitteeToNapi(&sync_committee);
+}
 
+fn indexedSyncCommitteeToNapi(sync_committee: anytype) !js_types.IndexedSyncCommittee {
+    const env = js.env();
     const obj = try env.createObject();
     try obj.setNamedProperty(
         "validatorIndices",
-        try numberSliceToNapiValue(env, u64, sync_committee.getValidatorIndices(), .{ .typed_array = .uint32 }),
+        try numberSliceToNapiValue(
+            env,
+            u64,
+            sync_committee.getValidatorIndices(),
+            .{ .typed_array = .uint32 },
+        ),
     );
+
+    const global = try env.getGlobal();
+    const map_ctor = try global.getNamedProperty("Map");
+    const map = try env.newInstance(map_ctor, .{});
+    const set_fn = try map.getNamedProperty("set");
+
+    var iterator = sync_committee.getValidatorIndexMap().iterator();
+    while (iterator.next()) |entry| {
+        const key = try env.createInt64(@intCast(entry.key_ptr.*));
+        const positions = try numberSliceToNapiValue(
+            env,
+            u32,
+            entry.value_ptr.items,
+            .{ .typed_array = .uint32 },
+        );
+        _ = try env.callFunction(set_fn, map, .{ key, positions });
+    }
+
+    try obj.setNamedProperty("validatorIndexMap", map);
     return .{ .val = obj };
 }
 

--- a/bindings/napi/js_types.zig
+++ b/bindings/napi/js_types.zig
@@ -37,10 +37,6 @@ pub const SyncCommittee = js.Object(struct {
 
 pub const IndexedSyncCommittee = js.Object(struct {
     validatorIndices: js.Uint32Array,
-});
-
-pub const IndexedSyncCommitteeWithMap = js.Object(struct {
-    validatorIndices: js.Uint32Array,
     validatorIndexMap: js.Value,
 });
 

--- a/bindings/test/beaconStateView.test.ts
+++ b/bindings/test/beaconStateView.test.ts
@@ -9,6 +9,18 @@ import {getFirstEraFilePath} from "./eraFiles.ts";
 const MAINNET_PUBKEY_CACHE_LIMIT = 2_000_000;
 const SYNTHETIC_VALIDATOR_COUNT = 16;
 
+function expectSyncCommitteeCache(cache: {
+  validatorIndices: Uint32Array;
+  validatorIndexMap: Map<number, number[]>;
+}): void {
+  expect(cache.validatorIndices).toBeInstanceOf(Uint32Array);
+  expect(cache.validatorIndices.length).toBeGreaterThan(0);
+  expect(cache.validatorIndexMap).toBeInstanceOf(Map);
+
+  const firstValidatorIndex = cache.validatorIndices[0];
+  expect(cache.validatorIndexMap.get(firstValidatorIndex)).toContain(0);
+}
+
 describe("BeaconStateView", () => {
   let state: InstanceType<typeof bindings.BeaconStateView>;
   let stateBytes: Uint8Array;
@@ -477,15 +489,16 @@ describe("BeaconStateView", () => {
   });
 
   describe("sync committee cache", () => {
-    it("currentSyncCommitteeIndexed should have validatorIndices", () => {
-      const indexed = state.currentSyncCommitteeIndexed;
-      expect(indexed.validatorIndices).toBeInstanceOf(Uint32Array);
-      expect(indexed.validatorIndices.length).toBeGreaterThan(0);
+    it("currentSyncCommitteeIndexed should return cache", () => {
+      expectSyncCommitteeCache(state.currentSyncCommitteeIndexed);
     });
 
     it("getIndexedSyncCommitteeAtEpoch should return cache", () => {
-      const indexed = state.getIndexedSyncCommitteeAtEpoch(state.epoch);
-      expect(indexed.validatorIndices).toBeInstanceOf(Uint32Array);
+      expectSyncCommitteeCache(state.getIndexedSyncCommitteeAtEpoch(state.epoch));
+    });
+
+    it("getIndexedSyncCommittee should return cache", () => {
+      expectSyncCommitteeCache(state.getIndexedSyncCommittee(state.slot));
     });
 
     it("syncProposerReward should be a non-negative number", () => {


### PR DESCRIPTION
**Motivation**

Missing binding call as reported by lodekeeper in this discord [message](https://discord.com/channels/593655374469660673/1508869388223250722/1547627396310769806)

**Description**

Merge indexed sync committee types into one
`IndexedSyncCommittee`, since lodestar-ts always
expects the `validatorIndexMap` to be included in the type


**AI Assistance Disclosure**

codex help
